### PR TITLE
feat(setup): complete installer with browser-use auto-install (v5.0.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "academic-research",
       "source": "./",
       "description": "Modulares akademisches Forschungs-Toolkit mit 13 selbstaktivierenden Skills, 5D-Scoring, Excel-Export und KI-Stil-Erkennung.",
-      "version": "5.0.0"
+      "version": "5.0.1"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "academic-research",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Modulares akademisches Forschungs-Toolkit mit 13 selbstaktivierenden Skills, 5D-Scoring, Excel-Export und KI-Stil-Erkennung. Durchsucht Semantic Scholar, CrossRef, OpenAlex, BASE, Google Scholar und weitere Quellen.",
   "author": {
     "name": "Jonas"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Alle bemerkenswerten Änderungen an diesem Plugin werden hier dokumentiert.
 
 Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Versionierung nach [Semantic Versioning](https://semver.org/lang/de/).
 
+## [5.0.1] — 2026-04-23
+
+### Changed
+
+- `scripts/setup.sh` zu einem vollständigen Installer ausgebaut. `browser-use` CLI wird jetzt automatisch via `uv` oder `pipx` installiert (falls eines der beiden verfügbar ist) statt nur geprüft zu werden. Zusätzliche Status-Checks für den globalen `browser-use`-Claude-Skill und das `document-skills`-Plugin mit konkreten Install-Hinweisen bei Fehlen.
+- `commands/setup.md` ruft jetzt zentral `scripts/setup.sh` auf, statt die einzelnen Schritte inline zu duplizieren. Dokumentiert Ausgabe-Interpretation und Verhalten bei fehlenden Komponenten.
+
 ## [5.0.0] — 2026-04-23
 
 > **⚠️ BREAKING:** User müssen Playwright-Konfiguration entfernen und `browser-use`-CLI plus `document-skills` Plugin installieren. Siehe README Prerequisites.

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -1,68 +1,50 @@
 ---
-description: Set up Python environment for academic research plugin v5
+description: Set up the academic research plugin (Python env, browser-use CLI, document-skills check, permissions)
 disable-model-invocation: true
-allowed-tools: Bash(python3 *), Bash(mkdir *), Bash(~/.academic-research/venv/bin/pip *)
+allowed-tools: Bash(bash *), Bash(python3 *)
 ---
 
 # Academic Research v5 Setup
 
-Set up the Python environment required by the academic research plugin.
+Vollständiges Setup über das zentrale Installationsskript. Ein Aufruf, alle Abhängigkeiten, klare Statusmeldungen.
 
-## Steps
+## Ausführung
 
-1. Create the data directory:
 ```bash
-mkdir -p ~/.academic-research/{sessions,pdfs}
+bash ${CLAUDE_PLUGIN_ROOT}/scripts/setup.sh
 ```
 
-2. Create Python virtual environment:
-```bash
-python3 -m venv ~/.academic-research/venv
-```
+Das Skript übernimmt in sechs Schritten:
 
-3. Install dependencies:
-```bash
-~/.academic-research/venv/bin/pip install -r ${CLAUDE_PLUGIN_ROOT}/scripts/requirements.txt
-```
+1. Legt `~/.academic-research/{sessions,pdfs,venv}` an.
+2. Erstellt die Python-venv und installiert `httpx`, `PyPDF2`, `pyyaml` (aus `scripts/requirements.txt`).
+3. Prüft, ob `browser-use` CLI vorhanden ist. Falls nicht: installiert automatisch via `uv tool install` oder `pipx install`, sofern eines der beiden Tools vorhanden ist. Führt anschließend `browser-use doctor` aus.
+4. Prüft, ob der globale `browser-use` Claude-Skill unter `~/.claude/skills/browser-use/` liegt.
+5. Prüft, ob das `document-skills` Plugin im Plugin-Cache vorhanden ist. Falls nicht: zeigt den exakten `/plugin install`-Befehl an — dieser Schritt ist **nicht automatisierbar**, da Plugins in Claude Code keine anderen Plugins auto-installieren dürfen.
+6. Schreibt die Claude-Code-Permissions über `scripts/configure_permissions.py`.
 
-4. Verify installation:
-```bash
-~/.academic-research/venv/bin/python -c "import httpx; print('✅ httpx:', httpx.__version__)"
-~/.academic-research/venv/bin/python -c "import PyPDF2; print('✅ PyPDF2:', PyPDF2.__version__)"
-~/.academic-research/venv/bin/python -c "import yaml; print('✅ pyyaml:', yaml.__version__)"
-```
+## Interpretation der Ausgabe
 
-5. Install `browser-use` CLI (required for browser search modules):
-```bash
-uv tool install browser-use   # oder: pipx install browser-use
-browser-use doctor
-```
-Wenn `browser-use` nicht installiert ist, funktionieren API-Module weiter, aber keine Browser-Datenbanken (Google Scholar, Springer, OECD, RePEc, OPAC, EBSCO, ProQuest).
+| Marker | Bedeutung |
+|--------|-----------|
+| ✅ Python environment: ready | venv + requirements.txt erfolgreich installiert |
+| ✅ browser-use CLI: ready | CLI vorhanden und `browser-use doctor` meldet keinen Fehler |
+| ✅ browser-use Claude-Skill: vorhanden | Skill unter `~/.claude/skills/browser-use/` |
+| ✅ document-skills Plugin: vorhanden | Plugin-Cache-Pfad existiert |
+| ⚠️ … | siehe Hinweistext direkt unter dem Marker |
 
-6. Configure Claude Code permissions:
-```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/configure_permissions.py
-```
+## Was passiert, wenn etwas fehlt
 
-7. Show result:
-```
-✅ Setup complete!
+- **Ohne `browser-use` CLI:** API-basierte Suchmodule (CrossRef, OpenAlex, Semantic Scholar, BASE, EconBiz, EconStor, arXiv) laufen weiter. Browser-basierte Suchmodule (Scholar, Springer, OECD, RePEc, OPAC, EBSCOhost, ProQuest) werden übersprungen.
+- **Ohne `browser-use` Claude-Skill:** Claude fällt bei Browser-Aufrufen auf direkte CLI-Kommandos zurück (funktional identisch, nur ohne den Skill-Wrapper mit seinen best-practice-Hinweisen).
+- **Ohne `document-skills` Plugin:** `/academic-research:excel` bricht mit klarer Fehlermeldung und Install-Befehl ab.
 
-Environment: ~/.academic-research/venv/
-Data dir:    ~/.academic-research/
+## Erneutes Ausführen
 
-Available commands:
+Das Skript ist idempotent. Ein zweiter Aufruf:
 
-  /academic-research:search "query"  — Search academic papers
-  /academic-research:score           — Score and rank literature
-  /academic-research:excel           — Generate literature Excel
-
-Skills (auto-activate in conversation):
-
-  Academic Context, Advisor, Chapter Writer, Style Evaluator,
-  Title Generator, Citation Extraction, Plagiarism Check,
-  Methodology Advisor, Submission Checker, Literature Gap Analysis,
-  Abstract Generator, Source Quality Audit, Research Question Refiner
-```
-
-If any step fails, show the error and suggest fixes.
+- erstellt kein zweites venv, installiert nur fehlende Packages
+- überspringt `browser-use` CLI-Install, wenn bereits installiert
+- wiederholt `browser-use doctor` (harmlos, aktualisiert den Status)
+- überschreibt keine Seed-Dateien
+- fügt Permissions nur hinzu, wenn sie noch nicht in `~/.claude/settings.local.json` stehen

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,33 +1,111 @@
 #!/bin/bash
-# Creates ~/.academic-research directory structure and Python venv
+# academic-research v5 — vollständiger Installer
+#
+# Führt alle Installationen aus, die automatisierbar sind:
+#   1. Datenverzeichnis + Python venv
+#   2. Python-Pakete aus requirements.txt
+#   3. browser-use CLI (via uv oder pipx)
+#   4. Check: globaler browser-use Claude-Skill
+#   5. Check: document-skills Plugin (Install-Befehl bei Fehlen)
+#   6. Claude-Code-Permissions via configure_permissions.py
 
 set -e
 
 BASE="$HOME/.academic-research"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-mkdir -p "$BASE/sessions"
-mkdir -p "$BASE/pdfs"
+# ---------------------------------------------------------------------------
+# 1. Datenverzeichnis + Python venv
+# ---------------------------------------------------------------------------
+
+mkdir -p "$BASE/sessions" "$BASE/pdfs"
 
 if [ ! -d "$BASE/venv" ]; then
   python3 -m venv "$BASE/venv"
 fi
 
-"$BASE/venv/bin/pip" install --quiet --upgrade pip
-"$BASE/venv/bin/pip" install --quiet -r "$(dirname "$0")/requirements.txt"
+# ---------------------------------------------------------------------------
+# 2. Python-Pakete
+# ---------------------------------------------------------------------------
 
-# Create empty files if they don't exist
+"$BASE/venv/bin/pip" install --quiet --upgrade pip
+"$BASE/venv/bin/pip" install --quiet -r "$SCRIPT_DIR/requirements.txt"
+
+# Leere Seed-Dateien
 touch "$BASE/citations.bib"
-[ -f "$BASE/annotations.json" ] || echo '{}' > "$BASE/annotations.json"
-[ -f "$BASE/fulltext_index.json" ] || echo '{"index":{},"docs":{}}' > "$BASE/fulltext_index.json"
-[ -f "$BASE/sessions/index.json" ] || echo '[]' > "$BASE/sessions/index.json"
+[ -f "$BASE/annotations.json" ]      || echo '{}' > "$BASE/annotations.json"
+[ -f "$BASE/fulltext_index.json" ]   || echo '{"index":{},"docs":{}}' > "$BASE/fulltext_index.json"
+[ -f "$BASE/sessions/index.json" ]   || echo '[]' > "$BASE/sessions/index.json"
 
 echo "✅ Python environment: ready"
+echo ""
 
-if command -v browser-use &>/dev/null; then
-  browser-use doctor &>/dev/null && echo "✅ browser-use: ready" || echo "⚠️  browser-use: install ok, but doctor meldet Probleme — bitte 'browser-use doctor' manuell prüfen"
-else
-  echo "⚠️  browser-use nicht gefunden — Browser-Module (Scholar, EBSCO, …) werden nicht funktionieren. Install: 'uv tool install browser-use' oder 'pipx install browser-use'"
+# ---------------------------------------------------------------------------
+# 3. browser-use CLI
+# ---------------------------------------------------------------------------
+
+if ! command -v browser-use &>/dev/null; then
+  echo "📦  browser-use CLI nicht gefunden — versuche Auto-Install…"
+  if command -v uv &>/dev/null; then
+    uv tool install browser-use && echo "   ↳ installiert via uv"
+  elif command -v pipx &>/dev/null; then
+    pipx install browser-use && echo "   ↳ installiert via pipx"
+  else
+    echo "⚠️  Weder 'uv' noch 'pipx' verfügbar — browser-use konnte nicht automatisch installiert werden."
+    echo "   Install-Optionen (manuell):"
+    echo "     • brew install pipx && pipx install browser-use"
+    echo "     • curl -LsSf https://astral.sh/uv/install.sh | sh && uv tool install browser-use"
+  fi
 fi
+
+# Re-check nach möglicher Installation + doctor
+if command -v browser-use &>/dev/null; then
+  if browser-use doctor &>/dev/null; then
+    echo "✅ browser-use CLI: ready"
+  else
+    echo "⚠️  browser-use CLI installiert, aber 'browser-use doctor' meldet Probleme."
+    echo "   Manuell prüfen: browser-use doctor"
+  fi
+else
+  echo "⚠️  browser-use CLI nicht installiert — Browser-Suchmodule (Scholar, EBSCO, …) werden übersprungen."
+fi
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# 4. browser-use Claude-Skill (global)
+# ---------------------------------------------------------------------------
+
+if [ -d "$HOME/.claude/skills/browser-use" ]; then
+  echo "✅ browser-use Claude-Skill: vorhanden (~/.claude/skills/browser-use/)"
+else
+  echo "⚠️  browser-use Claude-Skill unter ~/.claude/skills/browser-use/ fehlt."
+  echo "   Der Skill wird separat von Anthropic bereitgestellt (nicht Teil dieses Plugins)."
+  echo "   Wenn der Skill fehlt, greift Claude bei Browser-Aufrufen auf die CLI ohne Wrapper zurück."
+fi
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# 5. document-skills Plugin (für /academic-research:excel)
+# ---------------------------------------------------------------------------
+
+if [ -d "$HOME/.claude/plugins/cache/anthropic-agent-skills/document-skills" ]; then
+  echo "✅ document-skills Plugin: vorhanden"
+else
+  echo "⚠️  document-skills Plugin fehlt — /academic-research:excel wird ohne es abbrechen."
+  echo "   In Claude Code ausführen:"
+  echo "     /plugin install document-skills@anthropic-agent-skills"
+  echo "   (Plugin-zu-Plugin-Auto-Install wird von Claude Code nicht unterstützt.)"
+fi
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# 6. Claude-Code-Permissions
+# ---------------------------------------------------------------------------
+
+python3 "$SCRIPT_DIR/configure_permissions.py"
 
 echo ""
 echo "Setup complete: $BASE"


### PR DESCRIPTION
## Summary

Schließt eine Lücke aus E2: `/setup` prüfte bisher nur externe Abhängigkeiten, ohne sie zu installieren. Der vollständige Installer fehlte.

**Jetzt automatisch:**
- `browser-use` CLI-Install via `uv tool install` oder `pipx install` (je nachdem was vorhanden ist)
- `browser-use doctor`-Check nach Installation
- Statusmeldung für `~/.claude/skills/browser-use/` (globaler Claude-Skill)
- Statusmeldung für `document-skills`-Plugin mit exaktem `/plugin install`-Befehl bei Fehlen

**Bleibt manuell** (aus gutem Grund):
- `/plugin install document-skills@anthropic-agent-skills` — Plugin-zu-Plugin-Auto-Install ist in Claude Code architektonisch nicht erlaubt. Der Befehl wird exakt ausgegeben.

## Files

- `scripts/setup.sh` — vollständiger Installer, idempotent
- `commands/setup.md` — delegiert an setup.sh, dokumentiert Ausgabe-Interpretation
- `CHANGELOG.md` — neuer v5.0.1-Block
- `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` — Version 5.0.0 → 5.0.1

## Test plan

- [x] `bash -n scripts/setup.sh` — Syntax ok
- [x] Externe Checks simuliert auf Dev-Maschine: browser-use CLI, uv, browser-use-Skill, document-skills — alle `✅`
- [ ] `/setup` im Claude Code aufrufen und Ausgabe prüfen
- [ ] Zweiter Aufruf: idempotent (keine duplizierten Permissions, venv wird nicht neu erzeugt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)