### PR TITLE
docs(spec): finalize E2 architecture cleanup spec

### DIFF
--- a/docs/superpowers/specs/2026-04-23-academic-research-e2-architecture-design.md
+++ b/docs/superpowers/specs/2026-04-23-academic-research-e2-architecture-design.md
@@ -1,100 +1,242 @@
 # Epic 2 — Architektur-Bereinigung
 
 **Datum:** 2026-04-23
-**Status:** DRAFT — zu finalisieren im E2-Kickoff-Brainstorm nach Abschluss E1
+**Status:** FINALISIERT (Brainstorm-Ergebnis nach E1-Merge)
 **Parent:** [Refactor Overview](2026-04-23-academic-research-refactor-overview.md)
 **Branch:** `refactor/e2-architecture`
 **Ziel-Version:** v5.0.0 (Major, Breaking Changes)
-**Abhängigkeit:** E1 gemerged
+**Abhängigkeit:** E1 gemerged (v4.0.1)
 
 ## Zweck
 
-Strukturelle Bereinigung der Datei-Landschaft: redundante Python-Skripte löschen, Playwright durch `browser-use` ersetzen, externes `document-skills:xlsx` einbinden. Erzeugt das erste Breaking-Change-Release (v5.0.0).
+Strukturelle Bereinigung der Datei-Landschaft:
+- Drei redundante Python-Skripte löschen (citations, style_analysis, ranking), zu denen Skills/Agents existieren.
+- `excel.py` ersetzen durch den Claude-eigenen `document-skills:xlsx`-Skill.
+- `Playwright-MCP` durch den globalen `browser-use`-Skill (CLI-basiert) ersetzen.
+- `pdf.py` bleibt bestehen: Download-Fallback, PyPDF2-Textextraktion, TF-IDF-Index sind Infrastruktur, kein LLM-Ersatz sinnvoll.
 
-## In-Scope
+Erzeugt das erste Breaking-Change-Release (`v5.0.0`).
 
-### Block A — Redundante Python-Skripte löschen
+## Scope-Übersicht
 
-Begründung laut User: Skills/Agents performen besser als heuristische Python-Skripte. Gilt, wenn Skill/Agent denselben Task abdeckt.
+```
+Block A — Skripte löschen (3 Dateien)
+Block B — Playwright → browser-use (11 Touchpoints)
+Block C — excel.py → document-skills:xlsx (inkl. SessionStart-Check)
+Block D — Release (Version, CHANGELOG, Tag)
+```
 
-| Skript | Ersatz | Aktion |
-|--------|--------|--------|
-| `scripts/citations.py` (20 KB) | Skill `citation-extraction` + Agent `quote-extractor` | Löschen |
-| `scripts/style_analysis.py` (17 KB) | Skill `style-evaluator` | Löschen |
-| `scripts/ranking.py` (12 KB) | Agent `relevance-scorer` + Skill `source-quality-audit` | Löschen |
-| `scripts/excel.py` (14.5 KB) | externer Skill `document-skills:xlsx` | Löschen (siehe Block C) |
-| `scripts/pdf.py` (13.6 KB) | Agent `quote-extractor` via Read-Tool | **Prüfen**, dann löschen oder behalten |
-| `scripts/search.py` (19.5 KB) | kein Ersatz (CrossRef/OpenAlex/arXiv-APIs) | Behalten |
-| `scripts/dedup.py` (4.7 KB) | String-Matching-Utility, kein Agent-Case | Behalten |
-| `scripts/text_utils.py` (2.9 KB) | Helper für verbleibende Skripte | Behalten |
-| `scripts/configure_permissions.py` (2 KB) | Setup-Utility (wird in Block B angepasst) | Behalten |
+## Block A — Redundante Python-Skripte löschen
 
-**Folgen für Skills/Commands, die auf gelöschte Skripte verweisen:**
-- SKILL.md-Referenzen entfernen, durch Skill/Agent-Nutzung ersetzen
-- `commands/score.md`: Python-Aufruf durch Agent-Invokation ersetzen
-- `commands/excel.md`: komplett auf xlsx-Skill umstellen (Block C)
+### A.1 Zu löschen
 
-### Block B — Playwright-MCP → browser-use-Skill
+| Skript | Größe | Ersatz-Mechanismus |
+|--------|-------|--------------------|
+| `scripts/citations.py` | 20 KB | Skill `citation-extraction` + Agent `quote-extractor` |
+| `scripts/style_analysis.py` | 17 KB | Skill `style-evaluator` |
+| `scripts/ranking.py` | 12 KB | Agent `relevance-scorer` + Skill `source-quality-audit` |
 
-**Zu ändern (12 Stellen):**
+Zugehörige Tests ebenfalls löschen:
+- `tests/test_excel.py`
+- `tests/test_ranking.py`
+- `tests/test_style_analysis.py`
+
+### A.2 Zu behalten (explizit)
+
+| Skript | Begründung |
+|--------|------------|
+| `scripts/search.py` | Multi-API-Suche (CrossRef/OpenAlex/Semantic Scholar/arXiv/BASE/EconBiz/EconStor) — kein Agent-Ersatz |
+| `scripts/dedup.py` | Deterministisches String-Matching, kein LLM-Bedarf |
+| `scripts/pdf.py` | 5-Tier-Download-Fallback (OpenAlex → Unpaywall → arXiv → DOI → URL), PyPDF2-Parsing, TF-IDF-Index — pures IO und Mathematik |
+| `scripts/text_utils.py` | Helper für verbleibende Skripte |
+| `scripts/configure_permissions.py` | Setup-Utility (wird in Block B angepasst) |
+
+### A.3 Folge-Änderungen in Commands und Skills
+
+**Commands (grep-bestätigt):**
+- `commands/score.md:48` — Python-Aufruf `ranking.py` durch `relevance-scorer`-Agent-Invokation ersetzen
+- `commands/search.md:86` — denselben `ranking.py`-Aufruf streichen (Agent-Invokation läuft bereits in Step 7 des Commands)
+- `commands/excel.md` — komplett neu, siehe Block C
+
+**Skills (grep-bestätigt):**
+- `skills/citation-extraction/SKILL.md:8,87,102,108,114,149` — alle `citations.py`-Verweise auf Agent/Skill-Flow umstellen; keine Python-Pipeline mehr
+- `skills/source-quality-audit/SKILL.md:24,64,168` — `score_authority()`/`score_recency()`-Logik direkt im Skill-Prompt beschreiben
+- `skills/chapter-writer/SKILL.md:77` — `citations.py`-Referenz durch Agent-Output-Verweis ersetzen
+- `skills/style-evaluator/SKILL.md:25,96,140` — `style_analysis.py`-Referenzen streichen; Metriken direkt im Skill-Prompt spezifizieren
+
+**README:**
+- `README.md:271,274-276,366-367` — Skripte-Tabelle und Dateibaum auf verbleibende Dateien reduzieren
+
+## Block B — Playwright-MCP → `browser-use`-Skill
+
+### B.1 Kontext
+
+`browser-use` liegt unter `~/.claude/skills/browser-use/` als globaler User-Skill (nicht Bestandteil des Plugins, daher nur README-Hinweis auf CLI-Install). CLI-API ist index-basiert (`state` liefert nummerierte Elemente, keine CSS-Selektoren). Dadurch werden die aktuellen Playwright-Guides (Selektoren + JS-Extraktion) vollständig obsolet.
+
+### B.2 Zu entfernen
 
 | Datei | Änderung |
 |-------|----------|
-| `.mcp.json` | Playwright-MCP-Server-Eintrag komplett entfernen |
-| `scripts/configure_permissions.py:22-36` | 14 `mcp__playwright__*`-Permissions raus, browser-use-Permissions rein |
-| `scripts/setup.sh:27-30` | `npx playwright install`-Block raus |
-| `commands/setup.md:36-38` | Playwright-Install-Schritt raus |
-| `commands/search.md:69-71` | `"use Playwright MCP directly"` → konkrete Anleitung für `browser-use`-Skill |
-| `settings.json:12` | `Bash(cp ~/.playwright-mcp/* *)` raus |
-| `README.md:26` | Node.js-Voraussetzung überprüfen (browser-use braucht Python) |
-| `README.md:95-101` | Install-Block umschreiben |
-| `README.md:198,318,337,392` | Doku auf browser-use umstellen |
-| `config/browser_guides/*.md` | Navigationsguides von Playwright-Selektoren auf browser-use-Prompts umschreiben (Scholar, Springer, OECD, RePEc, OPAC) |
-| `.gitignore:27` | `.playwright-mcp/` raus |
+| `.mcp.json` | Komplett ersetzen durch `{"mcpServers": {}}` oder Datei löschen |
+| `scripts/configure_permissions.py:22-36` | 14 `mcp__playwright__*`-Permissions und `npx playwright`/`@playwright/mcp`-Bash-Regeln entfernen |
+| `scripts/setup.sh:26-34` | Playwright-Install-Block (npx playwright install chromium) entfernen |
+| `commands/setup.md` | Playwright-Install-Schritt streichen |
+| `settings.json:12` | `"Bash(cp ~/.playwright-mcp/* *)"` raus |
+| `.gitignore:27` | `.playwright-mcp/`-Eintrag raus |
+| `README.md` | Alle Playwright-Erwähnungen umschreiben oder löschen (ca. 6 Stellen, per `rg -i "playwright" README.md`) |
 
-### Block C — `document-skills:xlsx`-Integration
+### B.3 Zu ergänzen
 
-**Entscheidung:** Plugins können andere Plugins nicht direkt auto-installieren. Integration läuft über:
+| Datei | Änderung |
+|-------|----------|
+| `scripts/configure_permissions.py` | Neue Permission: `Bash(browser-use:*)` und `Bash(browser-use *)` (Skill-Rechte) |
+| `commands/setup.md` | Schritt: _"Prüfe, ob `browser-use` CLI installiert ist (`browser-use doctor`) und ob der globale `browser-use`-Skill verfügbar ist (`~/.claude/skills/browser-use/SKILL.md`)"_ |
+| `README.md` (Prerequisites) | `uv tool install browser-use` oder `pipx install browser-use` dokumentieren; Verweis auf https://github.com/browser-use/browser-use; Node.js-Prereq entfernen, falls sonst nicht mehr gebraucht |
 
-1. `scripts/excel.py` löschen
-2. `commands/excel.md` umschreiben: statt Python-Aufruf → Hinweis an Claude, den `document-skills:xlsx`-Skill anzuwenden, mit klarer Input/Output-Spezifikation
-3. **README-Voraussetzung** ergänzen: `/plugin install document-skills@anthropic-agent-skills` als Install-Step dokumentieren
-4. **SessionStart-Hook** in `hooks/hooks.json` erweitern: prüft, ob xlsx-Skill verfügbar, zeigt Warnung falls nicht
-5. `/setup`-Command ergänzt diesen Check ebenfalls
+### B.4 `commands/search.md` — Schritt 4 neu
+
+Der heutige Text _"For browser modules (…), use Playwright MCP directly. Read the corresponding browser guide"_ wird ersetzt durch:
+
+> **Schritt 4 (Browser-Search, nur im `standard`/`deep`-Modus, falls `--no-browser` nicht gesetzt):**
+>
+> Für jedes Browser-Modul in fester Reihenfolge (`google_scholar` → `springer` → `oecd` → `repec` → `opac` → `ebscohost` → `proquest`):
+>
+> 1. Guide aus `${CLAUDE_PLUGIN_ROOT}/config/browser_guides/<modul>.md` lesen (URL, Auth-Art, Anti-Scraping-Hinweise)
+> 2. Bei Auth-Modulen (`ebscohost`, `proquest`, `opac`): zuerst `han_login.md`-Flow durchlaufen
+> 3. Mit dem globalen `browser-use`-Skill:
+>    - `browser-use open <URL>` — Seite laden
+>    - `browser-use state` — klickbare Elemente mit Index abrufen
+>    - Query-Feld per Index identifizieren und ausfüllen: `browser-use input <idx> "<QUERY>"`
+>    - Suchen auslösen (Enter oder Submit-Button) und `browser-use state` für Ergebnisse
+>    - Bei Bedarf paginieren (max. 2 Seiten pro Modul)
+>    - Ergebnisse in das `api_results.json`-Schema normalisieren und anhängen
+> 4. Bei Fehler (CAPTCHA, Rate-Limit, fehlgeschlagenem Login): `browser-use screenshot`, User informieren, Partial Results behalten
+
+### B.5 Browser-Guides-Umbau
+
+**Strategie: radikale Verschlankung in einem Commit** (alle 9 Guides neu).
+
+**Neues Template pro Guide:**
+
+```markdown
+# <Datenbank> — Navigation Guide
+
+**URL:** https://...
+**Auth:** keine / HAN-Login (siehe han_login.md) / eigene Credentials in ~/.academic-research/credentials.json
+**Max. Ergebnisse:** <N>
+**Anti-Scraping:** <Warnung falls relevant — z. B. Scholar CAPTCHA-Risiko, Rate Limits>
+
+## Hinweise
+
+- Datenbankspezifische Besonderheiten (Advanced-Search-Pfad, Sprach-Toggle, Filter-Setup)
+- Was `browser-use` nicht aus der Seite selbst erraten kann
+- Bekannte Fallen (z. B. nicht ersten Link in Scholar-Ergebniszeile klicken, da Speichern/Zitieren-Buttons mitgezählt werden)
+```
+
+**Zielgrößen:**
+- No-Auth-Guides (scholar, destatis, oecd, springer, repec): 15-30 Zeilen
+- Auth-Guides (ebscohost, proquest, opac): 40-60 Zeilen
+- `han_login.md` bleibt als geteilte Login-Referenz, ebenfalls schlank neu (Navigationsflow + Credential-Quelle)
+
+**Alle Playwright-Artefakte raus:** CSS-Selektoren, `browser_snapshot`/`browser_evaluate`/`browser_navigate`/`browser_click`/`browser_type`/`browser_press_key`/`browser_wait_for`, JavaScript-Extraktionssnippets.
+
+## Block C — `document-skills:xlsx`-Integration
+
+### C.1 Löschungen und Umschreibung
+
+1. `scripts/excel.py` löschen (14.5 KB).
+2. `requirements.txt` — `openpyxl>=3.1.0` entfernen (wird vom Claude-Skill selbst mitgebracht).
+3. `commands/excel.md` komplett neu:
+   - **Input:** Pfad zu `.xlsx`/`.csv`/`.tsv` ODER strukturierte Paper-Daten aus Session-Dir (`ranked.json`, `papers.json`).
+   - **Flow:** Claude wendet den `document-skills:xlsx`-Skill auf die Eingabe an. Keine Python-Pipeline.
+   - **Output:** Excel-Datei im Session-Dir, Dateiname aus Argument oder Default.
+   - **Fallback:** Wenn xlsx-Skill nicht verfügbar → klare Fehlermeldung mit Install-Befehl abbrechen.
+
+### C.2 SessionStart-Hook-Erweiterung
+
+`hooks/hooks.json` erweitern. Bestehender Python-Venv-Check bleibt, ein zweiter Hook für xlsx-Verfügbarkeit wird ergänzt:
+
+```json
+{
+  "type": "command",
+  "command": "bash -c '[ -d \"$HOME/.claude/plugins/cache/anthropic-agent-skills/document-skills\" ] || echo \"⚠️  academic-research: document-skills nicht installiert — /academic-research:excel benötigt: /plugin install document-skills@anthropic-agent-skills\"'",
+  "timeout": 5
+}
+```
+
+Bewusst **stumm bei Erfolg**, um Noise zu vermeiden. Nur Warnung bei Fehlen.
+
+### C.3 `/setup`-Command
+
+`commands/setup.md` ergänzen um denselben Pfad-Check plus konkretem Install-Befehl in der Ausgabe (nicht nur Warnung).
+
+### C.4 README
+
+Neuer Prerequisites-Abschnitt:
+
+```markdown
+## Voraussetzungen
+
+- Python 3.10+
+- `browser-use`-CLI (`uv tool install browser-use`) + globaler Skill unter `~/.claude/skills/browser-use/`
+- `document-skills` Plugin (für `/academic-research:excel`):
+  /plugin install document-skills@anthropic-agent-skills
+```
+
+## Block D — Release
+
+### D.1 Version & Artefakte
+
+- `.claude-plugin/plugin.json`: `4.0.1` → `5.0.0`
+- `.claude-plugin/marketplace.json`: `4.0.1` → `5.0.0`
+- `CHANGELOG.md`: neuer `## [5.0.0]`-Block, Keep-a-Changelog-Format, mit expliziter **BREAKING**-Kennzeichnung aller betroffenen Stellen
+- Git-Tag `v5.0.0` erst nach Merge
+
+### D.2 Umbrella- und Ticket-Updates
+
+- Epic-Issue `#9` — Sub-Tickets `#19-#29` abhaken und schließen
+- Umbrella `#7` — E2-Checkbox setzen, E3 als "bereit zum Kickoff" markieren
+
+## Git-Plan — 11 Commits auf `refactor/e2-architecture`
+
+| # | Commit | Inhalt |
+|---|--------|--------|
+| 1 | `chore(scripts): delete citations.py, style_analysis.py, ranking.py + tests` | 3 Skripte + 3 Tests, kein Code-Call mehr |
+| 2 | `refactor(commands): wire score.md and search.md to relevance-scorer agent` | `commands/score.md`, `commands/search.md:86` |
+| 3 | `refactor(skills): remove deleted-script references` | citation-extraction, source-quality-audit, chapter-writer, style-evaluator SKILL.md |
+| 4 | `refactor: remove Playwright MCP, add browser-use permissions` | .mcp.json, configure_permissions.py, settings.json, setup.sh, .gitignore, commands/setup.md |
+| 5 | `refactor(search): migrate commands/search.md Step 4 to browser-use` | `commands/search.md` Browser-Search-Block |
+| 6 | `refactor(browser-guides): rewrite all 9 guides for browser-use` | alle 9 Dateien in `config/browser_guides/` |
+| 7 | `refactor(excel): replace scripts/excel.py with document-skills:xlsx` | `scripts/excel.py`-Löschung, `commands/excel.md`-Neufassung, requirements.txt schlanker |
+| 8 | `feat(hooks): warn on missing document-skills in SessionStart` | `hooks/hooks.json` |
+| 9 | `docs(readme): document browser-use + document-skills prerequisites` | `README.md`-Prerequisites, Skripte-Tabelle, Dateibaum |
+| 10 | `docs: add v5.0.0 changelog` | `CHANGELOG.md` |
+| 11 | `chore(release): v5.0.0` | `plugin.json`, `marketplace.json` |
+
+## Verifikation (vor Merge)
+
+- `rg "citations\.py|style_analysis\.py|ranking\.py|excel\.py"` — nur Treffer in `docs/superpowers/specs/` und `CHANGELOG.md` zulässig
+- `rg -i "playwright|mcp__playwright"` — nur Treffer in `docs/superpowers/specs/` und `CHANGELOG.md`
+- `rg "browser_snapshot|browser_evaluate|browser_navigate|browser_click|browser_type|browser_press_key|browser_wait_for"` — 0 Treffer
+- `rg "browser-use"` — Treffer in `commands/search.md`, `commands/setup.md`, `README.md`, `configure_permissions.py`, allen 9 Browser-Guides, `hooks/hooks.json` (falls referenziert), `CHANGELOG.md`
+- `/setup`-Command manuell durchlaufen, SessionStart-Hook-Warnung prüfen (mit und ohne installiertes document-skills)
+- `plugin-validator`-Agent auf den Branch ansetzen
+- Keine Tests schlagen fehl (die gelöschten Tests sind weg, die verbleibenden müssen weiter grün sein)
+
+## Rollback-Strategie
+
+- Major-Release → bei Problemen im Release pinnen User auf `v4.0.1`
+- Pre-Merge: `git revert` des PR-Merges oder Branch verwerfen
 
 ## Out-of-Scope
 
-- Inhaltliche Überarbeitung der Prompts → E3
-- Citations-API, Evals → E4
+- Inhaltliche Überarbeitung der Prompts → **E3**
+- Citations-API, Evals, Prompt Caching → **E4**
 - Neue Commands oder Skills
 
-## Offene Fragen für E2-Kickoff-Brainstorm
+## Entschieden im Brainstorm (Referenz)
 
-1. `scripts/pdf.py` — wirklich löschbar, oder braucht `quote-extractor` PDF-Preprocessing, das Read-Tool nicht leistet (OCR, Passwort-entsperrt, Encoding)?
-2. Wie soll `commands/search.md` bei Browser-Modulen mit `browser-use` konkret aussehen? Ein Prompt pro Datenbank oder ein generischer Prompt mit Parametern?
-3. SessionStart-Hook-Check auf externen Skill: welche API/welches Flag? Ggf. Klärung nötig in der Claude-Code-Doku.
-4. Config-Browser-Guides: komplett neu schreiben oder inkrementell? Migration pro Datenbank?
-
-## Git-Plan (grob, wird verfeinert)
-
-**Branch:** `refactor/e2-architecture` von `main` (nach E1-Merge)
-
-**Commits (grob gruppiert):**
-1. `chore(scripts): remove citations.py, style_analysis.py, ranking.py`
-2. `refactor(commands): update score and related commands to use agents`
-3. `refactor: remove Playwright MCP, migrate to browser-use`
-4. `refactor(excel): replace scripts/excel.py with document-skills:xlsx integration`
-5. `docs: update README for browser-use and document-skills requirements`
-6. `chore(release): v5.0.0`
-
-## Verifikation
-
-- Keine Verweise mehr auf gelöschte Skripte (`grep -r "citations\.py\|style_analysis\.py\|ranking\.py\|excel\.py"`)
-- Keine Verweise mehr auf Playwright (`grep -ri "playwright"`)
-- `/setup`-Command läuft sauber durch
-- `browser-use`-Skill wird für Browser-Datenbanken korrekt angesteuert
-- xlsx-Skill-Check in SessionStart-Hook funktioniert
-
-## Rollback
-
-Major-Release, deshalb Rollback = User muss zurück auf v4.0.1 pinnen. Pre-Merge: üblicher Branch-Revert-Pfad.
+1. **pdf.py bleibt** — 5-Tier-Download-Fallback, PyPDF2, TF-IDF sind Infrastruktur, kein LLM-Ersatz sinnvoll.
+2. **Ein generischer browser-use-Prompt in `search.md`** — Guides schrumpfen auf URL+Auth+Warnungen, keine Selektoren.
+3. **SessionStart-Pfad-Check auf `document-skills`** — stumm bei Erfolg, Warnung bei Fehlen; zusätzlich im `/setup`.
+4. **Alle 9 Browser-Guides in einem Commit neu** — einheitlicher Stil, YAGNI-radikale Verschlankung.


### PR DESCRIPTION
## Summary

Finalisiert den E2-Architektur-Spec nach dem Kickoff-Brainstorm.

**Entscheidungen aus dem Brainstorm:**
- `pdf.py` **bleibt** — Infrastruktur (5-Tier-Download, PyPDF2, TF-IDF), kein LLM-Ersatz sinnvoll
- **Ein generischer browser-use-Workflow** in `search.md`; Guides werden auf URL + Auth + Anti-Scraping verschlankt
- **SessionStart-Pfad-Check** auf `document-skills` (stumm bei Erfolg, Warnung bei Fehlen)
- **Alle 9 Browser-Guides in einem Commit** neu — einheitlicher, YAGNI-radikal verschlankter Stil

**11-Commit-Plan auf `refactor/e2-architecture`** (Details im Spec):
1. Skripte löschen (+ Tests)
2. `score.md`/`search.md` → Agent
3. Skill-References bereinigen
4. Playwright raus
5. `search.md` Schritt 4 → browser-use
6. Browser-Guides neu
7. excel.py → xlsx-Skill
8. SessionStart-Hook
9. README
10. CHANGELOG
11. Release v5.0.0

## Test plan

- [ ] Spec-Inhalt auf Vollständigkeit und Umsetzbarkeit prüfen
- [ ] Keine offenen Fragen mehr (alle 4 beantwortet)
- [ ] Git-Plan-Commits matchen die E2-Sub-Tickets (#19-#29)

Closes nichts (nur Spec-Finalisierung, Epic #9 bleibt offen bis Umsetzung).

🤖 Generated with [Claude Code](https://claude.com/claude-code)