### PR TITLE
Refactor E1: Critical Fixes (v4.0.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "academic-research",
       "source": "./",
       "description": "Modulares akademisches Forschungs-Toolkit mit 13 selbstaktivierenden Skills, 5D-Scoring, Excel-Export und KI-Stil-Erkennung.",
-      "version": "4.0.0"
+      "version": "4.0.1"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "academic-research",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Modulares akademisches Forschungs-Toolkit mit 13 selbstaktivierenden Skills, 5D-Scoring, Excel-Export und KI-Stil-Erkennung. Durchsucht Semantic Scholar, CrossRef, OpenAlex, BASE, Google Scholar und weitere Quellen.",
   "author": {
     "name": "Jonas"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+Alle bemerkenswerten Änderungen an diesem Plugin werden hier dokumentiert.
+
+Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Versionierung nach [Semantic Versioning](https://semver.org/lang/de/).
+
+## [4.0.1] — 2026-04-23
+
+### Fixed
+
+- Defekte Template-Pfade in drei Skills. `advisor`, `methodology-advisor` und `submission-checker` verwiesen auf `${CLAUDE_PLUGIN_ROOT}/templates/...`, die referenzierten Dateien liegen jedoch skill-lokal. Die Skills brachen zur Laufzeit bei Exposé-Generierung, Methodenkatalog-Lookup und FH-Requirements-Check (#12, #13, #14).
+- Offene Agent-Permissions in `commands/search.md`. `allowed-tools: Agent` ließ Aufruf beliebiger Subagenten zu — Privilege-Eskalations-Risiko. Jetzt eingeschränkt auf `Agent(query-generator, relevance-scorer, quote-extractor)` (#15).
+- Agent-Frontmatter normalisiert. Alle drei Agenten hatten `tools: ""` (mehrdeutiger Leerstring) und einzeilige Descriptions ohne `<example>`-Blöcke. `tools`-Feld entfernt bzw. als Array gesetzt, Descriptions um je zwei `<example>`-Blöcke ergänzt (#16, #17).
+
+### Changed
+
+- `quote-extractor.maxTurns` von 20 auf 5 reduziert. Extraktion ist near-single-shot; 20 war Overkill (#18).
+- `relevance-scorer.maxTurns` von 15 auf 3 reduziert. Ein Batch von 10 Papern = 1 Turn, 2 Puffer für Iteration (#18).
+
+## [4.0.0] — Vor 2026-04-23
+
+Erstes getracktes Release. Siehe Git-Historie für frühere Änderungen.

--- a/agents/query-generator.md
+++ b/agents/query-generator.md
@@ -2,8 +2,26 @@
 name: query-generator
 model: haiku
 color: blue
-description: Expands user research queries into module-specific search terms
-tools: ""
+description: |
+  Expands user research queries into module-specific search terms for seven academic APIs (CrossRef, OpenAlex, Semantic Scholar, BASE, EconBiz, EconStor, arXiv). Invoke at the start of any literature search to translate a natural-language query into API-optimised boolean and phrase queries. Examples:
+
+  <example>
+  Context: User startet eine Literaturrecherche über den search-Command.
+  user: "/academic-research:search 'Cloud Security Controls im Mittelstand'"
+  assistant: "Ich starte die Recherche. Der query-generator-Agent wird jetzt aufgerufen, um API-optimierte Queries für die sieben Datenbanken zu erzeugen."
+  <commentary>
+  Every search run spawns query-generator in Step 2 to translate the raw query into per-API syntax (boolean operators, phrase quoting, field filters).
+  </commentary>
+  </example>
+
+  <example>
+  Context: User möchte nur Queries sehen, ohne Suche auszuführen.
+  user: "Generiere mal passende Suchqueries für 'Agile Transformation in Banken' für CrossRef und OpenAlex"
+  assistant: "Ich nutze den query-generator-Agent, um die Queries zu erzeugen."
+  <commentary>
+  query-generator can be invoked standalone to preview or tune queries before triggering an actual search run.
+  </commentary>
+  </example>
 maxTurns: 10
 ---
 

--- a/agents/quote-extractor.md
+++ b/agents/quote-extractor.md
@@ -23,7 +23,7 @@ description: |
   </commentary>
   </example>
 tools: [Read]
-maxTurns: 20
+maxTurns: 5
 ---
 
 # Quote Extractor Agent

--- a/agents/quote-extractor.md
+++ b/agents/quote-extractor.md
@@ -2,8 +2,27 @@
 name: quote-extractor
 model: sonnet
 color: yellow
-description: Extracts relevant quotes from academic PDF text
-tools: Read
+description: |
+  Extracts 2-3 highly relevant, verbatim quotes (≤25 words each) from an academic PDF text that directly address a research query. Invoke after a paper has been scored as relevant and the PDF is available. Examples:
+
+  <example>
+  Context: User hat relevante Papers identifiziert und möchte zitierfähige Stellen.
+  user: "Extrahiere aus diesen drei PDFs Zitate zu meinem Thema 'Zero Trust Architecture'"
+  assistant: "Ich rufe den quote-extractor-Agent für jede PDF auf, um verbatime Zitate zur Query zu ziehen."
+  <commentary>
+  quote-extractor ist der Standard-Weg, um wörtliche Belegstellen aus PDFs zu ziehen. Er garantiert verbatim-Extraktion (keine Paraphrasen), prüft Titel-PDF-Match und markiert degradierten OCR-Text.
+  </commentary>
+  </example>
+
+  <example>
+  Context: search-Command läuft im deep-Modus und braucht Zitate für top-gerankte Papers.
+  user: "/academic-research:search 'Resilience Engineering' --mode deep"
+  assistant: "Nach dem Ranking wird der quote-extractor-Agent für jedes PDF der Top-Cluster aufgerufen."
+  <commentary>
+  Im deep-Modus läuft quote-extractor nach dem relevance-scorer für die besten Papers, um Zitat-Kandidaten in die Session einzusammeln.
+  </commentary>
+  </example>
+tools: [Read]
 maxTurns: 20
 ---
 

--- a/agents/relevance-scorer.md
+++ b/agents/relevance-scorer.md
@@ -22,7 +22,7 @@ description: |
   relevance-scorer kann standalone für Re-Scoring einer bestehenden Paperliste gegen eine neue Query verwendet werden.
   </commentary>
   </example>
-maxTurns: 15
+maxTurns: 3
 ---
 
 # Relevance Scorer Agent

--- a/agents/relevance-scorer.md
+++ b/agents/relevance-scorer.md
@@ -2,8 +2,26 @@
 name: relevance-scorer
 model: sonnet
 color: cyan
-description: Evaluates semantic relevance of academic papers to a research query
-tools: ""
+description: |
+  Scores a batch of up to 10 academic papers (title + abstract) against a research query on a 0.0-1.0 relevance scale with reasoning and confidence. Invoke after API search and deduplication to filter the result set. Examples:
+
+  <example>
+  Context: search-Command hat 200 Paper geliefert, Ranking und LLM-Scoring müssen laufen.
+  user: "/academic-research:search 'Explainable AI Healthcare'"
+  assistant: "Nach Deduplikation und 5D-Ranking wird der relevance-scorer-Agent in Batches von 10 Papers aufgerufen, um semantische Relevanz-Scores zu ergänzen."
+  <commentary>
+  relevance-scorer läuft in Step 7 des search-Commands. Er ergänzt die heuristischen Ranking-Scores um semantisches LLM-Urteil auf Titel/Abstract-Ebene.
+  </commentary>
+  </example>
+
+  <example>
+  Context: User möchte eine bestehende Paper-Liste gegen eine neue Query scoren.
+  user: "Bewerte diese 15 Paper aus meiner Literaturliste nach Relevanz zu 'Post-Quantum Kryptographie im Banking'"
+  assistant: "Ich rufe den relevance-scorer-Agent auf, der die Paper in Batches scort und pro Paper Score, Reasoning und Confidence liefert."
+  <commentary>
+  relevance-scorer kann standalone für Re-Scoring einer bestehenden Paperliste gegen eine neue Query verwendet werden.
+  </commentary>
+  </example>
 maxTurns: 15
 ---
 

--- a/commands/search.md
+++ b/commands/search.md
@@ -1,7 +1,7 @@
 ---
 description: Search academic papers across multiple APIs (Semantic Scholar, CrossRef, OpenAlex, BASE, EconBiz, EconStor, arXiv)
 disable-model-invocation: true
-allowed-tools: Read, Write, Bash(~/.academic-research/venv/bin/python *), Agent
+allowed-tools: Read, Write, Bash(~/.academic-research/venv/bin/python *), Agent(query-generator, relevance-scorer, quote-extractor)
 argument-hint: "<query>" [--mode quick|standard|deep|metadata] [--modules crossref,openalex,...] [--limit N]
 ---
 

--- a/docs/superpowers/specs/2026-04-23-academic-research-e1-critical-fixes-design.md
+++ b/docs/superpowers/specs/2026-04-23-academic-research-e1-critical-fixes-design.md
@@ -1,0 +1,163 @@
+# Epic 1 — Kritische Fixes
+
+**Datum:** 2026-04-23
+**Status:** Design approved
+**Parent:** [Refactor Overview](2026-04-23-academic-research-refactor-overview.md)
+**Branch:** `refactor/e1-critical-fixes`
+**Ziel-Version:** v4.0.1 (Patch)
+
+## Zweck
+
+E1 fixt alles, was entweder zur Laufzeit bricht, ein Security-Problem darstellt, oder offensichtliche Fehlkonfiguration ist. Keine Content-Änderungen, keine Breaking Changes, keine neuen Features. Diese Fixes müssen vor jedem weiteren Epic gelandet sein, damit spätere Test- und Refactor-Arbeit auf einem stabilen Fundament läuft.
+
+## In-Scope
+
+1. **Pfad-Bugs in drei Skills** (verweisen auf `${CLAUDE_PLUGIN_ROOT}/templates/...`, Dateien liegen aber skill-lokal)
+2. **Security-Fix** in `commands/search.md` (offene Agent-Permissions)
+3. **Agent-Frontmatter** normalisieren (`tools`-Feld, `<example>`-Blöcke)
+4. **`maxTurns` reduzieren** in zwei Agents (Kostenreduktion)
+
+## Out-of-Scope
+
+Explizit NICHT in E1:
+- Python-Skripte löschen → E2
+- Playwright → browser-use → E2
+- `document-skills:xlsx`-Integration → E2
+- Sprach-Vereinheitlichung, Anti-Fabrikations-Klauseln, numerische Schwellen → E3
+- Citations-API, Evals-Suiten, Pushy Descriptions, Evaluator-Pattern → E4
+
+## Detail pro Fix
+
+### Fix 1 — Pfad-Bug `skills/advisor/SKILL.md:78`
+
+**Aktuell:** Skill referenziert `${CLAUDE_PLUGIN_ROOT}/templates/expose-template.md`. Datei liegt aber unter `skills/advisor/expose-template.md`.
+
+**Änderung:** Pfad in der SKILL.md auf `${CLAUDE_PLUGIN_ROOT}/skills/advisor/expose-template.md` umstellen. Datei bleibt skill-lokal (Entscheidung aus Brainstorming).
+
+**Verifikation:**
+- `ls /Users/j65674/Repos/academic-research/skills/advisor/expose-template.md` existiert
+- `grep "expose-template" skills/advisor/SKILL.md` zeigt den neuen Pfad
+
+### Fix 2 — Pfad-Bug `skills/methodology-advisor/SKILL.md:29`
+
+**Aktuell:** Referenziert `${CLAUDE_PLUGIN_ROOT}/templates/methodology-catalog.md`. Datei liegt unter `skills/methodology-advisor/methodology-catalog.md`.
+
+**Änderung:** Pfad auf `${CLAUDE_PLUGIN_ROOT}/skills/methodology-advisor/methodology-catalog.md` umstellen.
+
+**Verifikation:** analog Fix 1.
+
+### Fix 3 — Pfad-Bug `skills/submission-checker/SKILL.md:21`
+
+**Aktuell:** Zeile 21 verweist laut Reviewer-Auditing auf `${CLAUDE_PLUGIN_ROOT}/templates/leibniz-fh-requirements.md`. Datei liegt vermutlich unter `skills/submission-checker/leibniz-fh-requirements.md`.
+
+**Änderung:** Erst prüfen: existiert die Datei tatsächlich skill-lokal? Falls ja → Pfad in SKILL.md auf `${CLAUDE_PLUGIN_ROOT}/skills/submission-checker/leibniz-fh-requirements.md` umstellen. Falls die Datei nicht existiert → als separater Findings notieren und nicht in E1 lösen (E3-Kandidat).
+
+**Verifikation:** analog Fix 1.
+
+### Fix 4 — Security `commands/search.md:4`
+
+**Aktuell:**
+```yaml
+allowed-tools: Read, Write, Bash(~/.academic-research/venv/bin/python *), Agent
+```
+
+Das `Agent` ohne Argument erlaubt jedes Subagent-Invokat.
+
+**Änderung:** `Agent(query-generator, relevance-scorer, quote-extractor)` — nur die drei Agents, die der Command tatsächlich aufruft.
+
+**Verifikation:**
+- `grep "allowed-tools" commands/search.md` zeigt die drei Agent-Namen
+- Command-Ablauf mental durchgespielt: keine anderen Agents werden gebraucht
+
+### Fix 5 — Agent `query-generator.md`: Frontmatter + Description
+
+**Aktuell:** `tools: ""` (leerer String, mehrdeutig). Description ohne `<example>`-Blöcke.
+
+**Änderung:**
+- `tools`-Feld komplett entfernen (Agent benötigt keine Tools)
+- In die Description zwei `<example>`-Blöcke einfügen, die typische Einsatzszenarien zeigen. Format:
+  ```
+  <example>
+  Context: User startet eine neue Literaturrecherche zu einem Thema
+  user: "Suche Literatur zu 'Cloud-Security-Controls im Mittelstand'"
+  assistant: "Ich nutze den query-generator-Agent, um Suchqueries für die Datenbanken zu erstellen."
+  <commentary>
+  Query-Generierung ist der erste Schritt jeder Recherche — Agent wird automatisch vom search-Command aufgerufen.
+  </commentary>
+  </example>
+  ```
+
+**Verifikation:**
+- YAML parseable (`python -c "import yaml; yaml.safe_load(open('agents/query-generator.md').read().split('---')[1])"`)
+- Description enthält mindestens zwei `<example>`-Blöcke
+
+### Fix 6 — Agent `quote-extractor.md`: Frontmatter + maxTurns
+
+**Aktuell:** `tools: ""`, `maxTurns: 20`, keine `<example>`-Blöcke.
+
+**Änderung:**
+- `tools: [Read]` als Array (Agent liest PDFs)
+- `maxTurns: 5` (Quote-Extraction ist Single-Shot mit evtl. kurzer Iteration, 20 ist Overkill)
+- Zwei `<example>`-Blöcke in Description
+
+**Verifikation:** YAML parseable, `maxTurns` == 5, `tools` ist Array.
+
+### Fix 7 — Agent `relevance-scorer.md`: Frontmatter + maxTurns
+
+**Aktuell:** `tools: ""`, `maxTurns: 15`, keine `<example>`-Blöcke.
+
+**Änderung:**
+- `tools`-Feld entfernen (keine Tools nötig)
+- `maxTurns: 3` (Batch-Scoring von 10 Papern = 1 Turn, +2 Puffer für Iteration)
+- Zwei `<example>`-Blöcke in Description
+
+**Verifikation:** analog Fix 6.
+
+## Git-Plan
+
+**Branch:** `refactor/e1-critical-fixes` von `main`
+
+**Commits (atomar, revertierbar):**
+
+| # | Commit-Message | Dateien |
+|---|----------------|---------|
+| 1 | `fix(skills): correct template paths in advisor, methodology-advisor, submission-checker` | 3 SKILL.md-Dateien |
+| 2 | `fix(commands): restrict search agent permissions to named agents` | `commands/search.md` |
+| 3 | `fix(agents): normalize tools field and add example blocks` | 3 Agent-Dateien |
+| 4 | `perf(agents): reduce maxTurns for quote-extractor and relevance-scorer` | `quote-extractor.md`, `relevance-scorer.md` |
+
+Commit 3 und 4 betreffen teils dieselben Dateien, bleiben aber getrennt, weil die Änderungstypen (Frontmatter-Normalisierung vs. Performance-Tuning) logisch unterschiedlich sind.
+
+**Version-Bump-Commit (5):** `chore(release): v4.0.1` in `.claude-plugin/plugin.json` und `.claude-plugin/marketplace.json`.
+
+**PR:** gegen `main`, Titel `Refactor E1: Critical Fixes (v4.0.1)`, Body referenziert den Spec.
+
+## Verifikations-Gesamtcheck (pre-merge)
+
+Bevor der PR gemerged wird:
+
+1. Alle sieben Fixes verifiziert (siehe oben)
+2. `git diff main..HEAD -- 'skills/**/SKILL.md' 'commands/*.md' 'agents/*.md'` manuell durchgesehen
+3. Python-YAML-Parse aller geänderten Frontmatter (kein Parse-Error)
+4. `jq` auf `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` (valide)
+5. Manuelle Sichtprüfung der `<example>`-Blöcke auf sinnvolle Szenarien
+
+## Rollback-Plan
+
+Bei Problemen nach Merge:
+- Einzelner Fix defekt → `git revert <commit-sha>` isoliert einen Fix
+- Kompletter PR defekt → `git revert -m 1 <merge-sha>` nimmt den gesamten Merge zurück
+- Breaking-Verhalten → Version bleibt bei v4.0.0 in `installed_plugins.json` zurück, User updated manuell
+
+## Erfolgskriterien für E1
+
+- Alle drei Pfad-Bugs gefixt, referenzierte Dateien existieren
+- `search.md` ruft keine unbekannten Agents mehr auf
+- Alle drei Agent-Frontmatter YAML-valide, `tools` korrekt typisiert
+- `maxTurns` beider betroffener Agents reduziert
+- v4.0.1 gemerged und getaggt
+- Keine Regressionen in den bestehenden Tests (`tests/`)
+
+## Begleitende GitHub-Tickets
+
+Jeder der sieben Fixes wird als Sub-Issue angelegt, verlinkt zu einem Epic-Issue `[Epic] E1: Critical Fixes (v4.0.1)`. Sub-Issues können unabhängig bearbeitet und geschlossen werden.

--- a/docs/superpowers/specs/2026-04-23-academic-research-e2-architecture-design.md
+++ b/docs/superpowers/specs/2026-04-23-academic-research-e2-architecture-design.md
@@ -1,0 +1,100 @@
+# Epic 2 — Architektur-Bereinigung
+
+**Datum:** 2026-04-23
+**Status:** DRAFT — zu finalisieren im E2-Kickoff-Brainstorm nach Abschluss E1
+**Parent:** [Refactor Overview](2026-04-23-academic-research-refactor-overview.md)
+**Branch:** `refactor/e2-architecture`
+**Ziel-Version:** v5.0.0 (Major, Breaking Changes)
+**Abhängigkeit:** E1 gemerged
+
+## Zweck
+
+Strukturelle Bereinigung der Datei-Landschaft: redundante Python-Skripte löschen, Playwright durch `browser-use` ersetzen, externes `document-skills:xlsx` einbinden. Erzeugt das erste Breaking-Change-Release (v5.0.0).
+
+## In-Scope
+
+### Block A — Redundante Python-Skripte löschen
+
+Begründung laut User: Skills/Agents performen besser als heuristische Python-Skripte. Gilt, wenn Skill/Agent denselben Task abdeckt.
+
+| Skript | Ersatz | Aktion |
+|--------|--------|--------|
+| `scripts/citations.py` (20 KB) | Skill `citation-extraction` + Agent `quote-extractor` | Löschen |
+| `scripts/style_analysis.py` (17 KB) | Skill `style-evaluator` | Löschen |
+| `scripts/ranking.py` (12 KB) | Agent `relevance-scorer` + Skill `source-quality-audit` | Löschen |
+| `scripts/excel.py` (14.5 KB) | externer Skill `document-skills:xlsx` | Löschen (siehe Block C) |
+| `scripts/pdf.py` (13.6 KB) | Agent `quote-extractor` via Read-Tool | **Prüfen**, dann löschen oder behalten |
+| `scripts/search.py` (19.5 KB) | kein Ersatz (CrossRef/OpenAlex/arXiv-APIs) | Behalten |
+| `scripts/dedup.py` (4.7 KB) | String-Matching-Utility, kein Agent-Case | Behalten |
+| `scripts/text_utils.py` (2.9 KB) | Helper für verbleibende Skripte | Behalten |
+| `scripts/configure_permissions.py` (2 KB) | Setup-Utility (wird in Block B angepasst) | Behalten |
+
+**Folgen für Skills/Commands, die auf gelöschte Skripte verweisen:**
+- SKILL.md-Referenzen entfernen, durch Skill/Agent-Nutzung ersetzen
+- `commands/score.md`: Python-Aufruf durch Agent-Invokation ersetzen
+- `commands/excel.md`: komplett auf xlsx-Skill umstellen (Block C)
+
+### Block B — Playwright-MCP → browser-use-Skill
+
+**Zu ändern (12 Stellen):**
+
+| Datei | Änderung |
+|-------|----------|
+| `.mcp.json` | Playwright-MCP-Server-Eintrag komplett entfernen |
+| `scripts/configure_permissions.py:22-36` | 14 `mcp__playwright__*`-Permissions raus, browser-use-Permissions rein |
+| `scripts/setup.sh:27-30` | `npx playwright install`-Block raus |
+| `commands/setup.md:36-38` | Playwright-Install-Schritt raus |
+| `commands/search.md:69-71` | `"use Playwright MCP directly"` → konkrete Anleitung für `browser-use`-Skill |
+| `settings.json:12` | `Bash(cp ~/.playwright-mcp/* *)` raus |
+| `README.md:26` | Node.js-Voraussetzung überprüfen (browser-use braucht Python) |
+| `README.md:95-101` | Install-Block umschreiben |
+| `README.md:198,318,337,392` | Doku auf browser-use umstellen |
+| `config/browser_guides/*.md` | Navigationsguides von Playwright-Selektoren auf browser-use-Prompts umschreiben (Scholar, Springer, OECD, RePEc, OPAC) |
+| `.gitignore:27` | `.playwright-mcp/` raus |
+
+### Block C — `document-skills:xlsx`-Integration
+
+**Entscheidung:** Plugins können andere Plugins nicht direkt auto-installieren. Integration läuft über:
+
+1. `scripts/excel.py` löschen
+2. `commands/excel.md` umschreiben: statt Python-Aufruf → Hinweis an Claude, den `document-skills:xlsx`-Skill anzuwenden, mit klarer Input/Output-Spezifikation
+3. **README-Voraussetzung** ergänzen: `/plugin install document-skills@anthropic-agent-skills` als Install-Step dokumentieren
+4. **SessionStart-Hook** in `hooks/hooks.json` erweitern: prüft, ob xlsx-Skill verfügbar, zeigt Warnung falls nicht
+5. `/setup`-Command ergänzt diesen Check ebenfalls
+
+## Out-of-Scope
+
+- Inhaltliche Überarbeitung der Prompts → E3
+- Citations-API, Evals → E4
+- Neue Commands oder Skills
+
+## Offene Fragen für E2-Kickoff-Brainstorm
+
+1. `scripts/pdf.py` — wirklich löschbar, oder braucht `quote-extractor` PDF-Preprocessing, das Read-Tool nicht leistet (OCR, Passwort-entsperrt, Encoding)?
+2. Wie soll `commands/search.md` bei Browser-Modulen mit `browser-use` konkret aussehen? Ein Prompt pro Datenbank oder ein generischer Prompt mit Parametern?
+3. SessionStart-Hook-Check auf externen Skill: welche API/welches Flag? Ggf. Klärung nötig in der Claude-Code-Doku.
+4. Config-Browser-Guides: komplett neu schreiben oder inkrementell? Migration pro Datenbank?
+
+## Git-Plan (grob, wird verfeinert)
+
+**Branch:** `refactor/e2-architecture` von `main` (nach E1-Merge)
+
+**Commits (grob gruppiert):**
+1. `chore(scripts): remove citations.py, style_analysis.py, ranking.py`
+2. `refactor(commands): update score and related commands to use agents`
+3. `refactor: remove Playwright MCP, migrate to browser-use`
+4. `refactor(excel): replace scripts/excel.py with document-skills:xlsx integration`
+5. `docs: update README for browser-use and document-skills requirements`
+6. `chore(release): v5.0.0`
+
+## Verifikation
+
+- Keine Verweise mehr auf gelöschte Skripte (`grep -r "citations\.py\|style_analysis\.py\|ranking\.py\|excel\.py"`)
+- Keine Verweise mehr auf Playwright (`grep -ri "playwright"`)
+- `/setup`-Command läuft sauber durch
+- `browser-use`-Skill wird für Browser-Datenbanken korrekt angesteuert
+- xlsx-Skill-Check in SessionStart-Hook funktioniert
+
+## Rollback
+
+Major-Release, deshalb Rollback = User muss zurück auf v4.0.1 pinnen. Pre-Merge: üblicher Branch-Revert-Pfad.

--- a/docs/superpowers/specs/2026-04-23-academic-research-e3-prompt-quality-design.md
+++ b/docs/superpowers/specs/2026-04-23-academic-research-e3-prompt-quality-design.md
@@ -1,0 +1,125 @@
+# Epic 3 — Prompt-Qualität
+
+**Datum:** 2026-04-23
+**Status:** DRAFT — zu finalisieren im E3-Kickoff-Brainstorm nach Abschluss E2
+**Parent:** [Refactor Overview](2026-04-23-academic-research-refactor-overview.md)
+**Branch:** `refactor/e3-prompt-quality`
+**Ziel-Version:** v5.1.0 (Minor, Verhaltens-Änderungen)
+**Abhängigkeit:** E2 gemerged
+
+## Zweck
+
+Inhaltliche Überarbeitung der Prompts in allen 13 Skills, 5 Commands und 3 Agents. Behebt systemische Schwächen aus dem Skill-Review: Sprach-Inkonsistenz, fehlender Fabrikationsschutz, schwammige Bewertungskriterien, fehlende Few-Shot-Beispiele.
+
+## In-Scope
+
+### Block A — Sprach-Vereinheitlichung auf Deutsch
+
+Alle Prompts in Skills, Commands, Agents auf konsistent Deutsch umstellen. Englisch nur in Code, Dateipfaden, JSON-Keys, Code-Kommentaren. Grund: User arbeitet durchgängig auf Deutsch (globales CLAUDE.md), Code-Switches bei Haiku/Sonnet reduzieren Qualität.
+
+Betrifft: alle 13 Skills, 5 Commands, 3 Agents (komplette Datei-Überarbeitung).
+
+### Block B — Anti-Fabrikations-Klauseln mit Begründung
+
+**Cookbook-konform** (nicht ALLCAPS-NEVER): Pro Skill eine Klausel im Stil:
+
+> *"Erfundene Quellen führen dazu, dass die Arbeit unzitierbar wird und bei der Plagiatsprüfung auffliegt. Arbeite ausschließlich mit Daten aus `literature_state.md` oder direkt geladenen PDFs. Wenn Daten fehlen: frag den User, rate nicht."*
+
+Variiert pro Skill mit konkretem Schadensszenario (Plagiatsvorwurf, Zitationsbruch, Methoden-Fehleinschätzung).
+
+Betrifft: alle 13 Skills, besonders `source-quality-audit`, `literature-gap-analysis`, `abstract-generator`, `submission-checker`, `chapter-writer`, `citation-extraction`.
+
+### Block C — Numerische Schwellen statt Floskeln
+
+Referenz: `plagiarism-check` (N-Gram-Schwellen, Severity-Classification) als Goldstandard.
+
+Ziel-Skills:
+- `source-quality-audit` — bereits numerisch, prüfen auf Vollständigkeit
+- `advisor` — "common academic standards" → konkrete Kriterien-Liste mit PASS/FAIL
+- `methodology-advisor` — Scoring-Matrix pro Methode (Datenqualität, Zeitaufwand, Supervisor-Präferenz, Fit)
+- `submission-checker` — schon operationalisiert, Regelwerk pro FH verifizieren
+- `style-evaluator` — Fallback-Rubrik bei fehlendem Script (Satzlänge, Metrik-Schwellen)
+- `literature-gap-analysis` — Coverage/Diversity/Recency numerisch
+
+### Block D — Few-Shot-Paare (Gut/Schlecht)
+
+Betrifft alle bewertenden/generierenden Skills. Pro Template bzw. Entscheidungsknoten je ein Positiv- und Negativ-Beispiel.
+
+Prio:
+- `research-question-refiner` (aktuell: Templates ohne Beispiele)
+- `abstract-generator` (Gut/Schlecht-Paar pro Strukturelement)
+- `title-generator`
+- `chapter-writer` (pro Kapiteltyp)
+
+### Block E — Memory-Precondition-Checks
+
+Standard-Skill-Eröffnung:
+
+> *"Bevor du startest: Prüfe, ob `academic_context.md` und `literature_state.md` vorhanden und aktuell sind. Falls nicht → triggere `academic-context`-Skill. Wenn der User das ablehnt → breche den aktuellen Skill ab und erkläre, warum er ohne Kontext nicht läuft."*
+
+Wird an jeden Skill-Anfang (außer `academic-context` selbst) angehängt.
+
+### Block F — Skill-Abgrenzung `literature-gap-analysis` ↔ `source-quality-audit`
+
+Beide prüfen Coverage, Diversity, Recency. Nirgends ist definiert, wann welcher zuständig ist.
+
+**Vorschlag:**
+- `source-quality-audit` → Qualität einzelner Quellen (Impact, Methodik, Peer-Review)
+- `literature-gap-analysis` → Vollständigkeit des Korpus (fehlende Themen, Autoren, Methoden)
+
+In beiden SKILL.md-Dateien klare Abgrenzungsklausel + Cross-Reference.
+
+### Block G — Umlaute in Trigger-Descriptions
+
+Descriptions enthalten aktuell ASCII-Ersatz ("Quellenqualitaet", "pruefen", "Schlagwoerter"). User tippt mit Umlauten, Skills triggern schlechter.
+
+**Fix:** Beide Varianten in Description aufführen: "Quellenqualität / Quellenqualitaet", "prüfen / pruefen" etc. Alternativ: nur Umlaut-Variante (User hat Umlaute auf seiner Tastatur).
+
+### Block H — 8 spezifische Einzelprobleme aus dem Skill-Review
+
+1. `commands/search.md:69-71` — konkrete browser-use-Anleitung (überschneidet sich mit E2 Block B)
+2. `agents/quote-extractor.md:28-33` — robusterer Pre-Execution-Guard (PDF-Wortzahl, Error-Marker)
+3. `agents/query-generator.md:114-126` — CS-Disambiguierung: Code-Switch raus, konkrete CS-Term-Liste
+4. `skills/methodology-advisor:52-99` — einheitliche Scoring-Tabelle statt asymmetrische Key-References
+5. `skills/research-question-refiner:153-163` — Few-Shot-Paare pro Template (überschneidet sich mit Block D)
+6. `skills/abstract-generator:140` — Default bei fehlendem Content: "Preliminary, pending validation"
+7. `skills/style-evaluator:139-140` — manuelle Fallback-Rubrik explizit
+8. `commands/excel.md` — komplett neu (überschneidet sich mit E2 Block C)
+
+## Out-of-Scope
+
+- Native Citations-API → E4
+- Evals-Suiten → E4
+- Pushy Descriptions + Trigger-Eval-Loop → E4
+- Evaluator-Optimizer-Muster → E4
+- Domain-Variants per `references/` → E4
+
+## Offene Fragen für E3-Kickoff-Brainstorm
+
+1. Komplett-Rewrite vs. inkrementell: lieber alle Skills am Stück auf Deutsch umstellen, oder Skill für Skill mit Zwischen-Checkpoints?
+2. Schadensszenarien für Anti-Fabrikations-Klauseln: aus Praxis/FH-Leibniz-Regeln, oder generisch?
+3. Umlaute: beide Varianten oder nur Umlaute?
+4. Memory-Precondition: harter Abbruch oder weicher "Proceed with limited context"?
+
+## Git-Plan (grob)
+
+**Branch:** `refactor/e3-prompt-quality` von `main` nach E2-Merge
+
+**Commits (grob gruppiert):**
+1. `refactor(skills): unify language to German across all skills`
+2. `refactor(commands+agents): unify language to German`
+3. `feat(skills): add anti-fabrication clauses with reasoning`
+4. `feat(skills): replace vague thresholds with numeric criteria`
+5. `feat(skills): add few-shot examples (good/bad pairs)`
+6. `feat(skills): add memory precondition checks`
+7. `fix(skills): clarify boundary between literature-gap-analysis and source-quality-audit`
+8. `fix(skills): add umlaut variants in trigger descriptions`
+9. `fix(agents+commands): address 8 specific issues from skill review`
+10. `chore(release): v5.1.0`
+
+## Verifikation
+
+- Komplette Spracheinheit (`grep -l "^#\|^-\|^\*" skills/**/SKILL.md` — keine Englisch-Absätze in den Hauptsektionen)
+- Jeder Skill hat Anti-Fabrikations-Klausel (`grep -l "erfund\|fabricat" skills/**/SKILL.md` bestätigt Coverage)
+- Jeder Skill hat Memory-Precondition-Check
+- Review durch Subagent (z. B. `skill-reviewer`) nach Abschluss

--- a/docs/superpowers/specs/2026-04-23-academic-research-e4-cookbook-design.md
+++ b/docs/superpowers/specs/2026-04-23-academic-research-e4-cookbook-design.md
@@ -1,0 +1,133 @@
+# Epic 4 — Cookbook-Adoption
+
+**Datum:** 2026-04-23
+**Status:** DRAFT — zu finalisieren im E4-Kickoff-Brainstorm nach Abschluss E3
+**Parent:** [Refactor Overview](2026-04-23-academic-research-refactor-overview.md)
+**Branch:** `refactor/e4-cookbook`
+**Ziel-Version:** v5.2.0 (Minor, neue Features)
+**Abhängigkeit:** E3 gemerged
+
+## Zweck
+
+Adoption der offiziellen Anthropic-Patterns aus `anthropics/anthropic-cookbook` und `anthropics/skills`. Macht das Plugin messbar qualitativ (Evals), halluzinationssicher (Citations-API) und triggerrobust (Pushy Descriptions + Trigger-Eval).
+
+## In-Scope
+
+### Block A — Native Citations-API
+
+**Cookbook-Quelle:** `anthropic-cookbook/misc/using_citations.ipynb`
+
+Die Claude-API hat ein Citations-Feature, das auf API-Ebene erzwingt, dass Claude nur aus gelieferten Dokumenten zitiert. Halluzinationssicherer als jede Prompt-Klausel.
+
+**Betroffene Komponenten:**
+- `agents/quote-extractor.md` — Pre-Execution-Guard raus, Citations-API rein
+- `skills/citation-extraction` — Prompt-basierte Zitation umstellen
+- `skills/chapter-writer` — beim Quellen-Einweben Citations-API nutzen
+
+**Aufwand:** Medium — erfordert API-Schema-Anpassung (`documents`-Parameter, Location-Format wählen: char/page/content-block).
+
+### Block B — Evals-Suite pro Skill
+
+**Cookbook-Quelle:** `anthropics/skills/skills/skill-creator/SKILL.md` + `references/schemas.md`
+
+Jedes Skill bekommt `evals/evals.json` mit:
+- Test-Prompts
+- Verifizierbare `expectations`
+- Baseline-Vergleich: with_skill vs. without_skill
+
+**Priorität (nach Halluzinationsrisiko):**
+1. `quote-extractor`
+2. `citation-extraction`
+3. `abstract-generator`
+4. `source-quality-audit`
+5. `chapter-writer`
+6. Rest
+
+**Infrastruktur:**
+- Test-Runner (Python-Script oder node-basiert)
+- CI-Integration? Oder manuell vor Release?
+- Eval-Reports in `docs/evals/`
+
+### Block C — Pushy Descriptions + Trigger-Eval-Loop
+
+**Cookbook-Quelle:** `anthropics/skills/skills/skill-creator/SKILL.md`
+
+Zitat: *"Claude has a tendency to 'undertrigger' skills […] please make the skill descriptions a little bit 'pushy'"*.
+
+**Vorgehen:**
+1. Alle 13 Skill-Descriptions "pushy" umformulieren
+2. Pro Skill ein Trigger-Eval-Set mit **20 Prompts**:
+   - 8-10 should-trigger (klare Fälle, deutsche Formulierungen, Fachjargon)
+   - 8-10 should-not-trigger (Near-Misses, Nachbar-Skills, unspezifische Alltagsfragen)
+3. Trigger-Eval als Teil der Evals-Suite aus Block B
+
+### Block D — Evaluator-Optimizer-Muster
+
+**Cookbook-Quelle:** `anthropic-cookbook/patterns/agents/evaluator_optimizer.ipynb`, `orchestrator_workers.ipynb`
+
+Iterative Skills (chapter-writer, advisor) bekommen eine Generator/Evaluator-Trennung.
+
+**Neuer Agent:** `quality-reviewer`
+- Input: generierter Inhalt + Kriterien-Checkliste (numerische Schwellen aus E3 Block C)
+- Output: PASS/REVISE mit konkreter Begründung
+- Wird von `chapter-writer`, `abstract-generator`, `advisor` vor finalem Output aufgerufen
+
+### Block E — Domain-Organisation via `references/<variant>.md`
+
+**Cookbook-Quelle:** `anthropics/skills/skills/skill-creator/SKILL.md` — Abschnitt "Domain organization"
+
+Skills mit mehreren Zielgruppen/Regelwerken bekommen SKILL.md als Workflow + Variant-Auswahl, pro Variante eine `references/<variant>.md`.
+
+**Betroffene Skills:**
+- `citation-extraction` → `references/{apa,harvard,chicago,din1505}.md`
+- `style-evaluator` → `references/{academic-de,academic-en}.md`
+- `submission-checker` → `references/{fh-leibniz,uni-general,journal-ieee,journal-acm}.md`
+
+### Block F — Prompt-Caching
+
+**Cookbook-Quelle:** `anthropic-cookbook/misc/prompt_caching.ipynb`
+
+`relevance-scorer` verarbeitet Batches von 10+ Papern. System-Prompt + Scoring-Rubrik sind statisch → gecacht. Spart massiv Tokens/Latenz.
+
+**Betroffene Komponenten:**
+- `agents/relevance-scorer.md` — Cache-Breakpoints definieren
+- Evtl. `agents/quote-extractor.md` für Batch-PDFs
+- `scripts/search.py` (falls weiterhin benutzt) — API-Calls mit cache_control
+
+## Out-of-Scope
+
+- MCP-Server-Umstellung mit formalem `outputSchema` → nicht relevant, weil aktuell kein MCP-Server exponiert wird
+- Neue Skills über die existierenden 13 hinaus
+- UI-Komponenten oder Dashboards
+
+## Offene Fragen für E4-Kickoff-Brainstorm
+
+1. Citations-API: char-Level oder page-Level Locations (User-Erwartung bei akademischen Quellen)?
+2. Evals-Runner: Python-eigen oder existierendes Framework (`pytest`, `inspect-ai`)?
+3. CI-Integration: GitHub Actions oder manuell?
+4. Pushy Descriptions: radikal oder moderat? Balance zwischen Undertriggering und Overtriggering.
+5. `quality-reviewer`-Agent: eigener Agent oder in `chapter-writer` eingebettet als Inline-Schritt?
+6. Welche Submission-Varianten wirklich relevant (FH-Leibniz ist fix, welche anderen)?
+
+## Git-Plan (grob)
+
+**Branch:** `refactor/e4-cookbook` von `main` nach E3-Merge
+
+**Commits (grob gruppiert):**
+1. `feat(agents): adopt native Citations API in quote-extractor and chapter-writer`
+2. `feat(skills): migrate citation-extraction to Citations API`
+3. `feat(evals): introduce evals suite with baseline comparison`
+4. `feat(skills): pushy descriptions and trigger-eval sets`
+5. `feat(agents): introduce quality-reviewer and evaluator-optimizer pattern`
+6. `refactor(skills): domain-organized references for citation-extraction and submission-checker`
+7. `perf: prompt caching in relevance-scorer`
+8. `docs: evals reports`
+9. `chore(release): v5.2.0`
+
+## Verifikation
+
+- Alle Evals-Suites laufen grün, Baseline-Gap dokumentiert
+- Trigger-Eval zeigt messbares Undertriggering-Reduction
+- Citations-API liefert location-genaue Zitate (manuelle Spot-Checks)
+- `quality-reviewer` wird vor Output aufgerufen (Code-Review)
+- Token-Ersparnis durch Caching messbar (vor/nach)

--- a/docs/superpowers/specs/2026-04-23-academic-research-refactor-overview.md
+++ b/docs/superpowers/specs/2026-04-23-academic-research-refactor-overview.md
@@ -1,0 +1,116 @@
+# Academic-Research Plugin — Refactor-Overview (v4 → v5)
+
+**Datum:** 2026-04-23
+**Status:** Design approved, Implementation pro Epic
+**Autor:** jam@ahler.org, assistiert durch Claude Code
+
+## Ausgangslage
+
+Das academic-research-Plugin (v4.0.0) ist strukturell solide, hat aber nach Reviews durch `plugin-validator`, `skill-reviewer` und Cookbook-Abgleich 25+ diskrete Findings über vier Themenbereiche. Ein einzelner Implementation-Plan wäre zu groß und zu riskant. Dieses Dokument dokumentiert die Decomposition und gibt den Rahmen für die vier Sub-Projekte vor.
+
+## Entscheidungen (nach Brainstorming)
+
+- **Scope-Struktur:** Vier Epics nacheinander, jedes mit eigenem Spec → Plan → Implementation → PR-Zyklus.
+- **Constraints:** Keine. Breaking Changes zulässig, keine Deadline, keine Abhängigkeits-Sperre.
+- **Git-Strategie:** Feature-Branch pro Epic (`refactor/e1-*`, `refactor/e2-*`, ...), ein PR pro Epic gegen `main`. Version-Bump nach jedem Merge.
+- **Template-Architektur:** Skill-lokal. Templates bleiben im jeweiligen Skill-Ordner, keine zentrale `templates/`-Hierarchie.
+
+## Epic-Übersicht
+
+### E1 — Kritische Fixes (v4.0.1)
+
+**Branch:** `refactor/e1-critical-fixes`
+**Umfang:** ~½ Tag
+**Risiko:** niedrig
+**Abhängigkeit:** keine
+
+Fixt ausschließlich Laufzeit-Bugs, eine Security-Lücke und offensichtliche Fehlkonfigurationen. Keine Content-Änderungen, keine Breaking Changes.
+
+- Pfad-Bugs in `advisor`, `methodology-advisor`, `submission-checker`
+- `commands/search.md`: offene Agent-Permissions einschränken
+- Agent-Frontmatter: `tools` als Array, `<example>`-Blöcke in Description
+- `maxTurns` reduzieren: `quote-extractor` 20→5, `relevance-scorer` 15→3
+
+Detail-Spec: [2026-04-23-academic-research-e1-critical-fixes-design.md](2026-04-23-academic-research-e1-critical-fixes-design.md)
+
+### E2 — Architektur-Bereinigung (v4.1.0 → v5.0.0)
+
+**Branch:** `refactor/e2-architecture`
+**Umfang:** 2-3 Tage
+**Risiko:** mittel (Regressionspotential in Suche und Export)
+**Abhängigkeit:** E1
+
+Strukturelle Bereinigung der Datei-Landschaft. Breaking Changes an Commands und MCP-Setup.
+
+- Redundante Python-Skripte löschen:
+  - `scripts/citations.py` (ersetzt durch Skill `citation-extraction` + Agent `quote-extractor`)
+  - `scripts/style_analysis.py` (ersetzt durch Skill `style-evaluator`)
+  - `scripts/ranking.py` (ersetzt durch Agent `relevance-scorer` + Skill `source-quality-audit`)
+  - `scripts/excel.py` (ersetzt durch `document-skills:xlsx`)
+  - Prüfen: `scripts/pdf.py` (ggf. ersetzbar durch `quote-extractor`-Agent)
+- Playwright-MCP → `browser-use`-Skill migrieren (12 Stellen: `.mcp.json`, `configure_permissions.py`, `setup.sh`, `README.md`, `commands/setup.md`, `commands/search.md`, `settings.json`, `config/browser_guides/*.md`, `.gitignore`)
+- `document-skills:xlsx`-Integration: `commands/excel.md` umbauen, README-Voraussetzung, SessionStart-Hook-Check
+- Betroffene Skills anpassen, die auf gelöschte Skripte verwiesen haben
+
+Wird in eigenem Brainstorm-Zyklus detailliert.
+
+### E3 — Prompt-Qualität (v5.1.0)
+
+**Branch:** `refactor/e3-prompt-quality`
+**Umfang:** 3-5 Tage
+**Risiko:** mittel (Verhalten ändert sich spürbar)
+**Abhängigkeit:** E2
+
+Inhaltliche Überarbeitung aller Prompts in Skills, Commands, Agents.
+
+- Sprach-Vereinheitlichung: alles Deutsch, Englisch nur in Code/Pfaden/JSON-Keys
+- Anti-Fabrikations-Klauseln mit Begründung (Cookbook-konform: kein blankes ALLCAPS-NEVER, sondern Begründung + Handlungsanweisung)
+- Numerische Schwellen statt Floskeln (Plagiarism-Check als Goldstandard)
+- Few-Shot-Paare (Gut/Schlecht) in allen bewertenden Skills
+- Memory-Precondition-Checks als Standard-Skill-Eröffnung
+- Umlaute in Trigger-Descriptions (ä/ö/ü statt ae/oe/ue, zusätzlich zur ASCII-Variante)
+- Skill-Abgrenzung zwischen `literature-gap-analysis` und `source-quality-audit` explizit machen
+- Die 8 spezifischen Einzelprobleme aus dem Skill-Review
+
+Wird in eigenem Brainstorm-Zyklus detailliert.
+
+### E4 — Cookbook-Adoption (v5.2.0)
+
+**Branch:** `refactor/e4-cookbook`
+**Umfang:** 3-5 Tage
+**Risiko:** hoch (API-Änderungen, Test-Infrastruktur)
+**Abhängigkeit:** E3
+
+Adoption der offiziellen Anthropic-Patterns.
+
+- Native Citations-API im `quote-extractor` und `citation-extraction` (ersetzt heuristische Pre-Execution-Guards)
+- Evals-Suite pro Skill (`evals/evals.json` mit `expectations`, Baseline with_skill vs. without_skill)
+- Pushy Descriptions + Trigger-Eval-Loop (20 Prompts je Skill: 8-10 should-trigger, 8-10 should-not-trigger inkl. Near-Misses)
+- Evaluator-Optimizer-Muster: neuer Agent `quality-reviewer`, Generator/Evaluator-Trennung in iterativen Skills
+- Domain-Organisation via `references/<variant>.md` für `citation-extraction` (APA, Harvard, Chicago, DIN 1505) und `style-evaluator`
+- Prompt-Caching im `relevance-scorer` für Batch-Runs
+
+Wird in eigenem Brainstorm-Zyklus detailliert.
+
+## Arbeitsweise-Regeln für alle Epics
+
+1. **Ein Feature-Branch pro Epic.** Kein Cross-Epic-Commit.
+2. **Nach jedem Epic:** Version-Bump in `.claude-plugin/plugin.json` und `.claude-plugin/marketplace.json`, Eintrag im CHANGELOG.
+3. **Vor jedem Merge:** Statische Verifikation (YAML-Parse, Path-Checks, JSON-Validity). Ab E4 zusätzlich Evals-Suite.
+4. **Rollback:** Atomare Commits, so dass `git revert` pro Fix möglich bleibt.
+5. **Out-of-Scope strikt respektieren:** Findings, die thematisch zu einem späteren Epic gehören, nicht vorziehen.
+
+## Versionierung
+
+| Epic | Ziel-Version | Änderungstyp |
+|------|--------------|--------------|
+| E1 | v4.0.1 | Patch (reine Bugfixes) |
+| E2 | v5.0.0 | Major (Breaking: Skripte weg, Playwright weg) |
+| E3 | v5.1.0 | Minor (Verhalten ändert sich, aber API stabil) |
+| E4 | v5.2.0 | Minor (neue Features, Citations-API, Evals) |
+
+## Was dieses Dokument NICHT leistet
+
+- Keine Detail-Spezifikation einzelner Fixes — das leisten die Epic-Specs.
+- Kein Implementation-Plan — den erzeugt pro Epic das `writing-plans`-Skill.
+- Keine Zeitschätzung mit Deadlines — Aufwände sind grobe Orientierung.

--- a/skills/advisor/SKILL.md
+++ b/skills/advisor/SKILL.md
@@ -75,7 +75,7 @@ If gaps are found, offer to trigger `/search` for specific chapters with targete
 
 ### 5. Expose Generation
 
-When the user requests an expose, use the template at `${CLAUDE_PLUGIN_ROOT}/templates/expose-template.md` as the base structure. Fill in sections from the academic context and outline:
+When the user requests an expose, use the template at `${CLAUDE_PLUGIN_ROOT}/skills/advisor/expose-template.md` as the base structure. Fill in sections from the academic context and outline:
 
 - Problemstellung (problem statement)
 - Zielsetzung (objective)

--- a/skills/methodology-advisor/SKILL.md
+++ b/skills/methodology-advisor/SKILL.md
@@ -26,7 +26,7 @@ Help choose, justify, and document the research methodology for the thesis. Comp
 
 ## Reference
 
-Consult the methodology catalog at `${CLAUDE_PLUGIN_ROOT}/templates/methodology-catalog.md` for detailed descriptions, strengths, weaknesses, and use cases of each methodology type.
+Consult the methodology catalog at `${CLAUDE_PLUGIN_ROOT}/skills/methodology-advisor/methodology-catalog.md` for detailed descriptions, strengths, weaknesses, and use cases of each methodology type.
 
 ## Core Workflow
 

--- a/skills/submission-checker/SKILL.md
+++ b/skills/submission-checker/SKILL.md
@@ -17,7 +17,7 @@ Validate that an academic paper meets all formal submission requirements: page c
 ## Memory and Reference Files
 
 - Read `academic_context.md` for work type, university, program, and citation style
-- Read `leibniz-fh-requirements.md` for university-specific formal requirements
+- Read `${CLAUDE_PLUGIN_ROOT}/skills/submission-checker/leibniz-fh-requirements.md` for university-specific formal requirements
 - Read `writing_state.md` for current word counts and chapter completion status
 
 ## Checklist Dimensions
@@ -46,7 +46,7 @@ Verify presence of all mandatory sections in correct order:
 
 ### 2. Page Count and Length
 
-Check against requirements from `leibniz-fh-requirements.md`:
+Check against requirements from `${CLAUDE_PLUGIN_ROOT}/skills/submission-checker/leibniz-fh-requirements.md`:
 
 | Work Type        | Typical Range (pages) |
 |------------------|-----------------------|
@@ -112,14 +112,14 @@ If figures or tables are present:
 
 Verify:
 - Present as last page (or per university placement rule)
-- Contains required wording per `leibniz-fh-requirements.md`
+- Contains required wording per `${CLAUDE_PLUGIN_ROOT}/skills/submission-checker/leibniz-fh-requirements.md`
 - Includes place and date fields
 - Includes signature line
 
 ## Evaluation Workflow
 
 1. Read `academic_context.md` to determine work type and university
-2. Read `leibniz-fh-requirements.md` for specific requirements
+2. Read `${CLAUDE_PLUGIN_ROOT}/skills/submission-checker/leibniz-fh-requirements.md` for specific requirements
 3. Read `writing_state.md` for current completion status
 4. Analyze the paper structure against the checklist
 5. Score each dimension as PASS, PARTIAL, or FAIL
@@ -156,8 +156,8 @@ Verify:
 
 ## Important Rules
 
-- Always check `leibniz-fh-requirements.md` first -- university-specific rules override general conventions
-- If `leibniz-fh-requirements.md` is not available, use standard German academic conventions and note that university-specific verification was not possible
+- Always check `${CLAUDE_PLUGIN_ROOT}/skills/submission-checker/leibniz-fh-requirements.md` first -- university-specific rules override general conventions
+- If `${CLAUDE_PLUGIN_ROOT}/skills/submission-checker/leibniz-fh-requirements.md` is not available, use standard German academic conventions and note that university-specific verification was not possible
 - Never assume formatting is correct without checking -- formatting errors are the most common reason for submission delays
 - Distinguish between hard requirements (FAIL = cannot submit) and soft recommendations (PARTIAL = should fix)
 - If the paper is not yet complete, run the check on available sections and note which checks are pending


### PR DESCRIPTION
## Summary

Epic 1 des v4→v5-Refactors. Fixt ausschließlich Laufzeit-Bugs, eine Security-Lücke und offensichtliche Fehlkonfigurationen. Keine Content-Änderungen, keine Breaking Changes.

**Epic:** #8
**Spec:** `docs/superpowers/specs/2026-04-23-academic-research-e1-critical-fixes-design.md`
**Version:** v4.0.0 → v4.0.1 (Patch)

## Closes

- Closes #12 — Pfad-Bug in `skills/advisor/SKILL.md`
- Closes #13 — Pfad-Bug in `skills/methodology-advisor/SKILL.md`
- Closes #14 — Pfad-Bug in `skills/submission-checker/SKILL.md`
- Closes #15 — Offene Agent-Permissions in `commands/search.md`
- Closes #16 — Normalisierung `tools`-Feld in allen 3 Agents
- Closes #17 — `<example>`-Blöcke in Agent-Descriptions
- Closes #18 — `maxTurns` reduziert

## Änderungen

| Commit | Inhalt |
|--------|--------|
| `683497c` | fix(skills): Template-Pfade korrigiert (3 SKILL.md, 8 Pfad-Referenzen) |
| `f4e6f0b` | fix(commands): `search.md` Agent-Permissions eingeschränkt |
| `8c7e06b` | fix(agents): `tools`-Frontmatter + 2 `<example>`-Blöcke je Agent |
| `6f57cab` | perf(agents): `maxTurns` runter (quote-extractor 20→5, relevance-scorer 15→3) |
| `67cb4a8` | chore(release): v4.0.1 mit CHANGELOG |

## Verifikation

- [x] Alle Zieldateien existieren (`ls` auf neue Pfade)
- [x] Keine `${CLAUDE_PLUGIN_ROOT}/templates/...`-Referenzen mehr in Skills
- [x] Agent-Frontmatter YAML-valide (Ruby YAML-Parser)
- [x] Agent-Descriptions je 2 `<example>`-Blöcke (geprüft)
- [x] `maxTurns`-Werte: quote-extractor=5, relevance-scorer=3
- [x] `allowed-tools` in `search.md` zeigt 3 Agent-Namen
- [x] `plugin.json` und `marketplace.json` valide JSON, Version 4.0.1
- [x] 10 Files, 96 Insertions, 19 Deletions — nur die geplanten Änderungen

## Test Plan

Da E1 reine Config-/Frontmatter-/Pfad-Fixes enthält (keine Code-Logik), läuft die Verifikation statisch:

- [ ] Plugin neu laden und `/academic-research:search` anstoßen → `query-generator`, `relevance-scorer`, `quote-extractor` werden per Auto-Dispatch gefunden
- [ ] `advisor`-Skill anstoßen und Exposé-Generation bis zu Schritt 5 durchspielen → `expose-template.md` wird über den neuen Pfad geladen
- [ ] `methodology-advisor` triggern → `methodology-catalog.md` wird geladen
- [ ] `submission-checker` triggern → `leibniz-fh-requirements.md` wird geladen
- [ ] `maxTurns`-Reduktion: Search-Run durchlaufen lassen, keine Turn-Limit-Errors

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>