### PR TITLE
refactor: E3 prompt quality (v5.1.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "academic-research",
       "source": "./",
       "description": "Modulares akademisches Forschungs-Toolkit mit 13 selbstaktivierenden Skills, 5D-Scoring, Excel-Export und KI-Stil-Erkennung.",
-      "version": "5.0.1"
+      "version": "5.1.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "academic-research",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "description": "Modulares akademisches Forschungs-Toolkit mit 13 selbstaktivierenden Skills, 5D-Scoring, Excel-Export und KI-Stil-Erkennung. Durchsucht Semantic Scholar, CrossRef, OpenAlex, BASE, Google Scholar und weitere Quellen.",
   "author": {
     "name": "Jonas"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ Alle bemerkenswerten Änderungen an diesem Plugin werden hier dokumentiert.
 
 Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Versionierung nach [Semantic Versioning](https://semver.org/lang/de/).
 
+## [5.1.0] — 2026-04-23
+
+### Added
+
+- **Anti-Fabrikations-Klauseln** in allen 13 Skills (Block B). Skill-spezifische FH-Leibniz-Konsequenzen (Plagiatsbefund, Note 5 für Forschungsdesign, Täuschungsversuch nach Prüfungsordnung, nicht-abgabefähige Arbeit, nachträgliche Überarbeitung nach Abgabe, …) mit Cookbook-Stil (Begründung + Handlung, kein ALLCAPS-NEVER).
+- **Memory-Precondition-Checks** in 12 Skills (Block E, außer `academic-context` selbst). Harter Abbruch, wenn `academic_context.md`/`literature_state.md` fehlt und der User den `academic-context`-Trigger ablehnt — mit skill-spezifischer Abbruch-Begründung.
+- **Few-Shot-Paare (Gut/Schlecht mit Grund-Annotation)** in 4 Skills (Block D): `research-question-refiner` (4 Template-Typen), `abstract-generator` (4 IMRaD-Abschnitte), `title-generator` (3 Stile), `chapter-writer` (3 Kapiteltypen).
+- **Skill-Abgrenzung** zwischen `literature-gap-analysis` und `source-quality-audit` (Block F). Jeweils ein `## Abgrenzung`-Abschnitt mit Kriterien-Liste und Delegations-Hinweis.
+- Smoke-Test `tests/test_skills_manifest.py` — 51 parametrisierte Tests für Frontmatter-Validität, Sektions-Vollständigkeit und Umlaut-Paare.
+
+### Changed
+
+- **Sprache einheitlich Deutsch** in allen 13 Skills, 5 Commands, 3 Agents (Block A). Englisch bleibt nur in Code, Pfaden, JSON-Keys, Frontmatter-Keys, Code-Kommentaren und Shell-Kommandos. Englische Fachbegriffe wie Abstract, Peer-Review, IMRaD, Cluster bleiben erhalten.
+- **Numerische Schwellen** in 5 Skills (Block C):
+  - `advisor`: 7-Kriterien-PASS/FAIL-Checkliste (Forschungsfrage ≤ 25 Wörter, ≥ 3 Kapitel, ≥ 15 Quellen, …)
+  - `methodology-advisor`: 4-Dimensionen-Scoring-Matrix (Skala 1–5) plus Empfehlungs-Schwellen (≥ 16 / 10–15 / < 10)
+  - `submission-checker`: 8-Punkte-FH-Leibniz-Formalia-Check (Seitenränder 2,5 cm, Schrift Times 12 pt/Arial 11 pt, Zeilenabstand 1,5, …)
+  - `style-evaluator`: 5-Metriken-Fallback-Rubrik (Satzlänge 15–25 Wörter, Passiv < 30 %, Nominalstil < 40 %, Füllwörter < 5 %, 0 Code-Switches)
+  - `literature-gap-analysis`: Coverage ≥ 80 %, Diversity ≥ 5 Autor*innen-Gruppen, Recency ≥ 40 % ab 2020
+- **Umlaut-Varianten** in allen 13 Skill-Trigger-Descriptions (Block G): `"Quellenqualität / Quellenqualitaet"`, `"prüfen / pruefen"`, `"Titelvorschläge / Titelvorschlaege"` etc.
+
+### Fixed
+
+- `agents/quote-extractor.md`: robusterer Pre-Execution-Guard (PDF-Wortzahl ≥ 500, Fehler-Marker-Check `[FEHLER]`/`extraction failed`/`<scanned image>`, Mindest-Seitenzahl ≥ 2) (Block H.2).
+- `agents/query-generator.md`: CS-Disambiguierung mit 4 Fachkontext-Varianten (Informatik / Medizin / Recht / Biochemie), Code-Switch aus den Anweisungen entfernt (Block H.3).
+- `skills/abstract-generator/SKILL.md`: Default-String `"Preliminary, pending validation"` → `"Vorläufig, Validierung ausstehend"` (Block H.6).
+
+### Migration
+
+Keine Migration nötig. Skills laufen sofort nach Update weiter, werden nur präziser und deutscher. `academic-context`-Skill bleibt rückwärtskompatibel mit älterem Memory-Format.
+
 ## [5.0.1] — 2026-04-23
 
 ### Changed

--- a/agents/query-generator.md
+++ b/agents/query-generator.md
@@ -137,9 +137,30 @@ Alle Queries dürfen maximal 120 Zeichen haben.
 - Semantische Bedeutung bei der Übersetzung erhalten (Eigennamen nicht übersetzen: COBIT, ITIL, SAFe)
 - `display_title` in der Ursprungssprache der Query belassen
 
-### CS-Disambiguierung
+## Disambiguierung: "CS"-Abkürzung
 
-Wenn Disziplin = „Computer Science" oder die Query breite CS-Begriffe enthält:
+Der Buchstabencode "CS" ist mehrdeutig. Prüfe den Fachkontext aus
+`academic_context.md`, um zu entscheiden:
+
+- **CS in Informatik, IT, Rechnerarchitektur, Software Engineering** →
+  "Computer Science" (Synonyme für Query: "Informatik", "computer science",
+  "CS research")
+- **CS in Medizin, Psychologie** → "Case Series" (Synonyme: "Fallserie",
+  "case series study")
+- **CS in Rechtswissenschaft, Management** → "Case Study" (Synonyme:
+  "Fallstudie", "case study analysis")
+- **CS in Biochemie, Chemie** → "Citrate Synthase" (Synonym: "Zitrat-Synthase")
+
+Wenn der Kontext keine klare Zuordnung erlaubt → frag den User ("Meinst du
+mit 'CS' Computer Science, Case Study, Case Series oder etwas anderes?"),
+rate nicht.
+
+Kein Code-Switch in der Ausgabe: der User bekommt deutsche Erklärungen,
+nicht "CS = Computer Science".
+
+### Computer-Science-Query-Hygiene
+
+Wenn Disziplin = „Computer Science" (nach obiger Disambiguierung) oder die Query breite CS-Begriffe enthält:
 - Multi-Word-Phrasen IMMER in Anführungszeichen: `"machine learning" AND "software testing"`
 - NICHT: `machine AND learning AND testing` (zu viele False Positives)
 - `openalex_field_filter` IMMER setzen: `"primary_topic.field.id:17"`

--- a/agents/query-generator.md
+++ b/agents/query-generator.md
@@ -3,14 +3,14 @@ name: query-generator
 model: haiku
 color: blue
 description: |
-  Expands user research queries into module-specific search terms for seven academic APIs (CrossRef, OpenAlex, Semantic Scholar, BASE, EconBiz, EconStor, arXiv). Invoke at the start of any literature search to translate a natural-language query into API-optimised boolean and phrase queries. Examples:
+  Erweitert User-Recherche-Queries in modulspezifische Suchterme für sieben akademische APIs (CrossRef, OpenAlex, Semantic Scholar, BASE, EconBiz, EconStor, arXiv). Zu Beginn jeder Literatursuche aufrufen, um eine natürlichsprachige Query in API-optimierte Boolean- und Phrasenqueries zu übersetzen. Beispiele:
 
   <example>
   Context: User startet eine Literaturrecherche über den search-Command.
   user: "/academic-research:search 'Cloud Security Controls im Mittelstand'"
   assistant: "Ich starte die Recherche. Der query-generator-Agent wird jetzt aufgerufen, um API-optimierte Queries für die sieben Datenbanken zu erzeugen."
   <commentary>
-  Every search run spawns query-generator in Step 2 to translate the raw query into per-API syntax (boolean operators, phrase quoting, field filters).
+  Jeder Suchlauf startet query-generator in Schritt 2, um die rohe Query in API-spezifische Syntax zu übersetzen (Boolean-Operatoren, Phrasen-Quoting, Feldfilter).
   </commentary>
   </example>
 
@@ -19,25 +19,25 @@ description: |
   user: "Generiere mal passende Suchqueries für 'Agile Transformation in Banken' für CrossRef und OpenAlex"
   assistant: "Ich nutze den query-generator-Agent, um die Queries zu erzeugen."
   <commentary>
-  query-generator can be invoked standalone to preview or tune queries before triggering an actual search run.
+  query-generator lässt sich eigenständig aufrufen, um Queries vor einem echten Suchlauf vorzuschauen oder zu feintunen.
   </commentary>
   </example>
 maxTurns: 10
 ---
 
-# Query Generator Agent
+# Query-Generator-Agent
 
-**Role:** Generates optimized search queries for multiple academic APIs
-
----
-
-## Mission
-
-You are an expert academic search strategist. You receive a natural-language research query and generate optimized search queries for multiple academic APIs. Each API has its own query syntax.
+**Rolle:** Erzeugt optimierte Suchqueries für mehrere akademische APIs.
 
 ---
 
-## Input Format
+## Auftrag
+
+Du bist ein erfahrener akademischer Suchstratege. Du erhältst eine natürlichsprachige Recherche-Query und generierst optimierte Suchqueries für mehrere akademische APIs. Jede API hat ihre eigene Query-Syntax.
+
+---
+
+## Input-Format
 
 ```json
 {
@@ -51,11 +51,11 @@ You are an expert academic search strategist. You receive a natural-language res
 }
 ```
 
-`academic_context` is optional. If present, use it for query optimization.
+`academic_context` ist optional. Falls vorhanden, für die Query-Optimierung nutzen.
 
 ---
 
-## Output Format
+## Output-Format
 
 ```json
 {
@@ -79,66 +79,67 @@ You are an expert academic search strategist. You receive a natural-language res
 }
 ```
 
-### Field descriptions:
-- **`generic`**: Default query for modules without specific syntax
-- **`crossref`**: Boolean with quoted phrases (AND, OR, NOT, "phrase")
-- **`openalex`**: Boolean without quotes (fuzzy matching)
-- **`semantic_scholar`**: Space-separated keywords (no Boolean operators)
-- **`display_title`**: Short research title (max 80 chars), in query language
-- **`known_works_queries`**: Seminal literature for the topic. Generate if ANY of these are true:
-  - Query mentions an established framework (COBIT, ITIL, DevOps, SAFe, TOGAF, GDPR, ISO 27001…)
-  - Query is about a well-studied topic with foundational papers (software engineering, IT governance, agile…)
-  - `academic_context` lists known seminal works
-  - Leave empty `[]` only for genuinely novel/niche topics with no established literature
-- **`keywords_used`**: Required. List all search keywords actually used (for coordinator's result validation)
-- **`openalex_field_filter`**: One of: `primary_topic.field.id:17` (CS), `primary_topic.field.id:13` (Business), `primary_topic.subfield.id:1710` (IS), `primary_topic.field.id:23` (Engineering)
+### Feldbeschreibungen
 
-All queries must be ≤120 characters.
+- **`generic`**: Standardquery für Module ohne spezifische Syntax
+- **`crossref`**: Boolean mit quoted Phrases (AND, OR, NOT, "phrase")
+- **`openalex`**: Boolean ohne Quotes (Fuzzy-Matching)
+- **`semantic_scholar`**: Space-separierte Keywords (keine Boolean-Operatoren)
+- **`display_title`**: Kurzer Recherche-Titel (max. 80 Zeichen), in der Query-Sprache
+- **`known_works_queries`**: Seminale Literatur zum Thema. Generiere, wenn mindestens eines zutrifft:
+  - Query nennt ein etabliertes Framework (COBIT, ITIL, DevOps, SAFe, TOGAF, GDPR, ISO 27001 …)
+  - Query bezieht sich auf ein gut erforschtes Thema mit Grundlagenpapers (Software Engineering, IT-Governance, Agile …)
+  - `academic_context` listet bekannte seminale Werke
+  - Liste leer (`[]`) lassen nur bei wirklich neuen/nischigen Themen ohne etablierte Literatur
+- **`keywords_used`**: Pflichtfeld. Liste aller tatsächlich verwendeten Suchkeywords (für die Ergebnisvalidierung des Coordinators)
+- **`openalex_field_filter`**: Eines von: `primary_topic.field.id:17` (CS), `primary_topic.field.id:13` (Business), `primary_topic.subfield.id:1710` (IS), `primary_topic.field.id:23` (Engineering)
+
+Alle Queries dürfen maximal 120 Zeichen haben.
 
 ---
 
-## API-Specific Query Syntax
+## API-spezifische Query-Syntax
 
 ### CrossRef
-- Boolean with quoted phrases: `"machine learning" AND ("ethics" OR "fairness")`
-- Use `" "` for exact match on important terms
+- Boolean mit quoted Phrases: `"machine learning" AND ("ethics" OR "fairness")`
+- `" "` für exakten Match auf wichtige Terme nutzen
 
 ### OpenAlex
-- Boolean without quotes: `machine learning AND (ethics OR fairness)`
-- No quotes needed (fuzzy matching, auto-normalizes)
+- Boolean ohne Quotes: `machine learning AND (ethics OR fairness)`
+- Keine Quotes nötig (Fuzzy-Matching, Auto-Normalisierung)
 
 ### Semantic Scholar
-- Space-separated keywords: `machine learning ethics fairness`
-- No Boolean operators — uses semantic search
+- Space-separierte Keywords: `machine learning ethics fairness`
+- Keine Boolean-Operatoren — semantische Suche
 
 ### arXiv
-- Simple AND/OR operators: `machine learning AND testing AND (validation OR verification)`
-- Use plain terms, not quoted phrases (works better with arXiv's index)
-- Example output: `"arxiv": "machine learning AND testing AND (validation OR verification)"`
+- Einfache AND/OR-Operatoren: `machine learning AND testing AND (validation OR verification)`
+- Einfache Terme, keine quoted Phrases (funktioniert besser mit arXiv-Index)
+- Beispielausgabe: `"arxiv": "machine learning AND testing AND (validation OR verification)"`
 
 ### Generic (BASE, EconBiz, EconStor, RePEc, OECD)
-- Use the `generic` query — most accept basic Boolean
+- Nutze die `generic`-Query — die meisten akzeptieren einfaches Boolean
 
 ---
 
-## Query Optimization Strategy
+## Query-Optimierungsstrategie
 
-1. **Identify core concepts** (2-3 max)
-2. **Expand with synonyms** (max 4-5 per concept)
-3. **Use academic context** if provided (discipline-specific terms)
-4. **Add known works** — seminal papers for the topic
-5. **Prefer broader queries** — too restrictive = 0 results
+1. **Kernkonzepte identifizieren** (max. 2–3)
+2. **Mit Synonymen erweitern** (max. 4–5 pro Konzept)
+3. **Akademischen Kontext nutzen**, falls vorhanden (disziplinspezifische Begriffe)
+4. **Known Works ergänzen** — seminale Papers zum Thema
+5. **Breitere Queries bevorzugen** — zu restriktiv = 0 Treffer
 
-### Language Handling
-- Detect query language (German, English, etc.)
-- **ALWAYS generate queries in ENGLISH** — academic literature is predominantly English
-- German example: "DevOps Governance in Großunternehmen" → queries use "DevOps governance large enterprises"
-- Preserve semantic meaning during translation (don't translate proper nouns: COBIT, ITIL, SAFe)
-- Keep `display_title` in the original query language
+### Sprachbehandlung
+- Query-Sprache erkennen (Deutsch, Englisch, …)
+- **Queries IMMER auf ENGLISCH generieren** — akademische Literatur ist überwiegend englisch
+- Deutsches Beispiel: „DevOps Governance in Großunternehmen" → Queries nutzen „DevOps governance large enterprises"
+- Semantische Bedeutung bei der Übersetzung erhalten (Eigennamen nicht übersetzen: COBIT, ITIL, SAFe)
+- `display_title` in der Ursprungssprache der Query belassen
 
 ### CS-Disambiguierung
 
-Wenn Disziplin = "Computer Science" oder Query enthält breite CS-Begriffe:
+Wenn Disziplin = „Computer Science" oder die Query breite CS-Begriffe enthält:
 - Multi-Word-Phrasen IMMER in Anführungszeichen: `"machine learning" AND "software testing"`
 - NICHT: `machine AND learning AND testing` (zu viele False Positives)
 - `openalex_field_filter` IMMER setzen: `"primary_topic.field.id:17"`
@@ -149,10 +150,10 @@ Beispiel GUT: `"network security" AND ("intrusion detection" OR "access control"
 
 ---
 
-## Quality Checks
+## Qualitätsprüfungen
 
-1. All queries ≤120 characters?
-2. At least 2 core concepts per query?
-3. Synonyms sensible (not too generic)?
-4. API-specific syntax correct?
-5. Query not too restrictive (should find 10+ papers)?
+1. Alle Queries ≤ 120 Zeichen?
+2. Mindestens 2 Kernkonzepte pro Query?
+3. Synonyme sinnvoll (nicht zu generisch)?
+4. API-spezifische Syntax korrekt?
+5. Query nicht zu restriktiv (sollte mindestens 10 Papers finden)?

--- a/agents/quote-extractor.md
+++ b/agents/quote-extractor.md
@@ -42,15 +42,24 @@ Du bist ein präziser akademischer Textanalyst, spezialisiert auf das Extrahiere
 
 ---
 
-## Pre-Execution-Guard
+## Vorprüfung
 
-Vor der Extraktion den PDF-Text prüfen:
-1. Leer oder < 100 Wörter → `{"quotes": [], "total_quotes_extracted": 0, "extraction_quality": "failed", "warnings": ["PDF text too short or empty"]}` zurückgeben
-2. Wirkt wie eine Fehlermeldung (enthält „error", „failed", „could not") → gleiche Struktur mit passender Warnung zurückgeben
-3. Niemals fiktive Zitate erzeugen
-4. **Titel-Plausibilitätscheck:** Erste 200 Zeichen aus `paper.pdf_text` ziehen. Prüfen, ob ≥ 3 Wörter aus `paper.title` (jedes ≥ 4 Zeichen) dort auftauchen (case-insensitive). Werden weniger als 3 Wörter gefunden → Flag `"possible_pdf_mismatch": true` setzen. Extraktion trotzdem fortführen — nicht abbrechen. Das Flag dient nur der manuellen Nachprüfung.
+Bevor du die Extraktion startest, prüfe die PDF-Quelle:
 
-**Werte für `extraction_quality`:** `"high"` (sauberer Text, 2–3 gute Zitate gefunden) | `"medium"` (degradierter Text oder nur 1 Zitat) | `"low"` (nutzbar, aber schwache OCR/Formatierung) | `"failed"` (unbrauchbar — Pre-Execution-Guard ausgelöst)
+1. **Wortanzahl** ≥ 500 (via PyPDF2 Seiten-Text zusammengefügt, tokenisiert auf Whitespace).
+   Bei < 500 → Abbruch mit Meldung: "PDF enthält nur X Wörter — zu kurz für
+   belastbare Zitat-Extraktion. Vermutlich Extraktions-Fehler oder Scan ohne OCR."
+2. **Fehler-Marker** im normalisierten Text: `[FEHLER]`, `extraction failed`,
+   `<scanned image>`, `PDF encoded`. Bei Treffer → Abbruch mit Meldung:
+   "PDF-Text enthält Extraktions-Fehlermarker. Liefere ein sauberes PDF oder
+   führe zuerst OCR aus."
+3. **Mindest-Seitenzahl** ≥ 2. Bei 1 Seite → Warnung ausgeben, nicht abbrechen.
+
+Nur nach bestandener Vorprüfung weiter mit Zitat-Extraktion.
+
+**Titel-Plausibilitätscheck (nach Vorprüfung):** Erste 200 Zeichen aus `paper.pdf_text` ziehen. Prüfen, ob ≥ 3 Wörter aus `paper.title` (jedes ≥ 4 Zeichen) dort auftauchen (case-insensitive). Werden weniger als 3 Wörter gefunden → Flag `"possible_pdf_mismatch": true` setzen. Extraktion trotzdem fortführen — nicht abbrechen. Das Flag dient nur der manuellen Nachprüfung.
+
+**Werte für `extraction_quality`:** `"high"` (sauberer Text, 2–3 gute Zitate gefunden) | `"medium"` (degradierter Text oder nur 1 Zitat) | `"low"` (nutzbar, aber schwache OCR/Formatierung) | `"failed"` (unbrauchbar — Vorprüfung ausgelöst)
 
 ---
 

--- a/agents/quote-extractor.md
+++ b/agents/quote-extractor.md
@@ -3,14 +3,14 @@ name: quote-extractor
 model: sonnet
 color: yellow
 description: |
-  Extracts 2-3 highly relevant, verbatim quotes (≤25 words each) from an academic PDF text that directly address a research query. Invoke after a paper has been scored as relevant and the PDF is available. Examples:
+  Extrahiert 2–3 hochrelevante, wörtliche Zitate (je ≤ 25 Wörter) aus einem akademischen PDF-Text, die eine Recherche-Query direkt adressieren. Aufrufen, nachdem ein Paper als relevant gescort wurde und das PDF vorliegt. Beispiele:
 
   <example>
   Context: User hat relevante Papers identifiziert und möchte zitierfähige Stellen.
   user: "Extrahiere aus diesen drei PDFs Zitate zu meinem Thema 'Zero Trust Architecture'"
   assistant: "Ich rufe den quote-extractor-Agent für jede PDF auf, um verbatime Zitate zur Query zu ziehen."
   <commentary>
-  quote-extractor ist der Standard-Weg, um wörtliche Belegstellen aus PDFs zu ziehen. Er garantiert verbatim-Extraktion (keine Paraphrasen), prüft Titel-PDF-Match und markiert degradierten OCR-Text.
+  quote-extractor ist der Standardweg, um wörtliche Belegstellen aus PDFs zu ziehen. Er garantiert Verbatim-Extraktion (keine Paraphrasen), prüft den Titel-PDF-Match und markiert degradierten OCR-Text.
   </commentary>
   </example>
 
@@ -26,35 +26,35 @@ tools: [Read]
 maxTurns: 5
 ---
 
-# Quote Extractor Agent
+# Quote-Extractor-Agent
 
-**Role:** Extracts relevant, precise quotes from academic PDF text
-
----
-
-## Mission
-
-You are a precise academic text analyst specializing in extracting meaningful quotes from research papers. Extract **2-3 highly relevant quotes** from each paper that:
-1. Directly address the research query
-2. Are standalone understandable (without paper context)
-3. Are ≤25 words
-4. Are EXACT text from the PDF (no paraphrasing!)
+**Rolle:** Extrahiert relevante, präzise Zitate aus akademischen PDF-Texten.
 
 ---
 
-## Pre-Execution Guard
+## Auftrag
 
-Before extraction, verify PDF text:
-1. If empty or <100 words → return `{"quotes": [], "total_quotes_extracted": 0, "extraction_quality": "failed", "warnings": ["PDF text too short or empty"]}`
-2. If looks like error message (contains "error", "failed", "could not") → return same structure with appropriate warning
-3. Never generate fake quotes
-4. **Title sanity check:** Extract first 200 characters of `paper.pdf_text`. Check if ≥3 words from `paper.title` (each ≥4 characters) appear there (case-insensitive). If fewer than 3 words found → set flag `"possible_pdf_mismatch": true`. Continue extraction anyway — do not abort. Only flags for manual review.
-
-**`extraction_quality` values:** `"high"` (clear text, 2-3 good quotes found) | `"medium"` (degraded text or only 1 quote) | `"low"` (usable but poor OCR/formatting) | `"failed"` (unusable — pre-execution guard triggered)
+Du bist ein präziser akademischer Textanalyst, spezialisiert auf das Extrahieren aussagekräftiger Zitate aus Forschungsarbeiten. Extrahiere pro Paper **2–3 hochrelevante Zitate**, die:
+1. Die Recherche-Query direkt adressieren
+2. Eigenständig verständlich sind (ohne Paper-Kontext)
+3. ≤ 25 Wörter lang sind
+4. EXAKTER Text aus dem PDF sind (keine Paraphrasen!)
 
 ---
 
-## Input Format
+## Pre-Execution-Guard
+
+Vor der Extraktion den PDF-Text prüfen:
+1. Leer oder < 100 Wörter → `{"quotes": [], "total_quotes_extracted": 0, "extraction_quality": "failed", "warnings": ["PDF text too short or empty"]}` zurückgeben
+2. Wirkt wie eine Fehlermeldung (enthält „error", „failed", „could not") → gleiche Struktur mit passender Warnung zurückgeben
+3. Niemals fiktive Zitate erzeugen
+4. **Titel-Plausibilitätscheck:** Erste 200 Zeichen aus `paper.pdf_text` ziehen. Prüfen, ob ≥ 3 Wörter aus `paper.title` (jedes ≥ 4 Zeichen) dort auftauchen (case-insensitive). Werden weniger als 3 Wörter gefunden → Flag `"possible_pdf_mismatch": true` setzen. Extraktion trotzdem fortführen — nicht abbrechen. Das Flag dient nur der manuellen Nachprüfung.
+
+**Werte für `extraction_quality`:** `"high"` (sauberer Text, 2–3 gute Zitate gefunden) | `"medium"` (degradierter Text oder nur 1 Zitat) | `"low"` (nutzbar, aber schwache OCR/Formatierung) | `"failed"` (unbrauchbar — Pre-Execution-Guard ausgelöst)
+
+---
+
+## Input-Format
 
 ```json
 {
@@ -71,7 +71,7 @@ Before extraction, verify PDF text:
 
 ---
 
-## Output Format
+## Output-Format
 
 ```json
 {
@@ -96,31 +96,31 @@ Before extraction, verify PDF text:
 
 ---
 
-## Strategy
+## Strategie
 
-### Priority sections (scan these first):
-1. **Abstract** — concentrated, best quotes
-2. **Introduction** — motivation, problem statement
-3. **Results / Findings** — quantitative evidence
-4. **Discussion** — interpretation, implications
-5. **Conclusion** — key takeaways
+### Priorisierte Abschnitte (zuerst scannen):
+1. **Abstract** — konzentriert, liefert meist die besten Zitate
+2. **Einleitung** — Motivation, Problemstellung
+3. **Ergebnisse / Findings** — quantitative Belege
+4. **Diskussion** — Interpretation, Implikationen
+5. **Fazit** — zentrale Take-aways
 
-### Skip: Methodology, Related Work, References
+### Überspringen: Methodik, Related Work, Literaturverzeichnis
 
-### Quote types to look for:
-- **Definitions/Frameworks** — explains a concept
-- **Empirical findings** — numbers, statistics
-- **Best practices** — actionable recommendations
-- **Challenges** — identified problems
+### Gesuchte Zitattypen:
+- **Definitionen/Frameworks** — erklären ein Konzept
+- **Empirische Befunde** — Zahlen, Statistiken
+- **Best Practices** — umsetzbare Empfehlungen
+- **Herausforderungen** — identifizierte Probleme
 
-### Quality checks before output:
-1. ≤25 words each?
-2. Exact extraction from PDF (no paraphrasing)?
-3. Standalone understandable?
-4. Relevant to research query?
-5. No duplicates (different aspects)?
+### Qualitätsprüfungen vor der Ausgabe:
+1. Jedes Zitat ≤ 25 Wörter?
+2. Exakte Extraktion aus dem PDF (keine Paraphrase)?
+3. Eigenständig verständlich?
+4. Relevant zur Recherche-Query?
+5. Keine Duplikate (unterschiedliche Aspekte)?
 
-**Better 0 quotes than bad quotes.** If no quotes pass all quality checks, return `"quotes": []` — the coordinator handles empty quote arrays gracefully.
+**Lieber 0 Zitate als schlechte Zitate.** Wenn kein Zitat alle Prüfungen besteht, `"quotes": []` zurückgeben — der Coordinator geht mit leeren Zitat-Arrays korrekt um.
 
-### Page number detection:
-The PDF text may contain page break markers in the format `--- PAGE N ---`. Use the most recent marker before each quote to set the `page` field. If no markers present, omit the field (set to `null`).
+### Seitennummer-Erkennung:
+Der PDF-Text kann Page-Break-Marker im Format `--- PAGE N ---` enthalten. Nutze den jüngsten Marker vor jedem Zitat, um das `page`-Feld zu setzen. Fehlen Marker, das Feld weglassen (auf `null` setzen).

--- a/agents/relevance-scorer.md
+++ b/agents/relevance-scorer.md
@@ -3,14 +3,14 @@ name: relevance-scorer
 model: sonnet
 color: cyan
 description: |
-  Scores a batch of up to 10 academic papers (title + abstract) against a research query on a 0.0-1.0 relevance scale with reasoning and confidence. Invoke after API search and deduplication to filter the result set. Examples:
+  Bewertet ein Batch von bis zu 10 akademischen Papers (Titel + Abstract) gegenüber einer Recherche-Query auf einer Relevanzskala von 0.0–1.0 mit Reasoning und Confidence. Nach API-Suche und Deduplikation aufrufen, um das Ergebnis-Set zu filtern. Beispiele:
 
   <example>
   Context: search-Command hat 200 Paper geliefert, Ranking und LLM-Scoring müssen laufen.
   user: "/academic-research:search 'Explainable AI Healthcare'"
   assistant: "Nach Deduplikation und 5D-Ranking wird der relevance-scorer-Agent in Batches von 10 Papers aufgerufen, um semantische Relevanz-Scores zu ergänzen."
   <commentary>
-  relevance-scorer läuft in Step 7 des search-Commands. Er ergänzt die heuristischen Ranking-Scores um semantisches LLM-Urteil auf Titel/Abstract-Ebene.
+  relevance-scorer läuft in Schritt 7 des search-Commands. Er ergänzt die heuristischen Ranking-Scores um ein semantisches LLM-Urteil auf Titel-/Abstract-Ebene.
   </commentary>
   </example>
 
@@ -19,25 +19,25 @@ description: |
   user: "Bewerte diese 15 Paper aus meiner Literaturliste nach Relevanz zu 'Post-Quantum Kryptographie im Banking'"
   assistant: "Ich rufe den relevance-scorer-Agent auf, der die Paper in Batches scort und pro Paper Score, Reasoning und Confidence liefert."
   <commentary>
-  relevance-scorer kann standalone für Re-Scoring einer bestehenden Paperliste gegen eine neue Query verwendet werden.
+  relevance-scorer lässt sich eigenständig für ein Re-Scoring einer bestehenden Paperliste gegen eine neue Query verwenden.
   </commentary>
   </example>
 maxTurns: 3
 ---
 
-# Relevance Scorer Agent
+# Relevance-Scorer-Agent
 
-**Role:** Semantic relevance scoring for academic papers
-
----
-
-## Mission
-
-You are an academic relevance evaluator with deep understanding of research terminology and cross-disciplinary connections. Evaluate the relevance of academic papers to a research query. Provide accurate relevance scores (0.0–1.0) using semantic understanding of academic language.
+**Rolle:** Semantisches Relevanz-Scoring für akademische Papers.
 
 ---
 
-## Input Format
+## Auftrag
+
+Du bist ein akademischer Relevanz-Evaluator mit tiefem Verständnis für Forschungsterminologie und interdisziplinäre Zusammenhänge. Bewerte die Relevanz akademischer Papers zu einer Recherche-Query. Liefere präzise Relevanz-Scores (0.0–1.0) auf Basis eines semantischen Verständnisses akademischer Sprache.
+
+---
+
+## Input-Format
 
 ```json
 {
@@ -53,24 +53,24 @@ You are an academic relevance evaluator with deep understanding of research term
 }
 ```
 
-Process up to 10 papers per batch.
+Pro Batch bis zu 10 Papers verarbeiten.
 
 ---
 
-## Scoring Scale
+## Bewertungsskala
 
-| Score | Level | Criteria |
-|-------|-------|----------|
-| 0.9–1.0 | Perfect match | Title + abstract directly address query |
-| 0.7–0.8 | Highly relevant | Main concepts mentioned, significant content overlap |
-| 0.5–0.6 | Relevant | At least one main concept, discusses related aspects |
-| 0.3–0.4 | Partially relevant | Shares broader concepts, tangential connection |
-| 0.1–0.2 | Barely related | Same field but different focus |
-| 0.0 | Not relevant | Different field or topic entirely |
+| Score | Stufe | Kriterien |
+|-------|-------|-----------|
+| 0.9–1.0 | Perfekter Treffer | Titel + Abstract adressieren die Query direkt |
+| 0.7–0.8 | Sehr relevant | Kernkonzepte genannt, erhebliche inhaltliche Überlappung |
+| 0.5–0.6 | Relevant | Mindestens ein Kernkonzept, behandelt verwandte Aspekte |
+| 0.3–0.4 | Teilrelevant | Teilt übergeordnete Konzepte, nur tangentialer Bezug |
+| 0.1–0.2 | Kaum verwandt | Gleiches Feld, anderer Fokus |
+| 0.0 | Nicht relevant | Völlig anderes Feld oder Thema |
 
 ---
 
-## Output Format
+## Output-Format
 
 ```json
 {
@@ -85,20 +85,20 @@ Process up to 10 papers per batch.
 }
 ```
 
-- **doi**: Raw DOI without prefix (used as key for score mapping)
+- **doi**: Rohe DOI ohne Präfix (dient als Key für das Score-Mapping)
 - **relevance_score**: Float 0.0–1.0
-- **reasoning**: 1-2 sentences explaining the score
-- **confidence**: How certain you are about the score:
-  - `"high"`: score is clearly correct — paper is unambiguously relevant (>0.7) or irrelevant (<0.3)
-  - `"medium"`: borderline case, abstract partially matches or is ambiguous (score 0.3–0.7)
-  - `"low"`: abstract missing or too short to judge (score based on title only)
+- **reasoning**: 1–2 Sätze zur Begründung des Scores
+- **confidence**: Wie sicher du dir beim Score bist:
+  - `"high"`: Score ist eindeutig — Paper ist unmissverständlich relevant (> 0.7) oder irrelevant (< 0.3)
+  - `"medium"`: Grenzfall, Abstract passt nur teilweise oder ist mehrdeutig (Score 0.3–0.7)
+  - `"low"`: Abstract fehlt oder ist zu kurz für eine Beurteilung (Score nur auf Titelbasis)
 
 ---
 
-## Guidelines
+## Leitlinien
 
-- Recognize synonyms: "CI/CD" ≈ "Continuous Integration", "ML" ≈ "Machine Learning"
-- **Multi-aspect queries**: if the query has 2+ concepts (e.g. "DevOps Governance"), a paper scoring >0.7 MUST address ALL concepts — not just one
-- **Missing abstract**: if `abstract` is null or empty, score based on title only and set `confidence: "low"`
-- Similar papers → similar scores (within ±0.1)
-- Do NOT penalize different phrasing, abbreviations, or spelling variants
+- Synonyme erkennen: „CI/CD" ≈ „Continuous Integration", „ML" ≈ „Machine Learning"
+- **Mehr-Aspekt-Queries**: Hat die Query 2+ Konzepte (z. B. „DevOps Governance"), MUSS ein Paper mit Score > 0.7 ALLE Konzepte adressieren — nicht nur eines
+- **Fehlendes Abstract**: Ist `abstract` leer oder null, Score nur auf Titelbasis und `confidence: "low"` setzen
+- Ähnliche Papers → ähnliche Scores (innerhalb ± 0.1)
+- Unterschiedliche Formulierungen, Abkürzungen oder Schreibvarianten NICHT bestrafen

--- a/commands/excel.md
+++ b/commands/excel.md
@@ -5,17 +5,17 @@ allowed-tools: Read, Write
 argument-hint: [--papers papers.json] [--output literature.xlsx] [--context]
 ---
 
-# Literature Excel Generator
+# Literatur-Excel-Generator
 
 Erstellt ein formatiertes Excel-Workbook aus gescorten Papers. Die eigentliche Excel-Generierung übernimmt der extern installierte `document-skills:xlsx`-Skill (siehe README-Prerequisites).
 
-## Usage
+## Verwendung
 
-- `/academic-research:excel` — Generate from latest session
+- `/academic-research:excel` — Aus letzter Session generieren
 - `/academic-research:excel --papers papers.json --output my_literature.xlsx`
-- `/academic-research:excel --context` — Include chapter assignment from academic context
+- `/academic-research:excel --context` — Kapitel-Zuordnung aus akademischem Kontext mitnehmen
 
-## Prerequisite
+## Voraussetzung
 
 `document-skills:xlsx` muss installiert sein:
 
@@ -27,14 +27,14 @@ Wenn nicht installiert: SessionStart-Hook warnt beim Start; dieser Command brich
 
 ## Erwartete Sheets
 
-1. **Literaturübersicht** — Full paper list with 5D scores, clusters, color-coded
-2. **Cluster-Analyse** — Statistics per cluster with bar chart
-3. **Kapitel-Zuordnung** — Papers assigned to outline chapters (requires `--context`)
-4. **Datenblatt** — Raw data for programmatic access
+1. **Literaturübersicht** — Vollständige Paperliste mit 5D-Scores, Clustern, farbcodiert
+2. **Cluster-Analyse** — Statistik pro Cluster mit Balkendiagramm
+3. **Kapitel-Zuordnung** — Papers den Gliederungskapiteln zugeordnet (benötigt `--context`)
+4. **Datenblatt** — Rohdaten für programmatischen Zugriff
 
-## Implementation
+## Umsetzung
 
-### Step 1: Papers lokalisieren
+### Schritt 1: Papers lokalisieren
 
 ```bash
 if [ -z "$PAPERS" ]; then
@@ -43,7 +43,7 @@ if [ -z "$PAPERS" ]; then
 fi
 ```
 
-### Step 2: xlsx-Skill-Verfügbarkeit prüfen
+### Schritt 2: Verfügbarkeit des xlsx-Skills prüfen
 
 ```bash
 if [ ! -d "$HOME/.claude/plugins/cache/anthropic-agent-skills/document-skills" ]; then
@@ -53,29 +53,29 @@ if [ ! -d "$HOME/.claude/plugins/cache/anthropic-agent-skills/document-skills" ]
 fi
 ```
 
-### Step 3: Input strukturieren
+### Schritt 3: Input strukturieren
 
-Lese die Paper-Daten aus `$PAPERS` (JSON-Array mit Feldern `title`, `authors`, `year`, `doi`, `total_score`, `cluster`, `relevance_score`, `recency_score`, `quality_score`, `authority_score`, `access_score`, `venue`, `source_module`).
+Lies die Paper-Daten aus `$PAPERS` (JSON-Array mit Feldern `title`, `authors`, `year`, `doi`, `total_score`, `cluster`, `relevance_score`, `recency_score`, `quality_score`, `authority_score`, `access_score`, `venue`, `source_module`).
 
 Wenn `--context` gesetzt:
-- Lese `academic_context.md` aus Memory; extrahiere `Gliederung`
+- Lies `academic_context.md` aus Memory; extrahiere die `Gliederung`
 - Berechne pro Paper die zugeordneten Kapitel (Keyword-Match zwischen `title`/`abstract` und Kapitelüberschriften)
 
-### Step 4: xlsx-Skill aktivieren
+### Schritt 4: xlsx-Skill aktivieren
 
 Rufe den `document-skills:xlsx`-Skill mit klarer Input/Output-Spezifikation auf:
 
-**Input:** Strukturierte Paper-Daten (siehe Step 3) plus Sheet-Spezifikation (welche Sheets, welche Spalten, welche Farbcodierung).
+**Input:** Strukturierte Paper-Daten (siehe Schritt 3) plus Sheet-Spezifikation (welche Sheets, welche Spalten, welche Farbcodierung).
 
 **Output:** `$OUTPUT` (Default: `~/.academic-research/sessions/$LATEST/literature.xlsx`).
 
 **Sheet-Spezifikation:**
 
-- **Literaturübersicht**: Spalten `Titel | Autoren | Jahr | Venue | DOI | Gesamt | Relevanz | Aktualität | Qualität | Autorität | Zugang | Cluster`. Farbcodierung je Cluster (Kern=grün, Ergänzung=blau, Hintergrund=grau, Methoden=gelb).
+- **Literaturübersicht**: Spalten `Titel | Autoren | Jahr | Venue | DOI | Gesamt | Relevanz | Aktualität | Qualität | Autorität | Zugang | Cluster`. Farbcodierung je Cluster (Kern = grün, Ergänzung = blau, Hintergrund = grau, Methoden = gelb).
 - **Cluster-Analyse**: Aggregatstatistik pro Cluster (Anzahl, Durchschnittsscore, Jahresverteilung) + eingebettetes Balkendiagramm.
 - **Kapitel-Zuordnung** (nur bei `--context`): Mapping Kapitel → Papers.
-- **Datenblatt**: Alle Rohdaten-Felder in flachem Tabellenformat.
+- **Datenblatt**: Alle Rohdatenfelder in flachem Tabellenformat.
 
-### Step 5: Ergebnis präsentieren
+### Schritt 5: Ergebnis präsentieren
 
-Zeige Output-Pfad und Zusammenfassung (Anzahl Papers, Cluster-Verteilung, Dateigrösse).
+Ausgabepfad und Zusammenfassung anzeigen (Anzahl Papers, Cluster-Verteilung, Dateigröße).

--- a/commands/history.md
+++ b/commands/history.md
@@ -4,36 +4,36 @@ allowed-tools: Read, Bash(cat ~/.academic-research/*), Bash(ls ~/.academic-resea
 argument-hint: [optional: search query or date]
 ---
 
-# Research History
+# Recherche-Verlauf
 
-View past research sessions stored in `~/.academic-research/sessions/`.
+Vergangene Recherche-Sessions ansehen, die unter `~/.academic-research/sessions/` abgelegt sind.
 
-## Usage
+## Verwendung
 
-- `/academic-research:history` — List all sessions
-- `/academic-research:history "DevOps"` — Search sessions by query
-- `/academic-research:history 2026-03-17` — Show specific session details
-- `/academic-research:history stats` — Show aggregate statistics
+- `/academic-research:history` — Alle Sessions auflisten
+- `/academic-research:history "DevOps"` — Sessions per Query durchsuchen
+- `/academic-research:history 2026-03-17` — Details einer bestimmten Session anzeigen
+- `/academic-research:history stats` — Aggregatstatistik anzeigen
 
-## Implementation
+## Umsetzung
 
-1. Read session index: `cat ~/.academic-research/sessions/index.json`
-2. If argument provided:
-   - If it's a date → find session from that date, show details
-   - If it's "stats" → show aggregate stats
-   - Otherwise → search sessions by query text
-3. Display results as formatted table:
+1. Session-Index einlesen: `cat ~/.academic-research/sessions/index.json`
+2. Wenn ein Argument übergeben wurde:
+   - Datum → Session von diesem Tag finden, Details anzeigen
+   - `"stats"` → Aggregatstatistik anzeigen
+   - Sonst → Sessions per Query-Text durchsuchen
+3. Ergebnisse als formatierte Tabelle ausgeben:
 
 ```
-📚 Research History
+📚 Recherche-Verlauf
 
-| # | Date       | Query                  | Papers | PDFs  | Mode     |
+| # | Datum      | Query                  | Papers | PDFs  | Modus    |
 |---|------------|------------------------|--------|-------|----------|
 | 1 | 2026-03-17 | DevOps Governance      | 47     | 42/47 | standard |
 | 2 | 2026-03-15 | AI Ethics              | 32     | 28/32 | deep     |
 | 3 | 2026-03-10 | ML in Healthcare       | 25     | 20/25 | quick    |
 
-Total: 3 sessions, 104 papers, 90 PDFs
+Gesamt: 3 Sessions, 104 Papers, 90 PDFs
 ```
 
-For detail view, show: papers list, quote count, module breakdown, file locations.
+Für die Detailansicht ausgeben: Paperliste, Zitat-Anzahl, Modul-Verteilung, Dateipfade.

--- a/commands/score.md
+++ b/commands/score.md
@@ -5,47 +5,47 @@ allowed-tools: Read, Agent(relevance-scorer)
 argument-hint: [papers.json] [--query "..."] [--mode standard]
 ---
 
-# Literature Scoring
+# Literatur-Scoring
 
-Re-score and rank papers using the `relevance-scorer`-Agent. Der Agent bewertet Titel+Abstract gegen die Query auf einer 0.0-1.0-Skala und liefert Reasoning und Confidence je Paper.
+Papers mithilfe des `relevance-scorer`-Agents neu scoren und ranken. Der Agent bewertet Titel + Abstract gegen die Query auf einer 0.0–1.0-Skala und liefert Reasoning und Confidence je Paper.
 
-## Usage
+## Verwendung
 
-- `/academic-research:score` — Score papers from latest session
-- `/academic-research:score papers.json --query "DevOps"` — Score specific file
-- `/academic-research:score --mode deep` — Score with additional confidence pass
+- `/academic-research:score` — Papers aus der letzten Session scoren
+- `/academic-research:score papers.json --query "DevOps"` — Bestimmte Datei scoren
+- `/academic-research:score --mode deep` — Scoring mit zusätzlichem Confidence-Durchlauf
 
-## 5D Dimensions (Referenz, Agent übernimmt 1D-Relevance)
+## 5D-Dimensionen (Referenz, Agent übernimmt 1D-Relevanz)
 
-| Dimension | Weight | Source |
-|-----------|--------|--------|
-| Relevanz | 0.35 | `relevance-scorer`-Agent (Titel+Abstract-Match) |
+| Dimension | Gewicht | Quelle |
+|-----------|---------|--------|
+| Relevanz | 0.35 | `relevance-scorer`-Agent (Titel + Abstract-Match) |
 | Aktualität | 0.20 | 5-Jahre-Halbwertszeit-Decay, berechnet aus `year`-Feld |
-| Qualität | 0.15 | Citations-per-year mit Log-Scaling, aus `citation_count` |
+| Qualität | 0.15 | Zitationen pro Jahr mit Log-Skalierung, aus `citation_count` |
 | Autorität | 0.15 | Venue-Heuristik aus `venue`/`source`-Feld |
 | Zugang | 0.15 | Open Access > Institutional > DOI > URL > Nichts |
 
-Die 4 nicht-Relevanz-Dimensionen werden direkt in der Command-Logik als arithmetische Funktionen berechnet (siehe Gewichtungen). Keine Python-Pipeline.
+Die vier Nicht-Relevanz-Dimensionen werden direkt in der Command-Logik als arithmetische Funktionen berechnet (siehe Gewichtungen). Keine Python-Pipeline.
 
-## Clusters
+## Cluster
 
-- **Kernliteratur** (green): Total ≥ 0.75, Relevance ≥ 0.80
-- **Ergänzungsliteratur** (blue): Total ≥ 0.50, Relevance ≥ 0.50
-- **Hintergrundliteratur** (gray): Total ≥ 0.30
-- **Methodenliteratur** (yellow): Methodology keywords in title/abstract
+- **Kernliteratur** (grün): Total ≥ 0.75, Relevanz ≥ 0.80
+- **Ergänzungsliteratur** (blau): Total ≥ 0.50, Relevanz ≥ 0.50
+- **Hintergrundliteratur** (grau): Total ≥ 0.30
+- **Methodenliteratur** (gelb): Methodologie-Schlüsselwörter in Titel/Abstract
 
-## Implementation
+## Umsetzung
 
-### Step 1: Paper-Quelle finden
+### Schritt 1: Paper-Quelle finden
 
 ```bash
 LATEST=$(ls -t ~/.academic-research/sessions/ | head -1)
 PAPERS=~/.academic-research/sessions/$LATEST/deduped.json
 ```
 
-Bei explizitem Argument: verwende diesen Pfad.
+Bei explizitem Argument: diesen Pfad verwenden.
 
-### Step 2: Relevance-Scoring via Agent
+### Schritt 2: Relevanz-Scoring via Agent
 
 Papers in Batches à 10 an den `relevance-scorer`-Agent schicken. Input pro Batch:
 
@@ -58,25 +58,25 @@ Papers in Batches à 10 an den `relevance-scorer`-Agent schicken. Input pro Batc
 }
 ```
 
-Output-Feld `relevance_score` je Paper als 0.0-1.0-Float einsammeln.
+Output-Feld `relevance_score` je Paper als 0.0–1.0-Float einsammeln.
 
-### Step 3: 4 weitere Dimensionen berechnen
+### Schritt 3: 4 weitere Dimensionen berechnen
 
 Je Paper:
 
 - `recency = exp(-ln(2) * (current_year - year) / 5)` — exponentieller Decay, 5-Jahres-Halbwertszeit
-- `quality = min(log10(citations / max(1, years_since_pub) + 1) / 2, 1.0)` — Log-skalierte Citations-pro-Jahr
+- `quality = min(log10(citations / max(1, years_since_pub) + 1) / 2, 1.0)` — Log-skalierte Zitationen pro Jahr
 - `authority` = 1.0 für bekannte Top-Venues (IEEE, ACM, Springer, Nature, Elsevier), 0.7 für indexierte Journals, 0.4 für Konferenzen, 0.2 sonst
 - `access` = 1.0 für Open Access, 0.8 für DOI mit Institutional Access, 0.5 für nur DOI, 0.2 für nur URL
 
-### Step 4: Gesamtscore und Cluster
+### Schritt 4: Gesamtscore und Cluster
 
 ```
 total = 0.35 * relevance + 0.20 * recency + 0.15 * quality + 0.15 * authority + 0.15 * access
 ```
 
-Cluster per Threshold-Tabelle oben zuordnen.
+Cluster gemäß Threshold-Tabelle oben zuordnen.
 
-### Step 5: Ausgabe
+### Schritt 5: Ausgabe
 
-Papers nach Cluster sortiert als formatted Markdown-Tabelle ausgeben. Als JSON in `ranked.json` im Session-Dir speichern.
+Papers nach Cluster sortiert als formatierte Markdown-Tabelle ausgeben. Als JSON in `ranked.json` im Session-Verzeichnis speichern.

--- a/commands/search.md
+++ b/commands/search.md
@@ -5,55 +5,55 @@ allowed-tools: Read, Write, Bash(~/.academic-research/venv/bin/python *), Bash(b
 argument-hint: "<query>" [--mode quick|standard|deep|metadata] [--modules crossref,openalex,...] [--limit N]
 ---
 
-# Academic Paper Search
+# Akademische Paper-Suche
 
-Search across 7 API sources in parallel. Optionally expand queries with the query-generator agent.
+Parallele Suche über 7 API-Quellen. Optional werden Queries mit dem `query-generator`-Agent erweitert.
 
-## Usage
+## Verwendung
 
-- `/academic-research:search "DevOps Governance"` — Standard search across all API modules
-- `/academic-research:search "Machine Learning" --mode quick` — Fast search (4 modules)
-- `/academic-research:search "IT Compliance" --mode deep` — Deep search (all modules + portfolio adjustments)
+- `/academic-research:search "DevOps Governance"` — Standardsuche über alle API-Module
+- `/academic-research:search "Machine Learning" --mode quick` — Schnelle Suche (4 Module)
+- `/academic-research:search "IT Compliance" --mode deep` — Tiefensuche (alle Module + Portfolio-Anpassungen)
 - `/academic-research:search "Cloud Computing" --modules crossref,semantic_scholar --limit 30`
 
-## Arguments
+## Argumente
 
-| Argument | Default | Description |
-|----------|---------|-------------|
-| `query` | (required) | Search query |
-| `--mode` | `standard` | quick (4 APIs), standard (7 APIs), deep (7 APIs + portfolio), metadata (no PDFs) |
-| `--modules` | (from mode) | Override: comma-separated module names |
-| `--limit` | `50` | Max results per module |
-| `--no-expand` | false | Skip query-generator agent, use raw query |
-| `--no-browser` | false | Skip browser modules (API-only) |
+| Argument | Default | Beschreibung |
+|----------|---------|--------------|
+| `query` | (erforderlich) | Suchanfrage |
+| `--mode` | `standard` | quick (4 APIs), standard (7 APIs), deep (7 APIs + Portfolio), metadata (keine PDFs) |
+| `--modules` | (aus Modus) | Override: kommagetrennte Modulnamen |
+| `--limit` | `50` | Maximale Treffer pro Modul |
+| `--no-expand` | false | `query-generator`-Agent überspringen, rohe Query nutzen |
+| `--no-browser` | false | Browser-Module überspringen (nur APIs) |
 
-## Module Selection by Mode
+## Modul-Auswahl nach Modus
 
 - **quick**: crossref, openalex, semantic_scholar, arxiv
 - **standard**: crossref, openalex, semantic_scholar, base, econbiz, econstor, arxiv
-- **deep**: All 7 API modules + browser modules (Google Scholar, Springer, OECD, RePEc, OPAC)
-- **metadata**: Same as standard
+- **deep**: Alle 7 API-Module + Browser-Module (Google Scholar, Springer, OECD, RePEc, OPAC)
+- **metadata**: Wie standard
 
-## Implementation
+## Umsetzung
 
-### Step 1: Setup session directory
+### Schritt 1: Session-Verzeichnis anlegen
 
 ```bash
 SESSION_DIR=~/.academic-research/sessions/$(date -u +%Y-%m-%dT%H-%M-%SZ)
 mkdir -p "$SESSION_DIR/pdfs"
 ```
 
-Save metadata:
+Metadaten sichern:
 ```json
 {"query": "$QUERY", "mode": "$MODE", "timestamp": "$TIMESTAMP", "modules": [...]}
 ```
 
-### Step 2: Query expansion (unless --no-expand)
+### Schritt 2: Query-Erweiterung (falls nicht `--no-expand`)
 
-Spawn the `query-generator` agent with the user's query and target modules.
-Save output to `$SESSION_DIR/queries.json`.
+Den `query-generator`-Agent mit der User-Query und den Ziel-Modulen starten.
+Ausgabe nach `$SESSION_DIR/queries.json` speichern.
 
-### Step 3: API search
+### Schritt 3: API-Suche
 
 ```bash
 ~/.academic-research/venv/bin/python ${CLAUDE_PLUGIN_ROOT}/scripts/search.py \
@@ -64,7 +64,7 @@ Save output to `$SESSION_DIR/queries.json`.
   --output "$SESSION_DIR/api_results.json"
 ```
 
-### Step 4: Browser search (standard/deep modes, unless --no-browser)
+### Schritt 4: Browser-Suche (standard-/deep-Modus, falls nicht `--no-browser`)
 
 Für jedes Browser-Modul in fester Reihenfolge:
 
@@ -84,13 +84,13 @@ Pro Modul:
    - Bei Bedarf paginieren — maximal 2 Seiten pro Modul
 4. Ergebnisse ins `api_results.json`-Schema normalisieren (`title`, `authors`, `year`, `venue`, `doi`, `url`, `source_module`, `snippet`) und an die bestehende Ergebnisliste anhängen.
 5. Fehlerbehandlung:
-   - CAPTCHA erkannt → `browser-use screenshot` machen, User informieren, Partial Results behalten.
-   - Login schlägt fehl → Modul überspringen, Warnung loggen, weitermachen mit nächstem Modul.
-   - Rate-Limit → 30s Pause, einmal retry, dann Modul überspringen.
+   - CAPTCHA erkannt → `browser-use screenshot` machen, User informieren, Teilergebnisse behalten.
+   - Login schlägt fehl → Modul überspringen, Warnung loggen, mit nächstem Modul weitermachen.
+   - Rate-Limit → 30s Pause, einmal wiederholen, dann Modul überspringen.
 
-Append results to `$SESSION_DIR/api_results.json`.
+Ergebnisse an `$SESSION_DIR/api_results.json` anhängen.
 
-### Step 5: Deduplication
+### Schritt 5: Deduplikation
 
 ```bash
 ~/.academic-research/venv/bin/python ${CLAUDE_PLUGIN_ROOT}/scripts/dedup.py \
@@ -98,19 +98,19 @@ Append results to `$SESSION_DIR/api_results.json`.
   --output "$SESSION_DIR/deduped.json"
 ```
 
-### Step 6: Ranking (5D scoring + clusters)
+### Schritt 6: Ranking (5D-Scoring + Cluster)
 
-Die Heuristik-Dimensionen (Aktualität, Qualität, Autorität, Zugang) werden direkt in diesem Command berechnet — siehe Formeln in `commands/score.md` → "4 weitere Dimensionen berechnen". Gesamtscore wie dort, Clusterzuweisung ebenfalls. Das Resultat in `$SESSION_DIR/ranked.json` schreiben.
+Die Heuristik-Dimensionen (Aktualität, Qualität, Autorität, Zugang) werden direkt in diesem Command berechnet — siehe Formeln in `commands/score.md` → „4 weitere Dimensionen berechnen". Gesamtscore wie dort, Clusterzuweisung ebenfalls. Das Resultat in `$SESSION_DIR/ranked.json` schreiben.
 
-### Step 7: LLM relevance scoring
+### Schritt 7: LLM-Relevanz-Scoring
 
-Spawn `relevance-scorer` agent in batches of 10 papers.
-Merge LLM scores into ranking. Select top-N based on mode (quick=15, standard=25, deep=40).
-Save as `$SESSION_DIR/papers.json`.
+Den `relevance-scorer`-Agent in Batches von 10 Papers starten.
+LLM-Scores ins Ranking einmischen. Top-N nach Modus wählen (quick=15, standard=25, deep=40).
+Als `$SESSION_DIR/papers.json` speichern.
 
-### Step 8: Show results
+### Schritt 8: Ergebnisse anzeigen
 
-Display a formatted table with: rank, title, year, score, cluster, source module.
-Report session directory path.
+Eine formatierte Tabelle mit Rang, Titel, Jahr, Score, Cluster und Quellmodul ausgeben.
+Pfad des Session-Verzeichnisses melden.
 
-Update memory file `literature_state.md` with new statistics if academic context exists.
+Die Memory-Datei `literature_state.md` mit neuen Statistiken aktualisieren, falls akademischer Kontext vorliegt.

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -36,15 +36,15 @@ Das Skript übernimmt in sechs Schritten:
 ## Was passiert, wenn etwas fehlt
 
 - **Ohne `browser-use` CLI:** API-basierte Suchmodule (CrossRef, OpenAlex, Semantic Scholar, BASE, EconBiz, EconStor, arXiv) laufen weiter. Browser-basierte Suchmodule (Scholar, Springer, OECD, RePEc, OPAC, EBSCOhost, ProQuest) werden übersprungen.
-- **Ohne `browser-use` Claude-Skill:** Claude fällt bei Browser-Aufrufen auf direkte CLI-Kommandos zurück (funktional identisch, nur ohne den Skill-Wrapper mit seinen best-practice-Hinweisen).
+- **Ohne `browser-use` Claude-Skill:** Claude fällt bei Browser-Aufrufen auf direkte CLI-Kommandos zurück (funktional identisch, nur ohne den Skill-Wrapper mit seinen Best-Practice-Hinweisen).
 - **Ohne `document-skills` Plugin:** `/academic-research:excel` bricht mit klarer Fehlermeldung und Install-Befehl ab.
 
 ## Erneutes Ausführen
 
 Das Skript ist idempotent. Ein zweiter Aufruf:
 
-- erstellt kein zweites venv, installiert nur fehlende Packages
-- überspringt `browser-use` CLI-Install, wenn bereits installiert
+- erstellt kein zweites venv, installiert nur fehlende Pakete
+- überspringt die `browser-use` CLI-Installation, wenn bereits installiert
 - wiederholt `browser-use doctor` (harmlos, aktualisiert den Status)
 - überschreibt keine Seed-Dateien
 - fügt Permissions nur hinzu, wenn sie noch nicht in `~/.claude/settings.local.json` stehen

--- a/docs/superpowers/plans/2026-04-23-academic-research-e3-prompt-quality.md
+++ b/docs/superpowers/plans/2026-04-23-academic-research-e3-prompt-quality.md
@@ -1,0 +1,1384 @@
+# E3 Prompt Quality Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Überarbeitet die Prompts in allen 13 Skills, 5 Commands und 3 Agents auf einheitliches Deutsch, fügt Anti-Fabrikations-Klauseln, Memory-Precondition-Checks, numerische Schwellen, Few-Shot-Paare, Skill-Abgrenzung und Umlaut-Varianten hinzu — liefert v5.1.0.
+
+**Architecture:** Reiner Text/Prompt-Refactor ohne Python-Änderungen. 10 themenorientierte Commits auf dem Feature-Branch `refactor/e3-prompt-quality`; pro Block (A–H) ein Commit, plus Smoke-Test-Commit und Release-Commit. Verifikation pro Block via `grep`-Trefferzähler.
+
+**Tech Stack:** Markdown mit YAML-Frontmatter (Skills/Commands/Agents). Python 3.10+ venv unter `~/.academic-research/venv` für den Smoke-Test. `gh` CLI für PR/Tag.
+
+**Spec:** [`docs/superpowers/specs/2026-04-23-academic-research-e3-prompt-quality-design.md`](../specs/2026-04-23-academic-research-e3-prompt-quality-design.md)
+
+**Branch:** `refactor/e3-prompt-quality` von `main` (v5.0.1). Dieser Plan wird als erster Commit auf dem Branch hinterlegt; ab Task 1 folgen die 10 themenorientierten Implementierungs-Commits.
+
+---
+
+## File Structure Overview
+
+- `skills/*/SKILL.md` (13 Dateien) — Hauptlastträger, erhalten Sprache + Anti-Fabrikation + Memory-Precondition + Umlaut-Varianten; 5 erhalten zusätzlich Numerik, 4 erhalten Few-Shots, 2 erhalten Boundary-Klausel.
+- `commands/{setup,search,score,excel,history}.md` (5 Dateien) — Sprache deutsch.
+- `agents/{query-generator,relevance-scorer,quote-extractor}.md` (3 Dateien) — Sprache deutsch; 2 erhalten zusätzliche Block-H-Fixes.
+- `tests/test_skills_manifest.py` (neu) — Smoke-Test für Frontmatter, Sektionen, Umlaut-Paare.
+- `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `CHANGELOG.md` — Release in Task 11.
+
+---
+
+## Task 1: Sprach-Vereinheitlichung in 13 Skills (Block A, Commit 1)
+
+**Files:**
+- Modify: `skills/abstract-generator/SKILL.md`
+- Modify: `skills/academic-context/SKILL.md`
+- Modify: `skills/advisor/SKILL.md`
+- Modify: `skills/chapter-writer/SKILL.md`
+- Modify: `skills/citation-extraction/SKILL.md`
+- Modify: `skills/literature-gap-analysis/SKILL.md`
+- Modify: `skills/methodology-advisor/SKILL.md`
+- Modify: `skills/plagiarism-check/SKILL.md`
+- Modify: `skills/research-question-refiner/SKILL.md`
+- Modify: `skills/source-quality-audit/SKILL.md`
+- Modify: `skills/style-evaluator/SKILL.md`
+- Modify: `skills/submission-checker/SKILL.md`
+- Modify: `skills/title-generator/SKILL.md`
+
+- [ ] **Step 1: Lies eine Skill-Datei vollständig** (Beispiel: `skills/plagiarism-check/SKILL.md`)
+
+Ziel: Gesamtstruktur verstehen, um Sprachumstellung zu planen (Überschriften, Fließtext, Listen-Items, Beispielinhalte).
+
+- [ ] **Step 2: Übersetze Fließtext, Überschriften, Listen, Beispiele in Deutsch**
+
+Sprach-Regeln (aus Spec Block A):
+- Deutsch: alle Überschriften (`#`, `##`, `###`), Fließtext, Listeneinträge, Warn-/Hinweistexte, Beispielinhalte in `<example>`-Tags
+- Englisch bleibt: Code, Dateipfade (`${CLAUDE_PLUGIN_ROOT}/scripts/...`), JSON-Keys, YAML-Frontmatter-Keys (`name:`, `description:`), Code-Kommentare, `<example>`-Tag-Namen selbst, Shell-Kommandos, Python-Methodennamen
+- Der Wert des `description:`-Frontmatter-Felds wird Deutsch (mit Umlauten, siehe Task 8 für die Keyword-Listen — in diesem Task nur Beschreibungs-Fließtext)
+- `<example>`-Inhalte (User-Zitate, Assistant-Antworten, `<commentary>`): Deutsch. Tag selbst (`<example>`, `<commentary>`) bleibt Englisch.
+
+Beispiel-Transformation (aus `plagiarism-check/SKILL.md`):
+
+```markdown
+# Plagiarism Check
+
+Check academic text for unintentional proximity to source material. Detect too-close paraphrases, …
+```
+
+→
+
+```markdown
+# Plagiatsprüfung
+
+Prüft akademischen Text auf unbeabsichtigte Nähe zum Quellmaterial. Erkennt zu
+nahe Paraphrasen, unzureichend umformulierte Passagen und fehlende Quellenangaben
+via N-Gramm-Overlap-Detection. Schlägt Umformulierungen für markierte Passagen vor.
+```
+
+Wiederhole diesen Prozess für alle 13 Skills.
+
+- [ ] **Step 3: Verifiziere jede Datei — keine englischen Hauptüberschriften**
+
+Run:
+```bash
+grep -rEn "^(##|###) [A-Z][a-z]+ " skills/*/SKILL.md
+```
+
+Expected: 0 Treffer (außer in Code-Blöcken mit ```markdown — die werden nicht gematcht, da grep ein Flag `-E` ohne multiline dotall verwendet).
+
+Falls Treffer auftauchen → Datei editieren bis grep leer ist.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/*/SKILL.md
+git commit -m "$(cat <<'EOF'
+refactor(skills): unify language to German in all 13 skills
+
+Uebersetzt alle Flies-Texte, Ueberschriften, Listen und Beispielinhalte in
+Deutsch. Englisch bleibt nur in Code, Pfaden, JSON-Keys, Frontmatter-Keys,
+Code-Kommentaren und Shell-Kommandos.
+
+Teil von #10 / #30. Block A (1/10).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Sprach-Vereinheitlichung in Commands und Agents (Block A, Commit 2)
+
+**Files:**
+- Modify: `commands/setup.md`
+- Modify: `commands/search.md`
+- Modify: `commands/score.md`
+- Modify: `commands/excel.md`
+- Modify: `commands/history.md`
+- Modify: `agents/query-generator.md`
+- Modify: `agents/relevance-scorer.md`
+- Modify: `agents/quote-extractor.md`
+
+- [ ] **Step 1: Übersetze 5 Commands nach gleichen Regeln wie Task 1**
+
+Commands enthalten oft strukturierte Workflow-Schritte ("Step 1", "Step 2"). Übersetze die Beschreibungen, nicht die Step-Nummerierung. Code-Blöcke und Shell-Kommandos bleiben Englisch.
+
+- [ ] **Step 2: Übersetze 3 Agents nach gleichen Regeln**
+
+Agent-`description:` (YAML-Frontmatter) wird Deutsch inkl. `<example>`-Block-Inhalten. Tag-Namen und Attribute bleiben Englisch.
+
+Beispiel für `agents/quote-extractor.md` description:
+
+```yaml
+description: Verwende diesen Agent, wenn woertliche Zitate mit Seitenzahlen aus PDF-Quellen extrahiert werden sollen. Beispiele: <example>…</example>
+```
+
+(Umlaut-Varianten in Frontmatter-Descriptions kommen erst in Task 8 — hier nur der Fließtext-Teil.)
+
+- [ ] **Step 3: Verifiziere — keine englischen Hauptüberschriften in Commands/Agents**
+
+Run:
+```bash
+grep -rEn "^(##|###) [A-Z][a-z]+ " commands/*.md agents/*.md
+```
+
+Expected: 0 Treffer.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add commands/*.md agents/*.md
+git commit -m "$(cat <<'EOF'
+refactor(commands+agents): unify language to German
+
+Uebersetzt alle 5 Commands und 3 Agents in konsistentes Deutsch. Code-Bloecke,
+Shell-Kommandos, Tag-Namen und Frontmatter-Keys bleiben Englisch.
+
+Teil von #10 / #30. Block A (2/10).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Anti-Fabrikations-Klauseln (Block B, Commit 3)
+
+**Files:**
+- Modify: alle 13 `skills/*/SKILL.md`
+
+- [ ] **Step 1: Füge in jeder SKILL.md den Abschnitt `## Keine Fabrikation` ein**
+
+Platzierung: **direkt nach dem Einleitungsabsatz** (vor dem ersten `##`-Abschnitt wie `When This Skill Activates` bzw. `Wann dieser Skill aktiviert wird`).
+
+Template (mit skill-spezifischem Konsequenz-Baustein):
+
+```markdown
+## Keine Fabrikation
+
+Erfundene [Platzhalter-A] sind für die FH Leibniz ein Plagiatsbefund und
+führen zu [Platzhalter-B aus Tabelle unten]. Arbeite ausschließlich mit
+Daten aus `literature_state.md` oder direkt geladenen PDFs. Fehlen Daten:
+frag den User, rate nicht.
+```
+
+**Tabelle: Platzhalter-A (Subjekt) und Platzhalter-B (Konsequenz) pro Skill:**
+
+| Skill | Platzhalter-A | Platzhalter-B |
+|---|---|---|
+| `source-quality-audit` | Bewertungen oder Quellenangaben | einer Quellenprüfung, die der Arbeit die Zitierbarkeit entzieht |
+| `literature-gap-analysis` | Abdeckungs-Statements oder Quellenlisten | einem Plagiatsverdacht, wenn behauptete Quellen nicht existieren |
+| `abstract-generator` | Ergebnisse, Methoden oder Zahlen im Abstract | einem Täuschungsversuch nach FH-Leibniz-Prüfungsordnung |
+| `submission-checker` | Formalia-Bestätigungen | einer Abgabe nicht-abgabefähiger Arbeit |
+| `chapter-writer` | Belege, Zitate oder Faktenaussagen im Fließtext | einem Plagiatsbefund laut FH-Leibniz-Regelung |
+| `citation-extraction` | Zitate, Seitenzahlen oder Quellenangaben | Zitaten, die in der Plagiatsprüfung als nicht-auffindbar markiert werden |
+| `methodology-advisor` | Methodik-Standards, Begründungen oder Vergleiche | Note 5 für das Forschungsdesign |
+| `plagiarism-check` | Similarity-Urteile oder N-Gramm-Matches | unentdecktem Plagiat, das später auffliegt |
+| `title-generator` | in den Titel eingebaute Claims | einer vor der Korrektur angreifbaren Arbeit |
+| `research-question-refiner` | Bezüge zu Vorarbeiten oder Forschungslücken | einer Fragestellung, die beim ersten Supervisor-Feedback kollabiert |
+| `style-evaluator` | Stil-Urteile über nicht gelesenen Text | tatsächlich fragwürdigem Stil, der unentdeckt bleibt |
+| `advisor` | Kapitelstruktur-Standards oder Gliederungsempfehlungen | nachträglichen Überarbeitungen nach Abgabe |
+| `academic-context` | Kontextangaben (Thema, Methodik, Fragestellung) | einer vergifteten Memory-Basis, die alle nachgelagerten Skills wertlos macht |
+
+Konkretes Beispiel für `skills/abstract-generator/SKILL.md`:
+
+```markdown
+## Keine Fabrikation
+
+Erfundene Ergebnisse, Methoden oder Zahlen im Abstract sind für die FH
+Leibniz ein Plagiatsbefund und führen zu einem Täuschungsversuch nach
+FH-Leibniz-Prüfungsordnung. Arbeite ausschließlich mit Daten aus
+`literature_state.md` oder direkt geladenen PDFs. Fehlen Daten: frag den
+User, rate nicht.
+```
+
+- [ ] **Step 2: Verifiziere — jede SKILL.md enthält `## Keine Fabrikation`**
+
+Run:
+```bash
+grep -l "^## Keine Fabrikation$" skills/*/SKILL.md | wc -l
+```
+
+Expected: `13`
+
+Falls < 13 → Skill ohne Klausel identifizieren (`grep -L "^## Keine Fabrikation$" skills/*/SKILL.md`) und nachtragen.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/*/SKILL.md
+git commit -m "$(cat <<'EOF'
+feat(skills): add anti-fabrication clauses with FH-specific reasoning
+
+Fuegt in jeder der 13 SKILL.md einen Abschnitt '## Keine Fabrikation' ein.
+Cookbook-Stil (Begruendung + Handlung). Konsequenz-Bausteine sind
+skill-spezifisch und nennen FH-Leibniz-Pruefungsordnung, Note 5 oder
+Plagiatsbefund.
+
+Teil von #10 / #31. Block B (3/10).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Numerische Schwellen (Block C, Commit 4)
+
+**Files:**
+- Modify: `skills/advisor/SKILL.md`
+- Modify: `skills/methodology-advisor/SKILL.md`
+- Modify: `skills/submission-checker/SKILL.md`
+- Modify: `skills/style-evaluator/SKILL.md`
+- Modify: `skills/literature-gap-analysis/SKILL.md`
+
+- [ ] **Step 1: Füge in `skills/advisor/SKILL.md` die PASS/FAIL-Checkliste ein**
+
+Platzierung: ersetze den Abschnitt `## When This Skill Activates` bzw. direkt darunter den bisherigen Absatz mit „common academic standards" durch folgenden Abschnitt:
+
+```markdown
+## Bewertungskriterien (PASS/FAIL)
+
+Prüfe die Outline gegen diese 7 Kriterien. Jedes ist PASS oder FAIL — kein
+Zwischenstufen-Urteil:
+
+1. **Forschungsfrage formuliert** — ≤ 25 Wörter, eine W-Frage (Was/Wie/Warum/Inwiefern)
+2. **Outline mit ≥ 3 Kapiteln** — Haupt-Kapitel, nicht nur Gliederungspunkte
+3. **Literaturbasis ≥ 15 Quellen** in `literature_state.md`
+4. **Methodik benannt** — qualitativ / quantitativ / Mixed / Literatur-Review etc.
+5. **Zeitplan mit Meilensteinen** — mindestens 3 Meilensteine mit Datum
+6. **Supervisor identifiziert** — Name in `academic_context.md`
+7. **Abgabetermin fixiert** — konkretes Datum in `academic_context.md`
+
+Ausgabe: Tabelle mit Kriterium + PASS/FAIL + Begründung bei FAIL.
+```
+
+- [ ] **Step 2: Füge in `skills/methodology-advisor/SKILL.md` die Scoring-Matrix ein**
+
+Platzierung: ersetze existierende Scoring-Beschreibung durch folgenden Abschnitt:
+
+```markdown
+## Methoden-Scoring-Matrix
+
+Bewerte jede Methoden-Option auf einer Skala 1–5 in 4 Dimensionen:
+
+| Dimension | 1 = schlecht | 3 = okay | 5 = ideal |
+|---|---|---|---|
+| **Datenqualität** | Zugriff fraglich, Daten veraltet/unvollständig | Zugriff gegeben, Daten ausreichend | Zugriff gesichert, Daten aktuell und vollständig |
+| **Zeitaufwand** | > Rahmen der Arbeit | passt eng in den Rahmen | deutlich unter Maximalrahmen |
+| **Supervisor-Präferenz** | explizit abgelehnt | neutral / nicht erwähnt | explizit empfohlen |
+| **Fit zur Forschungsfrage** | beantwortet Frage nicht | beantwortet Frage teilweise | beantwortet Frage direkt |
+
+Gesamt-Score = Summe der 4 Dimensionen (Min 4, Max 20).
+Empfehlung: Methode mit höchstem Score. Bei Gleichstand: Supervisor-Präferenz entscheidet.
+Dokumentiere Scoring in der Ausgabe, nicht nur die Empfehlung.
+```
+
+- [ ] **Step 3: Füge in `skills/submission-checker/SKILL.md` das FH-Leibniz-Regelwerk ein**
+
+Platzierung: Abschnitt `## FH-Leibniz-Formalia-Check` direkt nach `## Keine Fabrikation`:
+
+```markdown
+## FH-Leibniz-Formalia-Check
+
+Prüfe folgende Formalia. Jeder Punkt ist PASS/FAIL:
+
+1. **Seitenränder** — 2,5 cm rundum (oben/unten/links/rechts)
+2. **Schriftart** — Times New Roman 12 pt ODER Arial 11 pt
+3. **Zeilenabstand** — 1,5-fach
+4. **Eidesstattliche Erklärung** — vollständiger Wortlaut laut FH-Vorlage, unterschrieben
+5. **Deckblatt** — alle Pflicht-Felder: Titel, Name, Matrikelnummer, Studiengang, Supervisor, Abgabedatum
+6. **Literaturverzeichnis** — nach FH-vorgegebenem Zitationsstil durchgehend einheitlich
+7. **Seitenzählung** — Einleitung beginnt mit Seite 1 (arabisch), Verzeichnisse römisch
+8. **Inhaltsverzeichnis** — automatisiert (nicht manuell), Seitenangaben korrekt
+
+Ausgabe: Tabelle Kriterium + PASS/FAIL + bei FAIL: konkrete Korrektur-Anweisung.
+```
+
+- [ ] **Step 4: Füge in `skills/style-evaluator/SKILL.md` die Fallback-Rubrik ein**
+
+Platzierung: Abschnitt `## Fallback-Rubrik (ohne Script)` unter den bestehenden Analyse-Abschnitten:
+
+```markdown
+## Fallback-Rubrik (ohne Script)
+
+Wenn kein externes Stil-Analyse-Script verfügbar ist, prüfe manuell gegen
+diese 5 Schwellen:
+
+| Metrik | Schwelle | Messverfahren |
+|---|---|---|
+| **Satzlänge (Ø)** | 15–25 Wörter | 20 zufällige Sätze, Mittelwert |
+| **Passiv-Quote** | < 30 % | "wird/werden/wurde/wurden + Partizip II" in Stichprobe 20 Sätze |
+| **Nominalstil-Anteil** | < 40 % | Sätze mit ≥ 3 Nominalphrasen (auf "-ung/-heit/-keit/-tion") in Stichprobe |
+| **Füllwörter-Dichte** | < 5 % | "quasi, eigentlich, irgendwie, sozusagen, gewissermaßen" vs. Gesamtwörter |
+| **Code-Switches** | 0 | Englische Wörter außerhalb etablierter Fachbegriffe |
+
+Ausgabe: Tabelle Metrik + Ist-Wert + Schwelle + PASS/FAIL.
+```
+
+- [ ] **Step 5: Füge in `skills/literature-gap-analysis/SKILL.md` die Coverage-Metriken ein**
+
+Platzierung: Abschnitt `## Coverage-Metriken (numerisch)` nach `## Keine Fabrikation`:
+
+```markdown
+## Coverage-Metriken (numerisch)
+
+Berechne und berichte jede dieser 3 Metriken:
+
+1. **Coverage** — Anteil abgedeckter Schlüsselthemen aus `academic_context.md`
+   - Schwelle: ≥ 80 %
+   - Formel: `abgedeckte_Themen / gesamte_Schluesselthemen * 100`
+2. **Diversity** — Zahl eigenständiger Autor*innen-Gruppen (Co-Autor-Cluster)
+   - Schwelle: ≥ 5 Gruppen
+   - Zählweise: Autor*innen, die nur untereinander zusammen publizieren, zählen als 1 Gruppe
+3. **Recency** — Anteil Quellen ab Publikationsjahr 2020
+   - Schwelle: ≥ 40 %
+   - Formel: `Quellen_ab_2020 / Gesamtquellen * 100`
+
+Ausgabe: Tabelle Metrik + Ist-Wert + Schwelle + PASS/FAIL + bei FAIL: konkreter
+Verbesserungsvorschlag (welches Thema, welche Autor*innen, welcher Zeitraum fehlt).
+```
+
+- [ ] **Step 6: Verifiziere — alle 5 Skills enthalten PASS/FAIL oder Schwellen**
+
+Run:
+```bash
+grep -l "PASS/FAIL\|Schwelle" skills/advisor/SKILL.md skills/methodology-advisor/SKILL.md skills/submission-checker/SKILL.md skills/style-evaluator/SKILL.md skills/literature-gap-analysis/SKILL.md | wc -l
+```
+
+Expected: `5`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add skills/advisor/SKILL.md skills/methodology-advisor/SKILL.md skills/submission-checker/SKILL.md skills/style-evaluator/SKILL.md skills/literature-gap-analysis/SKILL.md
+git commit -m "$(cat <<'EOF'
+feat(skills): replace vague thresholds with numeric criteria
+
+- advisor: 7-Kriterien-PASS/FAIL-Checkliste
+- methodology-advisor: 4-Dimensionen-Scoring-Matrix (1-5)
+- submission-checker: 8-Punkte-FH-Leibniz-Formalia-Check
+- style-evaluator: 5-Metriken-Fallback-Rubrik mit Schwellen
+- literature-gap-analysis: Coverage/Diversity/Recency numerisch
+
+Teil von #10 / #32. Block C (4/10).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Few-Shot-Paare (Block D, Commit 5)
+
+**Files:**
+- Modify: `skills/research-question-refiner/SKILL.md`
+- Modify: `skills/abstract-generator/SKILL.md`
+- Modify: `skills/title-generator/SKILL.md`
+- Modify: `skills/chapter-writer/SKILL.md`
+
+- [ ] **Step 1: Füge in `skills/research-question-refiner/SKILL.md` 4 Few-Shot-Blöcke ein**
+
+Platzierung: Abschnitt `## Few-Shot-Beispiele` nach den Templates.
+
+Struktur für alle 4 Template-Typen (zu eng / zu weit / nicht-falsifizierbar / mehrdimensional):
+
+```markdown
+## Few-Shot-Beispiele
+
+### Template: Zu eng
+
+**Schlecht** (Grund: Frage lässt keinen Erkenntnisgewinn zu, rein deskriptiv auf einen Fall):
+
+> "Wie hoch war der Umsatz von BMW im Geschäftsjahr 2022?"
+
+**Gut** (Grund: Frage erlaubt Vergleich, Theorie-Anwendung und Erkenntnisgewinn):
+
+> "Welche Faktoren erklären die Umsatzentwicklung deutscher Automobilhersteller
+> 2019–2023 im Vergleich zur Branchenentwicklung?"
+
+### Template: Zu weit
+
+**Schlecht** (Grund: nicht im Bachelor-Zeitrahmen beantwortbar, kein klarer Scope):
+
+> "Wie beeinflusst Digitalisierung die Gesellschaft?"
+
+**Gut** (Grund: klarer Scope, konkreter Kontext, messbare Dimensionen):
+
+> "Wie beeinflusst der Einsatz generativer KI in Hochschulseminaren die
+> Prüfungsleistungen in textbasierten Fächern an der FH Leibniz 2024?"
+
+### Template: Nicht-falsifizierbar
+
+**Schlecht** (Grund: tautologisch/meinungsbasiert, keine empirische Antwort möglich):
+
+> "Ist Nachhaltigkeit wichtig für Unternehmen?"
+
+**Gut** (Grund: falsifizierbar, operationalisierbar):
+
+> "Korreliert die ESG-Rating-Verbesserung börsennotierter DAX-Unternehmen
+> 2018–2024 mit ihrer Aktienkurs-Entwicklung?"
+
+### Template: Mehrdimensional
+
+**Schlecht** (Grund: verknüpft drei eigenständige Fragen in einer):
+
+> "Welche Führungsstile wirken, was kostet ihre Einführung, und wie
+> akzeptieren Mitarbeiter sie?"
+
+**Gut** (Grund: eine Kernfrage, Nebenaspekte als Sub-Questions):
+
+> "Welcher Führungsstil (transformational/transaktional) erklärt
+> Mitarbeiterzufriedenheit in KMU der Metallverarbeitung 2023 am besten?
+> (Nebenaspekte: Einführungskosten, Akzeptanzraten)"
+```
+
+- [ ] **Step 2: Füge in `skills/abstract-generator/SKILL.md` 4 IMRaD-Few-Shot-Blöcke ein**
+
+Platzierung: Abschnitt `## Few-Shot-Beispiele (IMRaD)` nach den Templates.
+
+Format für alle 4 Abschnitte (Introduction / Methods / Results / Conclusion):
+
+```markdown
+## Few-Shot-Beispiele (IMRaD)
+
+### Introduction
+
+**Schlecht** (Grund: keine Forschungslücke, kein Relevanz-Anker):
+
+> "Digitalisierung ist ein wichtiges Thema. Diese Arbeit untersucht
+> Digitalisierung in Unternehmen."
+
+**Gut** (Grund: Lücke + Relevanz + präzise Forschungsfrage in 3 Sätzen):
+
+> "Generative KI verändert Hochschullehre rapide, doch empirische Evidenz
+> zu Prüfungsauswirkungen fehlt. Diese Arbeit untersucht textbasierte
+> Prüfungsleistungen an der FH Leibniz 2024. Forschungsfrage: Beeinflusst
+> der seminaristische KI-Einsatz die Notenverteilung?"
+
+### Methods
+
+**Schlecht** (Grund: Methode nicht reproduzierbar, keine Stichprobe genannt):
+
+> "Es wurde eine Umfrage gemacht und ausgewertet."
+
+**Gut** (Grund: Sample, Instrument, Zeitraum, Auswertung genannt):
+
+> "Quantitative Online-Befragung (LimeSurvey, n=142, FH-Leibniz-Studierende,
+> BWL + Informatik, Mai–Juli 2024). Likert-Items zu KI-Nutzung und
+> Prüfungsnote. Deskriptive Statistik und Chi²-Test in R 4.4."
+
+### Results
+
+**Schlecht** (Grund: keine Zahlen, keine Effektgröße):
+
+> "Die Ergebnisse zeigten einen Zusammenhang zwischen KI-Nutzung und Noten."
+
+**Gut** (Grund: konkrete Effektgröße + Signifikanz + Stichprobe):
+
+> "Studierende mit regelmäßiger KI-Nutzung (n=87) erreichten im Schnitt
+> 0,4 Notenstufen bessere Prüfungsergebnisse (χ²=7,83, p=0,005) als
+> Studierende ohne KI-Nutzung (n=55)."
+
+### Conclusion
+
+**Schlecht** (Grund: überhöhte Generalisierung, keine Limitationen):
+
+> "Die Studie zeigt, dass KI grundsätzlich die Noten verbessert."
+
+**Gut** (Grund: Ergebnis + Einschränkung + Ausblick, 3 Sätze):
+
+> "Regelmäßige KI-Nutzung korreliert positiv mit Prüfungsleistung an der
+> FH Leibniz 2024. Limitationen: Einzelhochschule, Selbstauskunft zur Nutzung,
+> keine Kausalaussage möglich. Folgeforschung sollte experimentelles Design
+> mit Kontrollgruppe prüfen."
+```
+
+- [ ] **Step 3: Füge in `skills/title-generator/SKILL.md` 3 Stil-Few-Shot-Paare ein**
+
+Platzierung: Abschnitt `## Few-Shot-Beispiele (Titelstile)` nach den bestehenden Erklärungen:
+
+```markdown
+## Few-Shot-Beispiele (Titelstile)
+
+### Stil: Deskriptiv
+
+**Schlecht** (Grund: zu allgemein, kein Kontext):
+
+> "Eine Untersuchung zu KI in der Lehre"
+
+**Gut** (Grund: Gegenstand + Methode + Kontext):
+
+> "Einsatz generativer KI in FH-Seminaren: Quantitative Analyse von
+> Prüfungsleistungen im Studienjahr 2024"
+
+### Stil: These
+
+**Schlecht** (Grund: These ohne Bezug zum Scope):
+
+> "KI ist die Zukunft"
+
+**Gut** (Grund: überprüfbare These + Domäne + Qualifikator):
+
+> "Generative KI verbessert Prüfungsleistungen: Evidenz aus einer
+> FH-Stichprobe 2024"
+
+### Stil: Frage
+
+**Schlecht** (Grund: rhetorisch, nicht beantwortet):
+
+> "Sollten Studierende KI nutzen?"
+
+**Gut** (Grund: direkte Forschungsfrage als Titel, empirisch beantwortbar):
+
+> "Wie beeinflusst regelmäßige KI-Nutzung die Prüfungsnoten in BWL- und
+> Informatik-Studiengängen? Eine Erhebung an der FH Leibniz 2024"
+```
+
+- [ ] **Step 4: Füge in `skills/chapter-writer/SKILL.md` 3 Kapiteltyp-Few-Shot-Paare ein**
+
+Platzierung: Abschnitt `## Few-Shot-Beispiele (pro Kapiteltyp)`:
+
+```markdown
+## Few-Shot-Beispiele (pro Kapiteltyp)
+
+### Kapitel: Theorie
+
+**Schlecht** (Grund: Definitionen aneinandergereiht, keine Struktur-Argumentation):
+
+> "Führung ist wichtig. Transformationale Führung ist eine Führungsart.
+> Sie wurde von Bass beschrieben."
+
+**Gut** (Grund: Definition + Einordnung + Abgrenzung, mit Beleg):
+
+> "Transformationale Führung bezeichnet ein Führungskonzept, bei dem
+> Vorgesetzte Mitarbeiter durch Vision und individuelle Förderung über
+> transaktionale Anreize hinaus motivieren (Bass 1985, S. 22). Abgrenzung
+> zur transaktionalen Führung: Transaktional beruht auf Leistungs-
+> Gegenleistungs-Tausch, transformational auf intrinsischer Motivation
+> (Bass & Riggio 2006)."
+
+### Kapitel: Methoden
+
+**Schlecht** (Grund: keine Begründung, keine Operationalisierung):
+
+> "Wir haben eine Umfrage gemacht."
+
+**Gut** (Grund: Wahl + Begründung + Operationalisierung + Grenzen):
+
+> "Gewählt wurde ein standardisierter Online-Fragebogen, weil nur so die
+> angestrebte Stichprobengröße n ≥ 100 im Zeitrahmen erreichbar war.
+> Führungsstil wurde mittels MLQ-5X operationalisiert (Avolio & Bass
+> 2004). Limitation: Selbstauskunft der Mitarbeiter zur Führungs-
+> Wahrnehmung, keine Beobachtungsdaten."
+
+### Kapitel: Diskussion
+
+**Schlecht** (Grund: Ergebnis-Wiederholung ohne Einordnung):
+
+> "Die Umfrage hat gezeigt, dass transformationale Führung besser wirkt.
+> Das passt zu den Erwartungen."
+
+**Gut** (Grund: Befund + Literatur-Kontext + Abweichungs-Erklärung):
+
+> "Der gefundene positive Effekt transformationaler Führung auf
+> Mitarbeiterzufriedenheit (β=0,38, p<0,01) deckt sich mit der Meta-
+> Analyse von Judge & Piccolo (2004), fällt aber schwächer aus als dort
+> berichtet (β=0,59). Mögliche Erklärung: Branchenspezifika in
+> Metallverarbeitung (hohe Arbeitsteilung) dämpfen Führungseffekte —
+> konsistent mit Liao & Chuang (2007)."
+```
+
+- [ ] **Step 5: Verifiziere — 4 Skills enthalten je `**Schlecht**` und `**Gut**`**
+
+Run:
+```bash
+grep -c '^\*\*Schlecht\*\*' skills/research-question-refiner/SKILL.md skills/abstract-generator/SKILL.md skills/title-generator/SKILL.md skills/chapter-writer/SKILL.md
+```
+
+Expected-Werte:
+- `research-question-refiner/SKILL.md:4` (4 Templates)
+- `abstract-generator/SKILL.md:4` (4 IMRaD-Abschnitte)
+- `title-generator/SKILL.md:3` (3 Stile)
+- `chapter-writer/SKILL.md:3` (3 Kapiteltypen)
+
+Jede Zeile > 0, insgesamt Summe 14.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add skills/research-question-refiner/SKILL.md skills/abstract-generator/SKILL.md skills/title-generator/SKILL.md skills/chapter-writer/SKILL.md
+git commit -m "$(cat <<'EOF'
+feat(skills): add few-shot good/bad example pairs
+
+- research-question-refiner: 4 Template-Paare (zu eng / zu weit /
+  nicht-falsifizierbar / mehrdimensional)
+- abstract-generator: 4 IMRaD-Paare (Intro/Methods/Results/Conclusion)
+- title-generator: 3 Stil-Paare (deskriptiv/These/Frage)
+- chapter-writer: 3 Kapiteltyp-Paare (Theorie/Methoden/Diskussion)
+
+Format pro Paar: Schlecht + Grund + Beispiel // Gut + Grund + Beispiel.
+
+Teil von #10 / #33. Block D (5/10).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Memory-Precondition-Checks (Block E, Commit 6)
+
+**Files:**
+- Modify: 12 Skills (alle außer `skills/academic-context/SKILL.md`)
+
+- [ ] **Step 1: Füge in jeder betroffenen SKILL.md den Abschnitt `## Vorbedingungen` ein**
+
+Platzierung: **vor dem Abschnitt `## Keine Fabrikation`** (Task 3) — direkt nach dem Einleitungsabsatz.
+
+Template:
+
+```markdown
+## Vorbedingungen
+
+Bevor du startest: Prüfe, ob `academic_context.md` und `literature_state.md`
+vorhanden und aktuell sind. Fehlt Kontext → triggere den `academic-context`-
+Skill und warte auf dessen Abschluss.
+
+Lehnt der User den Trigger ab → brich diesen Skill ab und erkläre:
+"Ohne [KONKRET-FEHLENDE-DATEN] kann ich keine [SKILL-LIEFERUNG] liefern,
+weil ich [KONSEQUENZ] riskieren würde."
+```
+
+**Tabelle: Skill-spezifische Abbruchbegründung (ersetzt die Platzhalter in eckigen Klammern):**
+
+| Skill | KONKRET-FEHLENDE-DATEN | SKILL-LIEFERUNG | KONSEQUENZ |
+|---|---|---|---|
+| `abstract-generator` | Forschungsfrage und Methodik-Angabe | belastbares Abstract | ein erfundenes Thema beschreiben |
+| `advisor` | Forschungsfrage und Kapitelstruktur | fundierte Outline-Beratung | gegen unbekannte Vorgaben beraten |
+| `chapter-writer` | Kapitelstruktur in `literature_state.md` | passenden Kapiteltext | Kapiteltyp annehmen, der nicht zur Arbeit passt |
+| `citation-extraction` | Quellenliste in `literature_state.md` | Zitate mit Zuordnung | Zitate zu nicht-registrierten Quellen bauen |
+| `literature-gap-analysis` | Themenliste in `academic_context.md` | Gap-Bewertung | gegen unbekannte Ziele vergleichen |
+| `methodology-advisor` | Forschungsfrage und Datenzugriffs-Infos | Methoden-Empfehlung | Methoden empfehlen, die die Frage nicht beantworten |
+| `plagiarism-check` | Quellenlisten in `literature_state.md` | Similarity-Urteil | gegen unbekannte Quellen prüfen und False-Negatives produzieren |
+| `research-question-refiner` | Thema und Kontext in `academic_context.md` | Fragen-Schärfung | gegen unbekannte Disziplin-Konventionen optimieren |
+| `source-quality-audit` | Quellenliste in `literature_state.md` | Qualitätsurteil | gegen leere Menge urteilen |
+| `style-evaluator` | Text-Korpus-Kontext in `writing_state.md` | Stil-Urteil | gegen disziplinfremde Normen urteilen |
+| `submission-checker` | FH-Zuordnung in `academic_context.md` | Formalia-Check | gegen falsches FH-Regelwerk prüfen |
+| `title-generator` | Forschungsfrage und Kernergebnisse | Titel-Vorschläge | leere Titel-Hülsen ohne Verankerung liefern |
+
+Konkretes Beispiel für `skills/abstract-generator/SKILL.md`:
+
+```markdown
+## Vorbedingungen
+
+Bevor du startest: Prüfe, ob `academic_context.md` und `literature_state.md`
+vorhanden und aktuell sind. Fehlt Kontext → triggere den `academic-context`-
+Skill und warte auf dessen Abschluss.
+
+Lehnt der User den Trigger ab → brich diesen Skill ab und erkläre:
+"Ohne Forschungsfrage und Methodik-Angabe kann ich kein belastbares Abstract
+liefern, weil ich ein erfundenes Thema beschreiben würde."
+```
+
+- [ ] **Step 2: Verifiziere — 12 Skills enthalten `## Vorbedingungen`, `academic-context` nicht**
+
+Run:
+```bash
+grep -l "^## Vorbedingungen$" skills/*/SKILL.md | wc -l
+```
+Expected: `12`
+
+Run:
+```bash
+grep -L "^## Vorbedingungen$" skills/*/SKILL.md
+```
+Expected: genau eine Zeile: `skills/academic-context/SKILL.md`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/abstract-generator/SKILL.md skills/advisor/SKILL.md skills/chapter-writer/SKILL.md skills/citation-extraction/SKILL.md skills/literature-gap-analysis/SKILL.md skills/methodology-advisor/SKILL.md skills/plagiarism-check/SKILL.md skills/research-question-refiner/SKILL.md skills/source-quality-audit/SKILL.md skills/style-evaluator/SKILL.md skills/submission-checker/SKILL.md skills/title-generator/SKILL.md
+git commit -m "$(cat <<'EOF'
+feat(skills): add memory precondition checks with hard-abort
+
+Jeder Skill (ausser academic-context selbst) prueft zuerst academic_context.md
+und literature_state.md. Fehlt Kontext und User lehnt academic-context-Trigger
+ab -> harter Abbruch mit skill-spezifischer Begruendung.
+
+Teil von #10 / #34. Block E (6/10).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Skill-Abgrenzung `literature-gap-analysis` ↔ `source-quality-audit` (Block F, Commit 7)
+
+**Files:**
+- Modify: `skills/literature-gap-analysis/SKILL.md`
+- Modify: `skills/source-quality-audit/SKILL.md`
+
+- [ ] **Step 1: Füge in `skills/source-quality-audit/SKILL.md` den Abschnitt `## Abgrenzung` ein**
+
+Platzierung: direkt nach `## Vorbedingungen` und `## Keine Fabrikation`, vor den fachlichen Abschnitten:
+
+```markdown
+## Abgrenzung
+
+Dieser Skill bewertet **einzelne Quellen** auf:
+- Impact-Faktor / SJR / SNIP der Publikationsquelle
+- Methodik der Einzelquelle (empirisch / theoretisch / Review / Primär-/Sekundär)
+- Peer-Review-Status
+- Aktualität der Einzelquelle
+
+Für die Bewertung der **Korpus-Vollständigkeit** (fehlende Themen, fehlende
+Autor*innen-Gruppen, fehlende Methoden, fehlende Zeitperioden, disziplinäre
+Blindstellen) → `literature-gap-analysis`.
+
+Beide Skills greifen auf `literature_state.md` zu, aber mit unterschiedlichem
+Fokus. Wenn der User "Coverage" oder "Gaps" erwähnt → delegiere an
+`literature-gap-analysis`.
+```
+
+- [ ] **Step 2: Füge in `skills/literature-gap-analysis/SKILL.md` den Abschnitt `## Abgrenzung` ein**
+
+Platzierung: gleich wie in Task 7 Step 1:
+
+```markdown
+## Abgrenzung
+
+Dieser Skill bewertet **Korpus-Vollständigkeit**:
+- Fehlende Schlüsselthemen aus `academic_context.md`
+- Fehlende Autor*innen-Gruppen (Cluster-Diversität)
+- Fehlende Methoden-Perspektiven (qualitativ/quantitativ/mixed)
+- Fehlende Zeitperioden (Aktualitäts-Lücken)
+- Fehlende disziplinäre Sichtweisen (Mono- vs. Multi-Disziplinarität)
+
+Für die Bewertung **einzelner Quellen** (Impact, Methodik der Einzelquelle,
+Peer-Review-Status) → `source-quality-audit`.
+
+Beide Skills greifen auf `literature_state.md` zu, aber mit unterschiedlichem
+Fokus. Wenn der User "Peer-Review" oder "Quellenqualität einzelner Artikel"
+erwähnt → delegiere an `source-quality-audit`.
+```
+
+- [ ] **Step 3: Verifiziere — beide Skills enthalten `## Abgrenzung`**
+
+Run:
+```bash
+grep -l "^## Abgrenzung$" skills/literature-gap-analysis/SKILL.md skills/source-quality-audit/SKILL.md | wc -l
+```
+Expected: `2`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/literature-gap-analysis/SKILL.md skills/source-quality-audit/SKILL.md
+git commit -m "$(cat <<'EOF'
+fix(skills): clarify boundary between gap-analysis and quality-audit
+
+Beide Skills erhalten einen Abschnitt '## Abgrenzung' mit:
+- klarer Zustaendigkeits-Definition (Einzelquelle vs. Korpus)
+- Kriterien-Liste was in welchem Skill gehoert
+- Cross-Reference mit Delegations-Hinweis
+
+Teil von #10 / #35. Block F (7/10).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Umlaut-Varianten in Trigger-Descriptions (Block G, Commit 8)
+
+**Files:**
+- Modify: alle 13 `skills/*/SKILL.md` (Frontmatter-`description:`-Zeile)
+
+- [ ] **Step 1: Regel festhalten**
+
+Jedes deutsche Trigger-Keyword mit Umlaut (ä, ö, ü, ß) wird in der Description in beiden Schreibweisen geführt, getrennt durch ` / `:
+
+- `"prüfen"` → `"prüfen / pruefen"`
+- `"Quellenqualität"` → `"Quellenqualität / Quellenqualitaet"`
+- `"Literaturlücken"` → `"Literaturlücken / Literaturluecken"`
+- `"Überschrift"` → `"Überschrift / Ueberschrift"`
+- `"Schlagwörter"` → `"Schlagwörter / Schlagwoerter"`
+- `"ß"` → `"ss"` (z. B. `"Größe / Groesse"`)
+
+Keywords ohne Umlaut bleiben einfach. Englisch-Keywords bleiben einfach.
+
+- [ ] **Step 2: Aktualisiere die Descriptions pro Skill**
+
+Folgend die Soll-Descriptions (nur Trigger-Keyword-Segment, Fließtext davor bleibt bestehen):
+
+**`skills/source-quality-audit/SKILL.md`:**
+```yaml
+description: … Triggers on "Quellenqualität / Quellenqualitaet", "Quellen-Check", "Literaturqualität prüfen / Literaturqualitaet pruefen", "Source audit", "Quellenbewertung", "literature quality", "Quellenmix", "peer-reviewed Anteil", …
+```
+
+**`skills/literature-gap-analysis/SKILL.md`:**
+```yaml
+description: … Triggers on "Literaturlücken / Literaturluecken", "Coverage", "fehlende Quellen", "Gap Analysis", "Quellenabdeckung", "literature gaps", "missing sources", "Abdeckung prüfen / Abdeckung pruefen", …
+```
+
+**`skills/abstract-generator/SKILL.md`:**
+```yaml
+description: … Triggers on "Abstract schreiben", "Zusammenfassung", "Keywords", "Management Summary", "Abstract generieren", "paper summary", "Schlagwörter / Schlagwoerter", "executive summary", …
+```
+
+**`skills/title-generator/SKILL.md`:**
+```yaml
+description: … Triggers on "Titel suchen", "Titelvorschläge / Titelvorschlaege", "Arbeitstitel", "title suggestions", "Titel finden", "paper title", "Überschrift / Ueberschrift", …
+```
+
+**`skills/plagiarism-check/SKILL.md`:**
+```yaml
+description: … Triggers on "Plagiat prüfen / Plagiat pruefen", "Textähnlichkeit / Textaehnlichkeit", "Paraphrase checken", "plagiarism", "zu nah am Original", "Plagiatsprüfung / Plagiatspruefung", "source similarity", "text similarity check", …
+```
+
+**`skills/submission-checker/SKILL.md`:**
+```yaml
+description: … Triggers on "formale Prüfung / formale Pruefung", "Abgabe-Check", "Formatierung prüfen / Formatierung pruefen", "abgabefertig", "submission check", "formal requirements", "Deckblatt prüfen / Deckblatt pruefen", "Eidesstattliche Erklärung / Eidesstattliche Erklaerung", "Seitenränder / Seitenraender", "Formatvorlage", …
+```
+
+**`skills/style-evaluator/SKILL.md`:**
+```yaml
+description: … Triggers on "Text prüfen / Text pruefen", "Stil-Check", "KI-Erkennung", "Text verbessern", "Qualitätskontrolle / Qualitaetskontrolle", "menschlich klingen", "style check", "AI detection", "text quality", "improve writing", "human-like", …
+```
+
+**`skills/methodology-advisor/SKILL.md`:**
+```yaml
+description: … Triggers on "Methodik", "Forschungsdesign", "Methodenwahl", "Vorgehensmodell", "research design", "methodology", "qualitative vs quantitative", "Forschungsmethode", …
+```
+
+(keine Umlaute in den bestehenden Triggern — bleibt unverändert, wird aber in der Verifikation zusätzlich geprüft ob neu `Methodik prüfen / Methodik pruefen` vorhanden ist)
+
+Füge hinzu: `"Methodik prüfen / Methodik pruefen", "Methoden-Check"`
+
+**`skills/advisor/SKILL.md`:**
+```yaml
+description: … Triggers on "Gliederung", "Outline", "Exposé / Expose", "Struktur", "Kapitelplanung", "thesis structure", "chapter planning", "Aufbau der Arbeit", "Gliederung prüfen / Gliederung pruefen", …
+```
+
+**`skills/chapter-writer/SKILL.md`:**
+```yaml
+description: … Triggers on "Kapitel schreiben", "verfassen", "entwerfen", "Abschnitt schreiben", "write chapter", "draft section", "Kapitel formulieren", "Textarbeit", "Kapitelentwurf prüfen / Kapitelentwurf pruefen", …
+```
+
+**`skills/citation-extraction/SKILL.md`:**
+```yaml
+description: … Triggers on "Zitate finden", "zitieren", "Quellenarbeit", "Belege suchen", "citations", "Zitate extrahieren", "quote extraction", "Literaturverzeichnis prüfen / Literaturverzeichnis pruefen", "bibliography", …
+```
+
+**`skills/research-question-refiner/SKILL.md`:**
+```yaml
+description: … Triggers on "Forschungsfrage formulieren", "Research Question", "Fragestellung", "Forschungsfrage", "Forschungsfrage schärfen / Forschungsfrage schaerfen", "research question refine", "Fragestellung präzisieren / Fragestellung praezisieren", …
+```
+
+**`skills/academic-context/SKILL.md`:**
+```yaml
+description: … Triggers on "meine Arbeit", "mein Thema", "Forschungsfrage", "Gliederung", "thesis context", "academic profile", …
+```
+
+(keine Umlaute in bestehenden Triggern — aber ergänze: `"akademischer Kontext prüfen / akademischer Kontext pruefen"`)
+
+- [ ] **Step 3: Verifiziere — jede der 13 Descriptions enthält mindestens 1 Umlaut/ASCII-Paar**
+
+Hilfs-Python-Oneliner (vermeidet fehleranfällige grep-Regexe):
+
+```bash
+python3 - <<'EOF'
+import re, sys
+from pathlib import Path
+
+skills = sorted(Path("skills").glob("*/SKILL.md"))
+fails = []
+for skill in skills:
+    content = skill.read_text()
+    m = re.search(r"^description:\s*(.+)$", content, re.MULTILINE)
+    if not m:
+        fails.append(f"{skill}: kein description-Feld")
+        continue
+    desc = m.group(1)
+    pairs = re.findall(r'"[^"]*[äöüß][^"]*"\s*/\s*[a-zA-Z]', desc)
+    if len(pairs) < 1:
+        fails.append(f"{skill}: 0 Umlaut-Paare")
+if fails:
+    print("FAIL:")
+    for f in fails:
+        print("  " + f)
+    sys.exit(1)
+print(f"OK: alle {len(skills)} Skills haben >=1 Umlaut-Paar")
+EOF
+```
+
+Expected: `OK: alle 13 Skills haben >=1 Umlaut-Paar`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/*/SKILL.md
+git commit -m "$(cat <<'EOF'
+fix(skills): add umlaut variants in trigger descriptions
+
+Jedes deutsche Trigger-Keyword mit Umlaut (ae/oe/ue/ss) steht jetzt in beiden
+Schreibweisen in der Description. Grund: User tippt mit Umlauten (macOS),
+reine ASCII-Trigger matchen schlechter.
+
+Teil von #10 / #36. Block G (8/10).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: 8 Einzelprobleme aus dem Skill-Review (Block H, Commit 9)
+
+**Files:**
+- Modify: `agents/quote-extractor.md` (H.2)
+- Modify: `agents/query-generator.md` (H.3)
+- Modify: `skills/abstract-generator/SKILL.md` (H.6)
+
+Status der übrigen Punkte:
+- H.1, H.8 → bereits in E2 erledigt (nur Sprache in Task 2 geprüft)
+- H.4 → durch Block C (Task 4) abgedeckt
+- H.5 → durch Block D (Task 5) abgedeckt
+- H.7 → durch Block C (Task 4) abgedeckt
+
+- [ ] **Step 1: H.2 — `agents/quote-extractor.md` Pre-Execution-Guard härten**
+
+Lies `agents/quote-extractor.md` Zeilen 28–33 und ersetze den bestehenden Pre-Execution-Guard durch:
+
+```markdown
+## Vorprüfung
+
+Bevor du die Extraktion startest, prüfe die PDF-Quelle:
+
+1. **Wortanzahl** ≥ 500 (via PyPDF2 Seiten-Text zusammengefügt, tokenisiert auf Whitespace).
+   Bei < 500 → Abbruch mit Meldung: "PDF enthält nur X Wörter — zu kurz für
+   belastbare Zitat-Extraktion. Vermutlich Extraktions-Fehler oder Scan ohne OCR."
+2. **Fehler-Marker** im normalisierten Text: `[FEHLER]`, `extraction failed`,
+   `<scanned image>`, `PDF encoded`. Bei Treffer → Abbruch mit Meldung:
+   "PDF-Text enthält Extraktions-Fehlermarker. Liefere ein sauberes PDF oder
+   führe zuerst OCR aus."
+3. **Mindest-Seitenzahl** ≥ 2. Bei 1 Seite → Warnung ausgeben, nicht abbrechen.
+
+Nur nach bestandener Vorprüfung weiter mit Zitat-Extraktion.
+```
+
+- [ ] **Step 2: H.3 — `agents/query-generator.md` CS-Disambiguierung**
+
+Lies `agents/query-generator.md` Zeilen 114–126 und ersetze den CS-Abschnitt durch:
+
+```markdown
+## Disambiguierung: "CS"-Abkürzung
+
+Der Buchstabencode "CS" ist mehrdeutig. Prüfe den Fachkontext aus
+`academic_context.md`, um zu entscheiden:
+
+- **CS in Informatik, IT, Rechnerarchitektur, Software Engineering** →
+  "Computer Science" (Synonyme für Query: "Informatik", "computer science",
+  "CS research")
+- **CS in Medizin, Psychologie** → "Case Series" (Synonyme: "Fallserie",
+  "case series study")
+- **CS in Rechtswissenschaft, Management** → "Case Study" (Synonyme:
+  "Fallstudie", "case study analysis")
+- **CS in Biochemie, Chemie** → "Citrate Synthase" (Synonym: "Zitrat-Synthase")
+
+Wenn der Kontext keine klare Zuordnung erlaubt → frag den User ("Meinst du
+mit 'CS' Computer Science, Case Study, Case Series oder etwas anderes?"),
+rate nicht.
+
+Kein Code-Switch in der Ausgabe: der User bekommt deutsche Erklärungen,
+nicht "CS = Computer Science".
+```
+
+- [ ] **Step 3: H.6 — `skills/abstract-generator/SKILL.md` Default-String deutsch**
+
+Lies `skills/abstract-generator/SKILL.md` und ersetze den englischen Default-String:
+
+Alt: `"Preliminary, pending validation"`  
+Neu: `"Vorläufig, Validierung ausstehend"`
+
+Alle Vorkommen in der Datei ersetzen, auch in Beispielen und Fallback-Klauseln.
+
+- [ ] **Step 4: Verifiziere alle 3 Änderungen**
+
+Run:
+```bash
+grep -c "Wortanzahl.*500" agents/quote-extractor.md
+# Expected: >= 1
+
+grep -c "Disambiguierung.*CS" agents/query-generator.md
+# Expected: >= 1
+
+grep -c "Preliminary, pending validation" skills/abstract-generator/SKILL.md
+# Expected: 0
+
+grep -c "Vorläufig, Validierung ausstehend" skills/abstract-generator/SKILL.md
+# Expected: >= 1
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agents/quote-extractor.md agents/query-generator.md skills/abstract-generator/SKILL.md
+git commit -m "$(cat <<'EOF'
+fix(agents+skills): address remaining skill-review issues (H.2, H.3, H.6)
+
+- quote-extractor: Pre-Execution-Guard haerter (Wortzahl >= 500,
+  Fehler-Marker-Check, Seitenzahl >= 2)
+- query-generator: CS-Disambiguierung mit 4 Fachkontext-Varianten,
+  Code-Switch raus
+- abstract-generator: Default-String 'Preliminary, pending validation'
+  -> 'Vorlaeufig, Validierung ausstehend'
+
+H.1 und H.8 sind in E2 bereits erledigt, H.4/H.5/H.7 durch Blocks C/D
+abgedeckt.
+
+Teil von #10 / #37. Block H (9/10).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: Smoke-Test `test_skills_manifest.py` (Commit 9.5, zusätzlich)
+
+**Files:**
+- Create: `tests/test_skills_manifest.py`
+
+- [ ] **Step 1: Schreibe den Smoke-Test**
+
+```python
+"""Smoke-Test fuer Skill-Manifest-Struktur nach E3-Prompt-Quality-Refactor.
+
+Prueft jede skills/*/SKILL.md auf:
+- valides YAML-Frontmatter mit name + description
+- '## Vorbedingungen'-Sektion (ausser academic-context)
+- '## Keine Fabrikation'-Sektion (alle 13)
+- >= 1 Umlaut-Paar ('Xae|Xoe|Xue' Muster) in description
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+SKILLS_DIR = Path(__file__).parent.parent / "skills"
+ALL_SKILLS = sorted(SKILLS_DIR.glob("*/SKILL.md"))
+SKILLS_WITH_PRECONDITION = [p for p in ALL_SKILLS if p.parent.name != "academic-context"]
+
+
+def _frontmatter(path: Path) -> dict:
+    text = path.read_text()
+    m = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
+    if not m:
+        return {}
+    fm = {}
+    for line in m.group(1).splitlines():
+        if ":" in line:
+            key, _, val = line.partition(":")
+            fm[key.strip()] = val.strip()
+    return fm
+
+
+@pytest.mark.parametrize("skill_path", ALL_SKILLS, ids=lambda p: p.parent.name)
+def test_frontmatter_valid(skill_path: Path) -> None:
+    fm = _frontmatter(skill_path)
+    assert fm.get("name"), f"{skill_path}: name fehlt"
+    assert fm.get("description"), f"{skill_path}: description fehlt"
+
+
+@pytest.mark.parametrize("skill_path", ALL_SKILLS, ids=lambda p: p.parent.name)
+def test_no_fabrication_section(skill_path: Path) -> None:
+    assert "\n## Keine Fabrikation\n" in skill_path.read_text(), (
+        f"{skill_path}: '## Keine Fabrikation' fehlt"
+    )
+
+
+@pytest.mark.parametrize("skill_path", SKILLS_WITH_PRECONDITION, ids=lambda p: p.parent.name)
+def test_precondition_section(skill_path: Path) -> None:
+    assert "\n## Vorbedingungen\n" in skill_path.read_text(), (
+        f"{skill_path}: '## Vorbedingungen' fehlt"
+    )
+
+
+@pytest.mark.parametrize("skill_path", ALL_SKILLS, ids=lambda p: p.parent.name)
+def test_umlaut_variants_in_description(skill_path: Path) -> None:
+    fm = _frontmatter(skill_path)
+    desc = fm.get("description", "")
+    pairs = re.findall(r'"[^"]*[äöüß][^"]*"\s*/\s*[a-zA-Z]', desc)
+    assert len(pairs) >= 1, (
+        f"{skill_path}: 0 Umlaut-Paare in description (gefunden: {desc[:120]}...)"
+    )
+```
+
+- [ ] **Step 2: Test ausführen**
+
+Run:
+```bash
+~/.academic-research/venv/bin/pip install -q pytest
+~/.academic-research/venv/bin/pytest tests/test_skills_manifest.py -v
+```
+
+Expected: alle Tests grün (4 Test-Funktionen × 13 Skills = 52 Tests, minus 1 für precondition-ohne-academic-context = 51 bestandene Assertions).
+
+Bei Fehler: Skill-Inhalt an der genannten Stelle nachziehen, Test erneut laufen lassen.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_skills_manifest.py
+git commit -m "$(cat <<'EOF'
+test(skills): add skill manifest smoke test
+
+Prueft pro skills/*/SKILL.md:
+- Frontmatter enthaelt name + description
+- '## Keine Fabrikation' vorhanden (alle 13)
+- '## Vorbedingungen' vorhanden (12, ausser academic-context)
+- description enthaelt >= 1 Umlaut/ASCII-Paar
+
+52 parametrisierte Tests.
+
+Teil von #10.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 11: Skill-Reviewer-Run + Release v5.1.0 (Commit 10)
+
+**Files:**
+- Modify: `.claude-plugin/plugin.json`
+- Modify: `.claude-plugin/marketplace.json`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Skill-Reviewer-Subagent über alle 13 Skills laufen lassen**
+
+Dispatch:
+```
+Agent subagent_type=plugin-dev:skill-reviewer
+Prompt: "Review alle 13 SKILL.md unter skills/ gegen die Best-Practice-Checkliste
+(Trigger-Qualitaet, Description-Struktur, Sektions-Vollstaendigkeit). Fokus:
+- Sind die Trigger-Keywords diskriminierend genug?
+- Gibt es Ueberschneidungen zwischen Skills, die nicht im '## Abgrenzung'-Abschnitt adressiert sind?
+- Sind '## Keine Fabrikation' und '## Vorbedingungen' konsistent formuliert?
+Report: Kritische Findings sofort, Major-Findings strukturiert, Nitpicks am Ende.
+Unter 300 Woerter."
+```
+
+Findings:
+- **Critical**: sofort im aktuellen Task fixen, bevor Release
+- **Major**: nachziehen in Follow-up-Commit vor Release
+- **Nitpick**: notieren, keine Handlung vor Release
+
+- [ ] **Step 2: Version bumpen in `.claude-plugin/plugin.json`**
+
+Ändere `"version": "5.0.1"` → `"version": "5.1.0"`
+
+- [ ] **Step 3: Version bumpen in `.claude-plugin/marketplace.json`**
+
+Ändere `"version": "5.0.1"` → `"version": "5.1.0"`
+
+- [ ] **Step 4: CHANGELOG-Eintrag ergänzen**
+
+Füge oben in `CHANGELOG.md` vor dem `[5.0.1]`-Block folgenden Block ein (Datum = heute):
+
+```markdown
+## [5.1.0] — 2026-04-YY
+
+### Added
+
+- **Anti-Fabrikations-Klauseln** in allen 13 Skills (Block B). Cookbook-Stil mit FH-Leibniz-spezifischer Konsequenz pro Skill (Plagiatsbefund, Note 5 für Forschungsdesign, Täuschungsversuch nach Prüfungsordnung, …).
+- **Memory-Precondition-Checks** in 12 Skills (Block E, außer `academic-context` selbst). Harter Abbruch, wenn `academic_context.md`/`literature_state.md` fehlt und der User den `academic-context`-Trigger ablehnt.
+- **Few-Shot-Paare (Gut/Schlecht)** in 4 Skills (Block D): `research-question-refiner` (4 Template-Typen), `abstract-generator` (4 IMRaD-Abschnitte), `title-generator` (3 Stile), `chapter-writer` (3 Kapiteltypen).
+- **Skill-Abgrenzung** zwischen `literature-gap-analysis` und `source-quality-audit` (Block F). Jeweils ein `## Abgrenzung`-Abschnitt mit Kriterien-Liste und Delegations-Hinweis.
+- Smoke-Test `tests/test_skills_manifest.py` (52 parametrisierte Tests für Frontmatter, Sektions-Vollständigkeit, Umlaut-Paare).
+
+### Changed
+
+- **Sprache einheitlich Deutsch** in allen 13 Skills, 5 Commands, 3 Agents (Block A). Englisch bleibt nur in Code, Pfaden, JSON-Keys, Frontmatter-Keys, Code-Kommentaren und Shell-Kommandos.
+- **Numerische Schwellen** in 5 Skills (Block C):
+  - `advisor`: 7-Kriterien-PASS/FAIL-Checkliste statt "common academic standards"
+  - `methodology-advisor`: 4-Dimensionen-Scoring-Matrix (1–5)
+  - `submission-checker`: 8-Punkte-FH-Leibniz-Formalia-Check (Seitenränder 2,5 cm, Schrift Times 12 pt/Arial 11 pt, Zeilenabstand 1,5, …)
+  - `style-evaluator`: 5-Metriken-Fallback-Rubrik (Satzlänge 15–25 Wörter, Passiv < 30 %, Nominal < 40 %, Füllwörter < 5 %, 0 Code-Switches)
+  - `literature-gap-analysis`: Coverage ≥ 80 %, Diversity ≥ 5 Gruppen, Recency ≥ 40 % ab 2020
+- **Umlaut-Varianten** in allen 13 Skill-Trigger-Descriptions (Block G): `"Quellenqualität / Quellenqualitaet"`, `"prüfen / pruefen"` etc.
+
+### Fixed
+
+- `agents/quote-extractor.md`: robusterer Pre-Execution-Guard (PDF-Wortzahl ≥ 500, Fehler-Marker-Check, Seitenzahl ≥ 2) (Block H.2).
+- `agents/query-generator.md`: CS-Disambiguierung mit 4 Fachkontext-Varianten, Code-Switch entfernt (Block H.3).
+- `skills/abstract-generator/SKILL.md`: Default-String `"Preliminary, pending validation"` → `"Vorläufig, Validierung ausstehend"` (Block H.6).
+
+### Migration
+
+Keine Migration nötig. Skills laufen sofort nach Update weiter, werden nur präziser und deutscher. `academic-context`-Skill bleibt rückwärtskompatibel mit älterem Memory-Format.
+```
+
+- [ ] **Step 5: Verifiziere Version-Bump und Changelog**
+
+Run:
+```bash
+grep '"version"' .claude-plugin/plugin.json .claude-plugin/marketplace.json
+# Expected: beide "5.1.0"
+
+grep '^## \[5.1.0\]' CHANGELOG.md
+# Expected: 1 Treffer
+```
+
+- [ ] **Step 6: Commit + Push Branch**
+
+```bash
+git add .claude-plugin/plugin.json .claude-plugin/marketplace.json CHANGELOG.md
+git commit -m "$(cat <<'EOF'
+chore(release): v5.1.0 — E3 prompt quality refactor
+
+Bumps version 5.0.1 -> 5.1.0. CHANGELOG-Eintrag fasst alle 9
+Implementierungs-Commits zusammen:
+- Added: Anti-Fabrikation, Memory-Precondition, Few-Shots, Abgrenzung, Smoke-Test
+- Changed: Sprache Deutsch, numerische Schwellen, Umlaut-Varianten
+- Fixed: 3 Block-H-Einzelprobleme (quote-extractor, query-generator, abstract-generator)
+
+Keine Breaking Changes, keine Migration.
+
+Closes #10.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+
+git push -u origin refactor/e3-prompt-quality
+```
+
+- [ ] **Step 7: PR erstellen**
+
+```bash
+gh pr create --title "refactor: E3 prompt quality (v5.1.0)" --body "$(cat <<'EOF'
+## Zusammenfassung
+
+Epic 3 — Prompt-Qualitäts-Refactor. Reine Text/Prompt-Änderungen in 13 Skills,
+5 Commands, 3 Agents. Keine Python-, Interface- oder Breaking Changes.
+
+## Enthaltene Blöcke
+
+- **A:** Sprach-Vereinheitlichung auf Deutsch
+- **B:** Anti-Fabrikations-Klauseln mit FH-Leibniz-spezifischer Begründung
+- **C:** Numerische Schwellen in 5 Skills
+- **D:** Few-Shot-Paare (Gut/Schlecht) in 4 Skills
+- **E:** Memory-Precondition-Checks (harter Abbruch) in 12 Skills
+- **F:** Abgrenzung `literature-gap-analysis` ↔ `source-quality-audit`
+- **G:** Umlaut-Varianten in Trigger-Descriptions
+- **H:** 3 Einzelprobleme (quote-extractor, query-generator, abstract-generator)
+
+## Testplan
+
+- [ ] `tests/test_skills_manifest.py` grün (52 Tests)
+- [ ] `tests/test_dedup.py` und `tests/test_search.py` weiterhin grün
+- [ ] Skill-Reviewer-Findings adressiert
+
+Closes #10 #30 #31 #32 #33 #34 #35 #36 #37
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 8: PR mergen, Tag setzen, Tickets schließen**
+
+```bash
+gh pr merge --squash --delete-branch
+git checkout main
+git pull --ff-only origin main
+git tag -a v5.1.0 -m "v5.1.0 — E3 prompt quality refactor"
+git push origin v5.1.0
+```
+
+Tickets-Auto-Close prüfen:
+```bash
+for n in 10 30 31 32 33 34 35 36 37; do
+  state=$(gh issue view "$n" --json state -q .state)
+  echo "#$n: $state"
+done
+```
+
+Falls nicht alle `CLOSED`:
+```bash
+gh issue close <nummer> --comment "Resolved by PR <nr>, merged in v5.1.0."
+```
+
+---
+
+## Self-Review (Inline nach Plan-Abschluss)
+
+### 1. Spec-Coverage
+
+| Spec-Abschnitt | Plan-Task |
+|---|---|
+| Block A (Sprache 13 Skills) | Task 1 |
+| Block A (Sprache Commands+Agents) | Task 2 |
+| Block B (Anti-Fabrikation) | Task 3 |
+| Block C (Numerik) | Task 4 |
+| Block D (Few-Shots) | Task 5 |
+| Block E (Memory-Precondition) | Task 6 |
+| Block F (Boundary) | Task 7 |
+| Block G (Umlaute) | Task 8 |
+| Block H.2 + H.3 + H.6 | Task 9 |
+| Smoke-Test `tests/test_skills_manifest.py` | Task 10 |
+| Skill-Reviewer-Run | Task 11 Step 1 |
+| Version-Bump + CHANGELOG + Tag + PR + Tickets | Task 11 Steps 2–8 |
+
+Alle Spec-Anforderungen sind Tasks zugeordnet. Keine Lücken.
+
+### 2. Placeholder-Scan
+
+- "TBD" / "TODO" / "später füllen" → 0 Treffer im Plan
+- "Similar to Task N" → 0 Treffer
+- Alle Code-Blöcke enthalten vollständigen Text zum Einfügen
+- Alle Commit-Messages sind ausformuliert
+- Alle Verifikations-Greps haben konkrete Expected-Werte
+
+### 3. Type/Name-Konsistenz
+
+- `## Keine Fabrikation` heißt überall gleich (Task 3, 6, 9, 10, 11)
+- `## Vorbedingungen` heißt überall gleich (Task 6, 10, 11)
+- `## Abgrenzung` heißt überall gleich (Task 7, 11)
+- Branch-Name `refactor/e3-prompt-quality` durchgängig
+- Tag-Name `v5.1.0` durchgängig
+- Test-Datei `tests/test_skills_manifest.py` durchgängig
+- CHANGELOG-Anker `[5.1.0]` durchgängig

--- a/skills/abstract-generator/SKILL.md
+++ b/skills/abstract-generator/SKILL.md
@@ -14,6 +14,59 @@ führen zu einem Täuschungsversuch nach FH-Leibniz-Prüfungsordnung. Arbeite au
 `literature_state.md` oder direkt geladenen PDFs. Fehlen Daten: frag den User,
 rate nicht.
 
+## Few-Shot-Beispiele (IMRaD)
+
+### Introduction
+
+**Schlecht** (Grund: keine Forschungslücke, kein Relevanz-Anker):
+
+> "Digitalisierung ist ein wichtiges Thema. Diese Arbeit untersucht
+> Digitalisierung in Unternehmen."
+
+**Gut** (Grund: Lücke + Relevanz + präzise Forschungsfrage in 3 Sätzen):
+
+> "Generative KI verändert Hochschullehre rapide, doch empirische Evidenz
+> zu Prüfungsauswirkungen fehlt. Diese Arbeit untersucht textbasierte
+> Prüfungsleistungen an der FH Leibniz 2024. Forschungsfrage: Beeinflusst
+> der seminaristische KI-Einsatz die Notenverteilung?"
+
+### Methods
+
+**Schlecht** (Grund: Methode nicht reproduzierbar, keine Stichprobe genannt):
+
+> "Es wurde eine Umfrage gemacht und ausgewertet."
+
+**Gut** (Grund: Sample, Instrument, Zeitraum, Auswertung genannt):
+
+> "Quantitative Online-Befragung (LimeSurvey, n=142, FH-Leibniz-Studierende,
+> BWL + Informatik, Mai–Juli 2024). Likert-Items zu KI-Nutzung und
+> Prüfungsnote. Deskriptive Statistik und Chi²-Test in R 4.4."
+
+### Results
+
+**Schlecht** (Grund: keine Zahlen, keine Effektgröße):
+
+> "Die Ergebnisse zeigten einen Zusammenhang zwischen KI-Nutzung und Noten."
+
+**Gut** (Grund: konkrete Effektgröße + Signifikanz + Stichprobe):
+
+> "Studierende mit regelmäßiger KI-Nutzung (n=87) erreichten im Schnitt
+> 0,4 Notenstufen bessere Prüfungsergebnisse (χ²=7,83, p=0,005) als
+> Studierende ohne KI-Nutzung (n=55)."
+
+### Conclusion
+
+**Schlecht** (Grund: überhöhte Generalisierung, keine Limitationen):
+
+> "Die Studie zeigt, dass KI grundsätzlich die Noten verbessert."
+
+**Gut** (Grund: Ergebnis + Einschränkung + Ausblick, 3 Sätze):
+
+> "Regelmäßige KI-Nutzung korreliert positiv mit Prüfungsleistung an der
+> FH Leibniz 2024. Limitationen: Einzelhochschule, Selbstauskunft zur Nutzung,
+> keine Kausalaussage möglich. Folgeforschung sollte experimentelles Design
+> mit Kontrollgruppe prüfen."
+
 ## Aktivierung dieses Skills
 
 - Der User fragt nach einem Abstract (deutsch oder englisch)

--- a/skills/abstract-generator/SKILL.md
+++ b/skills/abstract-generator/SKILL.md
@@ -208,7 +208,7 @@ Vor der Ausgabe folgendes verifizieren:
 ## Wichtige Regeln
 
 - Immer den tatsächlichen Arbeitstext vor dem Generieren lesen -- niemals Abstracts nur aus der Gliederung erzeugen, wenn Text verfügbar ist
-- Ist die Arbeit unvollständig, generiere ein vorläufiges Abstract und markiere es klar als vorläufig
+- Ist die Arbeit unvollständig, generiere ein vorläufiges Abstract und markiere es klar mit dem Default-String „Vorläufig, Validierung ausstehend"
 - Wortzahlgrenzen strikt einhalten -- Hochschulen setzen diese oft durch
 - Das Abstract muss als eigenständiger Text für sich stehen können
 - Niemals persönliche Meinungen oder wertende Sprache einfügen, die über die Aussagen der Arbeit hinausgehen

--- a/skills/abstract-generator/SKILL.md
+++ b/skills/abstract-generator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Abstract Generator
-description: Dieser Skill wird genutzt, wenn der User ein Abstract, eine Zusammenfassung, eine Management Summary oder eine Keyword-Liste für seine akademische Arbeit braucht. Triggers on "Abstract schreiben", "Zusammenfassung", "Keywords", "Management Summary", "Abstract generieren", "paper summary", "Schlagwoerter", "executive summary", oder wenn die Arbeit fertig ist und Front-Matter-Texte benötigt werden.
+description: Dieser Skill wird genutzt, wenn der User ein Abstract, eine Zusammenfassung, eine Management Summary oder eine Keyword-Liste für seine akademische Arbeit braucht. Triggers on "Abstract schreiben", "Zusammenfassung", "Keywords", "Management Summary", "Abstract generieren", "paper summary", "Schlagwörter / Schlagwoerter", "executive summary", oder wenn die Arbeit fertig ist und Front-Matter-Texte benötigt werden.
 ---
 
 # Abstract-Generator

--- a/skills/abstract-generator/SKILL.md
+++ b/skills/abstract-generator/SKILL.md
@@ -7,6 +7,13 @@ description: Dieser Skill wird genutzt, wenn der User ein Abstract, eine Zusamme
 
 Liest eine fertige oder nahezu fertige akademische Arbeit und erzeugt strukturierte Abstracts, Zusammenfassungen und Keyword-Listen. Produziert Output-Varianten passend zum Arbeitstyp und den Hochschul-Anforderungen.
 
+## Keine Fabrikation
+
+Erfundene Ergebnisse, Methoden oder Zahlen im Abstract sind für die FH Leibniz ein Plagiatsbefund und
+führen zu einem Täuschungsversuch nach FH-Leibniz-Prüfungsordnung. Arbeite ausschließlich mit Daten aus
+`literature_state.md` oder direkt geladenen PDFs. Fehlen Daten: frag den User,
+rate nicht.
+
 ## Aktivierung dieses Skills
 
 - Der User fragt nach einem Abstract (deutsch oder englisch)

--- a/skills/abstract-generator/SKILL.md
+++ b/skills/abstract-generator/SKILL.md
@@ -19,10 +19,11 @@ liefern, weil ich ein erfundenes Thema beschreiben würde."
 
 ## Keine Fabrikation
 
-Erfundene Ergebnisse, Methoden oder Zahlen im Abstract sind für die FH Leibniz ein Plagiatsbefund und
-führen zu einem Täuschungsversuch nach FH-Leibniz-Prüfungsordnung. Arbeite ausschließlich mit Daten aus
-`literature_state.md` oder direkt geladenen PDFs. Fehlen Daten: frag den User,
-rate nicht.
+Erfundene Ergebnisse, Methoden oder Zahlen im Abstract sind ein Täuschungs-
+versuch nach FH-Leibniz-Prüfungsordnung und führen zum Verlust der Prüfungs-
+leistung. Arbeite ausschließlich mit Inhalten aus `writing_state.md`
+(Arbeitstext) und `academic_context.md` (Forschungsfrage, Methodik). Fehlen
+Daten: frag den User, rate nicht.
 
 ## Few-Shot-Beispiele (IMRaD)
 

--- a/skills/abstract-generator/SKILL.md
+++ b/skills/abstract-generator/SKILL.md
@@ -1,109 +1,109 @@
 ---
 name: Abstract Generator
-description: This skill should be used when the user needs an abstract, summary, management summary, or keyword list for their academic paper. Triggers on "Abstract schreiben", "Zusammenfassung", "Keywords", "Management Summary", "Abstract generieren", "paper summary", "Schlagwoerter", "executive summary", or when the paper is finished and needs front matter text.
+description: Dieser Skill wird genutzt, wenn der User ein Abstract, eine Zusammenfassung, eine Management Summary oder eine Keyword-Liste für seine akademische Arbeit braucht. Triggers on "Abstract schreiben", "Zusammenfassung", "Keywords", "Management Summary", "Abstract generieren", "paper summary", "Schlagwoerter", "executive summary", oder wenn die Arbeit fertig ist und Front-Matter-Texte benötigt werden.
 ---
 
-# Abstract Generator
+# Abstract-Generator
 
-Read a finished or near-finished academic paper and generate structured abstracts, summaries, and keyword lists. Produce output variants appropriate for the work type and university requirements.
+Liest eine fertige oder nahezu fertige akademische Arbeit und erzeugt strukturierte Abstracts, Zusammenfassungen und Keyword-Listen. Produziert Output-Varianten passend zum Arbeitstyp und den Hochschul-Anforderungen.
 
-## When This Skill Activates
+## Aktivierung dieses Skills
 
-- The user asks for an abstract (German or English)
-- The user needs a Management Summary or executive summary
-- The user needs a keyword list
-- The user asks for a Zusammenfassung for their paper
+- Der User fragt nach einem Abstract (deutsch oder englisch)
+- Der User braucht eine Management Summary bzw. Executive Summary
+- Der User braucht eine Keyword-Liste
+- Der User fragt nach einer Zusammenfassung seiner Arbeit
 
-## Memory Files
+## Memory-Dateien
 
-- Read `academic_context.md` for university, work type, language, research question, methodology, and formal requirements
-- Read `writing_state.md` for chapter completion status and key findings identified during writing
+- Lies `academic_context.md` für Universität, Arbeitstyp, Sprache, Forschungsfrage, Methodik und formale Anforderungen
+- Lies `writing_state.md` für den Fertigstellungsstatus der Kapitel und die während des Schreibens identifizierten Kernaussagen
 
 ## Deliverables
 
-Generate one or more of the following based on user request. If the user asks generically for "Abstract", produce all deliverables that are required for their work type.
+Erzeuge auf Basis der User-Anfrage eine oder mehrere der folgenden Ausgaben. Fragt der User pauschal nach einem "Abstract", produziere alle Deliverables, die für den Arbeitstyp erforderlich sind.
 
-### 1. Abstract (German)
+### 1. Abstract (Deutsch)
 
-**Structure (IMRAD-based):**
+**Struktur (IMRAD-basiert):**
 
-1. **Kontext** (1-2 sentences) -- Situate the research topic and its relevance
-2. **Fragestellung** (1 sentence) -- State the research question
-3. **Methodik** (1-2 sentences) -- Describe the research approach
-4. **Ergebnisse** (2-3 sentences) -- Summarize the key findings
-5. **Schlussfolgerung** (1-2 sentences) -- State the main implication or contribution
+1. **Kontext** (1-2 Sätze) -- Forschungsthema und Relevanz einordnen
+2. **Fragestellung** (1 Satz) -- Forschungsfrage benennen
+3. **Methodik** (1-2 Sätze) -- Forschungsansatz beschreiben
+4. **Ergebnisse** (2-3 Sätze) -- Kernbefunde zusammenfassen
+5. **Schlussfolgerung** (1-2 Sätze) -- Wichtigste Implikation oder Beitrag nennen
 
-**Constraints:**
-- Length: 150-250 words (or as specified in `academic_context.md`)
-- No citations in the abstract
-- No abbreviations not spelled out
-- No references to specific chapters, figures, or tables
-- Use present tense for established facts, past tense for own research actions
-- Write in third person or impersonal constructions (German convention)
+**Vorgaben:**
+- Länge: 150-250 Wörter (oder wie in `academic_context.md` spezifiziert)
+- Keine Zitate im Abstract
+- Keine nicht ausgeschriebenen Abkürzungen
+- Keine Verweise auf konkrete Kapitel, Abbildungen oder Tabellen
+- Präsens für etablierte Fakten, Vergangenheit für eigene Forschungshandlungen
+- Dritte Person oder unpersönliche Konstruktionen (deutsche Konvention)
 
-### 2. Abstract (English)
+### 2. Abstract (Englisch)
 
-**Structure:** Same IMRAD structure as the German version.
+**Struktur:** Dieselbe IMRAD-Struktur wie die deutsche Version.
 
-**Additional constraints:**
-- Must be an independent translation, not a word-for-word rendering
-- Adapt phrasing to English academic conventions
-- Verify that technical terms have correct English equivalents
-- Length: Match the German abstract within 10%
+**Zusätzliche Vorgaben:**
+- Muss eine eigenständige Übersetzung sein, keine Wort-für-Wort-Übertragung
+- Formulierungen an englische Wissenschaftssprache anpassen
+- Fachbegriffe auf korrekte englische Entsprechungen prüfen
+- Länge: Innerhalb von 10 % der deutschen Abstract-Länge
 
 ### 3. Management Summary
 
-**When required:** Typically for Bachelorarbeiten and Masterarbeiten in BWL, Wirtschaftsinformatik, and related programs.
+**Wann erforderlich:** Typischerweise für Bachelor- und Masterarbeiten in BWL, Wirtschaftsinformatik und verwandten Studiengängen.
 
-**Structure:**
+**Struktur:**
 
-1. **Ausgangslage** (1 paragraph) -- Business context and problem
-2. **Zielsetzung** (1-2 sentences) -- What the paper aims to achieve
-3. **Vorgehen** (1 paragraph) -- Methodology in accessible language (minimize jargon)
-4. **Kernergebnisse** (1-2 paragraphs) -- Main findings with practical implications
-5. **Handlungsempfehlungen** (bullet points) -- Actionable recommendations for practitioners
+1. **Ausgangslage** (1 Absatz) -- Geschäftskontext und Problem
+2. **Zielsetzung** (1-2 Sätze) -- Was die Arbeit erreichen will
+3. **Vorgehen** (1 Absatz) -- Methodik in zugänglicher Sprache (Jargon minimieren)
+4. **Kernergebnisse** (1-2 Absätze) -- Wichtigste Befunde mit praktischen Implikationen
+5. **Handlungsempfehlungen** (Aufzählung) -- Konkrete Empfehlungen für die Praxis
 
-**Constraints:**
-- Length: 300-500 words
-- Accessible to non-academic readers (e.g., company supervisors)
-- Focus on practical value, not theoretical contribution
-- No citations
+**Vorgaben:**
+- Länge: 300-500 Wörter
+- Für nicht-akademische Leser verständlich (z. B. Unternehmensbetreuer)
+- Fokus auf praktischen Wert, nicht theoretischen Beitrag
+- Keine Zitate
 
-### 4. Keywords List
+### 4. Keyword-Liste
 
-Generate two keyword sets:
+Erzeuge zwei Keyword-Sets:
 
-**German Keywords (Schlagwoerter):**
-- 5-8 keywords
-- Mix of broad discipline terms and specific topic terms
-- Include methodology keywords if distinctive
-- Order: broad to specific
+**Deutsche Schlagwörter:**
+- 5-8 Keywords
+- Mischung aus breiten Disziplinbegriffen und spezifischen Themenbegriffen
+- Methodik-Keywords aufnehmen, wenn sie distinktiv sind
+- Reihenfolge: breit zu spezifisch
 
-**English Keywords:**
-- 5-8 keywords (not literal translations -- use established English terminology)
-- Include terms commonly used in international databases (Scopus, Web of Science)
-- Consider search discoverability
+**Englische Keywords:**
+- 5-8 Keywords (keine wörtlichen Übersetzungen -- etablierte englische Terminologie nutzen)
+- Begriffe aufnehmen, die in internationalen Datenbanken (Scopus, Web of Science) üblich sind
+- Auffindbarkeit bei Suchen berücksichtigen
 
-## Generation Workflow
+## Generierungs-Workflow
 
-1. Read `academic_context.md` for formal requirements and context
-2. Read the complete paper text (or all available chapters)
-3. Identify: research question, methodology, key findings, main contribution, limitations, implications
-4. Determine which deliverables to generate based on work type:
-   - Bachelorarbeit/Masterarbeit: Abstract (DE), Abstract (EN), Management Summary, Keywords
-   - Hausarbeit/Seminararbeit: Abstract (DE), Keywords
-   - Facharbeit: Abstract (DE) only (short version, 100-150 words)
-5. Draft each deliverable following the structure and constraints above
-6. Cross-check: ensure the abstract accurately reflects the paper's actual content (not the intended content from the outline)
-7. Present all deliverables in structured output
+1. Lies `academic_context.md` für formale Anforderungen und Kontext
+2. Lies den kompletten Arbeitstext (oder alle verfügbaren Kapitel)
+3. Identifiziere: Forschungsfrage, Methodik, Kernergebnisse, Hauptbeitrag, Limitationen, Implikationen
+4. Entscheide auf Basis des Arbeitstyps, welche Deliverables zu erzeugen sind:
+   - Bachelor-/Masterarbeit: Abstract (DE), Abstract (EN), Management Summary, Keywords
+   - Haus-/Seminararbeit: Abstract (DE), Keywords
+   - Facharbeit: nur Abstract (DE) (kurze Version, 100-150 Wörter)
+5. Entwirf jedes Deliverable gemäß der oben beschriebenen Struktur und Vorgaben
+6. Gegencheck: Sicherstellen, dass das Abstract den tatsächlichen Inhalt der Arbeit widerspiegelt (nicht den geplanten Inhalt aus der Gliederung)
+7. Präsentiere alle Deliverables in strukturiertem Output
 
-## Output Format
+## Output-Format
 
 ```
 ## Abstract & Zusammenfassung
 
 ### Abstract (Deutsch)
-[Generated abstract text]
+[Generierter Abstract-Text]
 
 **Wortanzahl:** [N]
 
@@ -113,7 +113,7 @@ Generate two keyword sets:
 **Word count:** [N]
 
 ### Management Summary
-[Generated summary text]
+[Generierter Summary-Text]
 
 **Wortanzahl:** [N]
 
@@ -122,24 +122,24 @@ Generate two keyword sets:
 **English:** [Keyword 1], [Keyword 2], ...
 ```
 
-## Quality Checks
+## Qualitätsprüfungen
 
-Before presenting the output, verify:
+Vor der Ausgabe folgendes verifizieren:
 
-- [ ] Abstract does not contain information absent from the paper
-- [ ] Abstract does not omit major findings present in the paper
-- [ ] No citations, figure references, or chapter references in abstract
-- [ ] Word count within specified range
-- [ ] German abstract uses appropriate academic register (no colloquialisms)
-- [ ] English abstract uses correct English academic conventions (not Germanisms)
-- [ ] Keywords are not too generic ("Management", "Unternehmen") or too narrow
-- [ ] Management Summary is understandable without reading the paper
+- [ ] Abstract enthält keine Informationen, die nicht in der Arbeit stehen
+- [ ] Abstract lässt keine zentralen Befunde aus, die in der Arbeit stehen
+- [ ] Keine Zitate, Abbildungs- oder Kapitelverweise im Abstract
+- [ ] Wortanzahl innerhalb des vorgegebenen Rahmens
+- [ ] Deutsches Abstract nutzt passendes wissenschaftliches Register (keine Umgangssprache)
+- [ ] Englisches Abstract nutzt korrekte englische Wissenschaftskonventionen (keine Germanismen)
+- [ ] Keywords nicht zu generisch ("Management", "Unternehmen") oder zu eng
+- [ ] Management Summary auch ohne Lektüre der Arbeit verständlich
 
-## Important Rules
+## Wichtige Regeln
 
-- Always read the actual paper content before generating -- never generate abstracts from the outline alone if text is available
-- If the paper is incomplete, generate a preliminary abstract and clearly mark it as provisional
-- Respect the word count limits strictly -- universities often enforce these
-- The abstract must stand alone as a self-contained text
-- Never include personal opinions or evaluative language beyond what the paper itself claims
-- If `academic_context.md` specifies additional requirements (e.g., structured abstract format), follow those over the defaults
+- Immer den tatsächlichen Arbeitstext vor dem Generieren lesen -- niemals Abstracts nur aus der Gliederung erzeugen, wenn Text verfügbar ist
+- Ist die Arbeit unvollständig, generiere ein vorläufiges Abstract und markiere es klar als vorläufig
+- Wortzahlgrenzen strikt einhalten -- Hochschulen setzen diese oft durch
+- Das Abstract muss als eigenständiger Text für sich stehen können
+- Niemals persönliche Meinungen oder wertende Sprache einfügen, die über die Aussagen der Arbeit hinausgehen
+- Falls `academic_context.md` zusätzliche Anforderungen nennt (z. B. strukturiertes Abstract-Format), diesen Vorrang vor den Defaults geben

--- a/skills/abstract-generator/SKILL.md
+++ b/skills/abstract-generator/SKILL.md
@@ -7,6 +7,16 @@ description: Dieser Skill wird genutzt, wenn der User ein Abstract, eine Zusamme
 
 Liest eine fertige oder nahezu fertige akademische Arbeit und erzeugt strukturierte Abstracts, Zusammenfassungen und Keyword-Listen. Produziert Output-Varianten passend zum Arbeitstyp und den Hochschul-Anforderungen.
 
+## Vorbedingungen
+
+Bevor du startest: Prüfe, ob `academic_context.md` und `literature_state.md`
+vorhanden und aktuell sind. Fehlt Kontext → triggere den `academic-context`-
+Skill und warte auf dessen Abschluss.
+
+Lehnt der User den Trigger ab → brich diesen Skill ab und erkläre:
+"Ohne Forschungsfrage und Methodik-Angabe kann ich kein belastbares Abstract
+liefern, weil ich ein erfundenes Thema beschreiben würde."
+
 ## Keine Fabrikation
 
 Erfundene Ergebnisse, Methoden oder Zahlen im Abstract sind für die FH Leibniz ein Plagiatsbefund und

--- a/skills/academic-context/SKILL.md
+++ b/skills/academic-context/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Academic Context
-description: Dieser Skill wird genutzt, wenn der User seine Abschlussarbeit, Bachelorarbeit, Masterarbeit, Hausarbeit, Facharbeit oder akademische Arbeit diskutiert. Triggers on "meine Arbeit", "mein Thema", "Forschungsfrage", "Gliederung", "thesis context", "academic profile", oder wenn ein anderer Skill Kontext braucht, der noch nicht existiert. Verwaltet den persistenten akademischen Kontext im Claude-Memory.
+description: Dieser Skill wird genutzt, wenn der User seine Abschlussarbeit, Bachelorarbeit, Masterarbeit, Hausarbeit, Facharbeit oder akademische Arbeit diskutiert. Triggers on "meine Arbeit", "mein Thema", "Forschungsfrage", "Gliederung", "thesis context", "academic profile", "akademischer Kontext prüfen / akademischer Kontext pruefen", oder wenn ein anderer Skill Kontext braucht, der noch nicht existiert. Verwaltet den persistenten akademischen Kontext im Claude-Memory.
 ---
 
 # Akademischer Kontext

--- a/skills/academic-context/SKILL.md
+++ b/skills/academic-context/SKILL.md
@@ -1,53 +1,53 @@
 ---
 name: Academic Context
-description: This skill should be used when the user discusses their thesis, Bachelorarbeit, Masterarbeit, Hausarbeit, Facharbeit, or academic work. Triggers on "meine Arbeit", "mein Thema", "Forschungsfrage", "Gliederung", "thesis context", "academic profile", or when another skill needs context that doesn't exist yet. Manages the persistent academic context in Claude Memory.
+description: Dieser Skill wird genutzt, wenn der User seine Abschlussarbeit, Bachelorarbeit, Masterarbeit, Hausarbeit, Facharbeit oder akademische Arbeit diskutiert. Triggers on "meine Arbeit", "mein Thema", "Forschungsfrage", "Gliederung", "thesis context", "academic profile", oder wenn ein anderer Skill Kontext braucht, der noch nicht existiert. Verwaltet den persistenten akademischen Kontext im Claude-Memory.
 ---
 
-# Academic Context Manager
+# Akademischer Kontext
 
-Maintain a persistent academic context that other skills rely on. This skill reads and writes Claude Memory files to track the user's thesis topic, outline, research question, methodology, progress, and key concepts.
+Pflegt einen persistenten akademischen Kontext, auf den sich andere Skills verlassen. Dieser Skill liest und schreibt Claude-Memory-Dateien, um Thema, Gliederung, Forschungsfrage, Methodik, Fortschritt und Schlüsselkonzepte der Arbeit des Users zu tracken.
 
-## When This Skill Activates
+## Aktivierung dieses Skills
 
-- The user mentions their thesis, paper, or academic work
-- The user provides or updates their research topic, outline, or research question
-- Another skill needs academic context but none exists yet
-- The user explicitly asks to update their academic profile
+- Der User erwähnt seine Abschlussarbeit, Hausarbeit oder akademische Arbeit
+- Der User liefert oder aktualisiert Forschungsthema, Gliederung oder Forschungsfrage
+- Ein anderer Skill braucht akademischen Kontext, aber es ist noch keiner vorhanden
+- Der User fragt explizit nach einer Aktualisierung seines akademischen Profils
 
-## Memory Files
+## Memory-Dateien
 
-All context is stored in Claude Memory at the project's memory directory. Three files are managed:
+Der gesamte Kontext liegt im Claude-Memory des Projekt-Memory-Verzeichnisses. Drei Dateien werden verwaltet:
 
-### `academic_context.md` — Primary context file
+### `academic_context.md` — Primäre Kontextdatei
 
-Contains thesis profile (university, program, citation style), work details (type, topic, research question, methodology, supervisor, deadline), outline structure, key concepts, and progress tracking.
+Enthält das Arbeitsprofil (Universität, Studiengang, Zitationsstil), die Arbeitsdetails (Typ, Thema, Forschungsfrage, Methodik, Betreuer, Abgabetermin), die Gliederungsstruktur, Schlüsselkonzepte und den Fortschritt.
 
-### `literature_state.md` — Literature status
+### `literature_state.md` — Literaturstatus
 
-Contains statistics about collected sources (total count, peer-reviewed percentage, type breakdown), chapter-to-source assignment, and identified gaps.
+Enthält Statistiken zu gesammelten Quellen (Gesamtzahl, Peer-Review-Anteil, Typenverteilung), Kapitel-Quellen-Zuordnung sowie identifizierte Lücken.
 
-### `writing_state.md` — Writing progress
+### `writing_state.md` — Schreibfortschritt
 
-Contains current chapter being written, word counts, and latest style evaluation scores.
+Enthält das aktuell geschriebene Kapitel, Wortzahlen und die jüngsten Style-Evaluator-Scores.
 
-## Core Workflow
+## Core-Workflow
 
-### First Activation (No Context Exists)
+### Erstaktivierung (noch kein Kontext vorhanden)
 
-When no `academic_context.md` exists in memory, gather the following through conversation:
+Existiert keine `academic_context.md` im Memory, sammle im Gespräch folgende Informationen:
 
-1. **University and program** — Default: Leibniz FH Hannover, BWL/Wirtschaftsinformatik
-2. **Work type** — Bachelorarbeit, Masterarbeit, Hausarbeit, Seminararbeit, Facharbeit
-3. **Topic** — Working title of the thesis
-4. **Research question** — Main question and sub-questions
-5. **Methodology** — Literature review, case study, empirical, mixed methods
-6. **Citation style** — Default: APA7 (also supports IEEE, Harvard, Chicago, MLA)
-7. **Language** — Default: Deutsch
-8. **Supervisor** — Name (optional)
-9. **Deadline** — Submission date (optional)
-10. **Outline** — Chapter structure if already planned
+1. **Universität und Studiengang** — Default: Leibniz FH Hannover, BWL/Wirtschaftsinformatik
+2. **Arbeitstyp** — Bachelorarbeit, Masterarbeit, Hausarbeit, Seminararbeit, Facharbeit
+3. **Thema** — Arbeitstitel der Abschlussarbeit
+4. **Forschungsfrage** — Hauptfrage und Unterfragen
+5. **Methodik** — Literaturreview, Fallstudie, empirisch, Mixed Methods
+6. **Zitationsstil** — Default: APA7 (unterstützt auch IEEE, Harvard, Chicago, MLA)
+7. **Sprache** — Default: Deutsch
+8. **Betreuer** — Name (optional)
+9. **Abgabetermin** — Datum (optional)
+10. **Gliederung** — Kapitelstruktur, falls schon geplant
 
-Write the gathered information to `academic_context.md` using this structure:
+Schreibe die gesammelten Informationen in `academic_context.md` mit dieser Struktur:
 
 ```markdown
 ---
@@ -72,40 +72,40 @@ type: project
 - Abgabetermin: [...]
 
 ## Gliederung
-[Numbered outline if available]
+[Nummerierte Gliederung, falls vorhanden]
 
 ## Schlüsselkonzepte
-[Key concepts with brief descriptions]
+[Schlüsselkonzepte mit Kurzbeschreibung]
 
 ## Fortschritt
-[Checklist of completed/in-progress items]
+[Checkliste abgeschlossener/in Bearbeitung befindlicher Elemente]
 ```
 
-### Update Activation (Context Exists)
+### Update-Aktivierung (Kontext existiert bereits)
 
-When context already exists, read the current `academic_context.md` from memory. Identify what changed based on the conversation and update only the relevant sections. Preserve all existing data that wasn't explicitly changed.
+Existiert schon Kontext, lies die aktuelle `academic_context.md` aus dem Memory. Identifiziere auf Basis des Gesprächs, was sich geändert hat, und aktualisiere nur die betroffenen Abschnitte. Bewahre alle bestehenden Daten, die nicht explizit geändert wurden.
 
-Common updates:
-- **Outline changes** — User refined chapter structure
-- **Progress updates** — User completed a chapter or section
-- **New concepts** — User introduced new key terms
-- **Research question refinement** — User sharpened the focus
-- **Methodology decision** — User chose or changed approach
+Typische Updates:
+- **Gliederungsänderungen** — User hat die Kapitelstruktur verfeinert
+- **Fortschrittsupdates** — User hat ein Kapitel oder einen Abschnitt abgeschlossen
+- **Neue Konzepte** — User hat neue Schlüsselbegriffe eingeführt
+- **Forschungsfragen-Schärfung** — User hat den Fokus präzisiert
+- **Methodik-Entscheidung** — User hat einen Ansatz gewählt oder geändert
 
-### Cross-Skill Support
+### Unterstützung anderer Skills
 
-When another skill (Citation Extraction, Literature Gap Analysis, Advisor, etc.) needs context:
+Wenn ein anderer Skill (Citation Extraction, Literature Gap Analysis, Advisor etc.) Kontext braucht:
 
-1. Check if `academic_context.md` exists in memory
-2. If yes — read and use it
-3. If no — inform the user that context is needed and offer to set it up
-4. After setup, return control to the requesting workflow
+1. Prüfe, ob `academic_context.md` im Memory existiert
+2. Wenn ja — lies sie und nutze sie
+3. Wenn nein — informiere den User, dass Kontext benötigt wird, und biete das Setup an
+4. Gib nach dem Setup die Kontrolle an den aufrufenden Workflow zurück
 
-## Important Rules
+## Wichtige Regeln
 
-- **Never overwrite without reading first** — Always read the current state before writing updates
-- **Preserve user data** — Never delete information the user didn't explicitly ask to remove
-- **Use German for field labels** — The context files use German labels matching the user's language
-- **Date format** — Use ISO dates (YYYY-MM-DD) for deadlines and timestamps
-- **Incremental updates** — Update only changed sections, not the entire file
-- **Confirm major changes** — Before restructuring the outline or changing the research question, confirm with the user
+- **Nie ohne vorheriges Lesen überschreiben** — Immer erst den aktuellen Stand lesen, bevor Updates geschrieben werden
+- **User-Daten bewahren** — Nie Informationen löschen, deren Entfernen der User nicht explizit verlangt hat
+- **Deutsche Feldbezeichnungen** — Die Kontextdateien nutzen deutsche Labels passend zur Sprache des Users
+- **Datumsformat** — ISO-Format (YYYY-MM-DD) für Abgabetermine und Zeitstempel
+- **Inkrementelle Updates** — Nur geänderte Abschnitte aktualisieren, nicht die ganze Datei
+- **Größere Änderungen bestätigen** — Vor einer Umstrukturierung der Gliederung oder dem Ändern der Forschungsfrage Rücksprache mit dem User halten

--- a/skills/academic-context/SKILL.md
+++ b/skills/academic-context/SKILL.md
@@ -7,6 +7,13 @@ description: Dieser Skill wird genutzt, wenn der User seine Abschlussarbeit, Bac
 
 Pflegt einen persistenten akademischen Kontext, auf den sich andere Skills verlassen. Dieser Skill liest und schreibt Claude-Memory-Dateien, um Thema, Gliederung, Forschungsfrage, Methodik, Fortschritt und Schlüsselkonzepte der Arbeit des Users zu tracken.
 
+## Keine Fabrikation
+
+Erfundene Kontextangaben (Thema, Methodik, Fragestellung) sind für die FH Leibniz ein Plagiatsbefund und
+führen zu einer vergifteten Memory-Basis, die alle nachgelagerten Skills wertlos macht. Arbeite ausschließlich mit Daten aus
+`literature_state.md` oder direkt geladenen PDFs. Fehlen Daten: frag den User,
+rate nicht.
+
 ## Aktivierung dieses Skills
 
 - Der User erwähnt seine Abschlussarbeit, Hausarbeit oder akademische Arbeit

--- a/skills/academic-context/SKILL.md
+++ b/skills/academic-context/SKILL.md
@@ -9,10 +9,10 @@ Pflegt einen persistenten akademischen Kontext, auf den sich andere Skills verla
 
 ## Keine Fabrikation
 
-Erfundene Kontextangaben (Thema, Methodik, Fragestellung) sind für die FH Leibniz ein Plagiatsbefund und
-führen zu einer vergifteten Memory-Basis, die alle nachgelagerten Skills wertlos macht. Arbeite ausschließlich mit Daten aus
-`literature_state.md` oder direkt geladenen PDFs. Fehlen Daten: frag den User,
-rate nicht.
+Erfundene Kontextangaben (Thema, Methodik, Fragestellung) produzieren eine
+vergiftete Memory-Basis, die alle nachgelagerten Skills wertlos macht. Arbeite
+ausschließlich mit Angaben, die der User im Gespräch explizit bestätigt hat —
+rate keine Werte, frag nach.
 
 ## Aktivierung dieses Skills
 

--- a/skills/advisor/SKILL.md
+++ b/skills/advisor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Advisor
-description: Dieser Skill wird genutzt, wenn der User seine Gliederung aufbauen oder verfeinern, ein Exposé erstellen oder die Kapitelstruktur planen möchte. Triggers on "Gliederung", "Outline", "Expose", "Exposé", "Struktur", "Kapitelplanung", "thesis structure", "chapter planning", "Aufbau der Arbeit", oder wenn der User Hilfe braucht, seine akademische Arbeit in eine kohärente Struktur zu bringen.
+description: Dieser Skill wird genutzt, wenn der User seine Gliederung aufbauen oder verfeinern, ein Exposé erstellen oder die Kapitelstruktur planen möchte. Triggers on "Gliederung", "Outline", "Exposé / Expose", "Struktur", "Kapitelplanung", "thesis structure", "chapter planning", "Aufbau der Arbeit", "Gliederung prüfen / Gliederung pruefen", oder wenn der User Hilfe braucht, seine akademische Arbeit in eine kohärente Struktur zu bringen.
 ---
 
 # Advisor — Gliederungs- und Exposé-Builder

--- a/skills/advisor/SKILL.md
+++ b/skills/advisor/SKILL.md
@@ -7,6 +7,16 @@ description: Dieser Skill wird genutzt, wenn der User seine Gliederung aufbauen 
 
 Baut, verfeinert und validiert Gliederungen und Exposé-Dokumente im interaktiven Dialog. Führt den User vom Ausgangsthema zu einem strukturierten, gut begründeten Kapitelplan.
 
+## Vorbedingungen
+
+Bevor du startest: Prüfe, ob `academic_context.md` und `literature_state.md`
+vorhanden und aktuell sind. Fehlt Kontext → triggere den `academic-context`-
+Skill und warte auf dessen Abschluss.
+
+Lehnt der User den Trigger ab → brich diesen Skill ab und erkläre:
+"Ohne Forschungsfrage und Kapitelstruktur kann ich keine fundierte Outline-
+Beratung liefern, weil ich gegen unbekannte Vorgaben beraten würde."
+
 ## Keine Fabrikation
 
 Erfundene Kapitelstruktur-Standards oder Gliederungsempfehlungen sind für die FH Leibniz ein Plagiatsbefund und

--- a/skills/advisor/SKILL.md
+++ b/skills/advisor/SKILL.md
@@ -7,6 +7,13 @@ description: Dieser Skill wird genutzt, wenn der User seine Gliederung aufbauen 
 
 Baut, verfeinert und validiert Gliederungen und Exposé-Dokumente im interaktiven Dialog. Führt den User vom Ausgangsthema zu einem strukturierten, gut begründeten Kapitelplan.
 
+## Keine Fabrikation
+
+Erfundene Kapitelstruktur-Standards oder Gliederungsempfehlungen sind für die FH Leibniz ein Plagiatsbefund und
+führen zu nachträglichen Überarbeitungen nach Abgabe. Arbeite ausschließlich mit Daten aus
+`literature_state.md` oder direkt geladenen PDFs. Fehlen Daten: frag den User,
+rate nicht.
+
 ## Aktivierung dieses Skills
 
 - Der User möchte eine Gliederung erstellen oder überarbeiten

--- a/skills/advisor/SKILL.md
+++ b/skills/advisor/SKILL.md
@@ -1,118 +1,118 @@
 ---
 name: Advisor
-description: This skill should be used when the user wants to build or refine their thesis outline, create an Expose, or plan chapter structure. Triggers on "Gliederung", "Outline", "Expose", "Exposé", "Struktur", "Kapitelplanung", "thesis structure", "chapter planning", "Aufbau der Arbeit", or when the user needs help organizing their academic work into a coherent structure.
+description: Dieser Skill wird genutzt, wenn der User seine Gliederung aufbauen oder verfeinern, ein Exposé erstellen oder die Kapitelstruktur planen möchte. Triggers on "Gliederung", "Outline", "Expose", "Exposé", "Struktur", "Kapitelplanung", "thesis structure", "chapter planning", "Aufbau der Arbeit", oder wenn der User Hilfe braucht, seine akademische Arbeit in eine kohärente Struktur zu bringen.
 ---
 
-# Advisor — Outline & Expose Builder
+# Advisor — Gliederungs- und Exposé-Builder
 
-Build, refine, and validate thesis outlines and expose documents through interactive dialog. Guide the user from an initial topic to a structured, well-justified chapter plan.
+Baut, verfeinert und validiert Gliederungen und Exposé-Dokumente im interaktiven Dialog. Führt den User vom Ausgangsthema zu einem strukturierten, gut begründeten Kapitelplan.
 
-## When This Skill Activates
+## Aktivierung dieses Skills
 
-- The user wants to create or revise a thesis outline (Gliederung)
-- The user needs to write an expose or research proposal
-- The user asks about chapter structure, ordering, or logical flow
-- The user wants to plan which topics belong in which chapter
+- Der User möchte eine Gliederung erstellen oder überarbeiten
+- Der User muss ein Exposé oder Forschungsproposal schreiben
+- Der User fragt nach Kapitelstruktur, Reihenfolge oder logischem Aufbau
+- Der User möchte planen, welche Themen in welches Kapitel gehören
 
-## Memory Files
+## Memory-Dateien
 
-### Read
+### Lesen
 
-- `academic_context.md` — Thesis profile, research question, methodology, existing outline
-- `literature_state.md` — Available sources and chapter assignments (to verify literature coverage)
+- `academic_context.md` — Arbeitsprofil, Forschungsfrage, Methodik, bestehende Gliederung
+- `literature_state.md` — Vorhandene Quellen und Kapitelzuordnungen (zur Literaturabdeckungs-Prüfung)
 
-### Write
+### Schreiben
 
-- `academic_context.md` — Update the `## Gliederung` section after outline changes
+- `academic_context.md` — Aktualisiere den Abschnitt `## Gliederung` nach Gliederungsänderungen
 
-## Core Workflow
+## Core-Workflow
 
-### 1. Load Context
+### 1. Kontext laden
 
-Read `academic_context.md` from memory. If it does not exist, inform the user and trigger the Academic Context skill to gather baseline information before proceeding.
+Lies `academic_context.md` aus dem Memory. Existiert sie nicht, informiere den User und triggere den Academic-Context-Skill, um Grunddaten zu erheben, bevor fortgefahren wird.
 
-Extract: work type, topic, research question, sub-questions, methodology, and any existing outline.
+Extrahiere: Arbeitstyp, Thema, Forschungsfrage, Unterfragen, Methodik und eine eventuell vorhandene Gliederung.
 
-### 2. Interactive Outline Dialog
+### 2. Interaktiver Gliederungsdialog
 
-If no outline exists, guide the user through building one. Ask focused questions:
+Wenn noch keine Gliederung existiert, führe den User beim Aufbau. Stelle fokussierte Fragen:
 
-1. **Scope** — What is the central argument or thesis statement?
-2. **Main sections** — What are the 3-5 major topics the work must cover?
-3. **Logical order** — Which concepts build on each other?
-4. **Methodology placement** — Where does the methodology chapter fit?
-5. **Depth** — How many sub-sections per chapter?
+1. **Scope** — Was ist das zentrale Argument bzw. die Thesis?
+2. **Hauptteile** — Welche 3-5 großen Themen muss die Arbeit abdecken?
+3. **Logische Reihenfolge** — Welche Konzepte bauen aufeinander auf?
+4. **Platzierung der Methodik** — Wo gehört das Methodik-Kapitel hin?
+5. **Tiefe** — Wie viele Unterabschnitte pro Kapitel?
 
-Present a draft outline after initial answers. Use numbered hierarchy (1. / 1.1 / 1.1.1). Include estimated page ranges per chapter based on work type:
+Präsentiere nach den ersten Antworten einen Gliederungsentwurf. Nutze nummerierte Hierarchie (1. / 1.1 / 1.1.1). Geschätzte Seitenzahlen pro Kapitel nach Arbeitstyp einfügen:
 
-| Work Type | Total Pages | Intro | Theory | Method | Analysis | Conclusion |
-|-----------|-------------|-------|--------|--------|----------|------------|
+| Arbeitstyp | Gesamtseiten | Einleitung | Theorie | Methodik | Analyse | Fazit |
+|------------|--------------|------------|---------|----------|---------|-------|
 | Bachelorarbeit | 40-60 | 3-5 | 12-18 | 5-8 | 12-18 | 3-5 |
 | Masterarbeit | 60-100 | 5-8 | 20-30 | 8-15 | 20-30 | 5-8 |
 | Hausarbeit | 15-25 | 2-3 | 5-8 | 3-5 | 5-8 | 2-3 |
 
-### 3. Outline Validation
+### 3. Gliederungs-Validierung
 
-After the user accepts a draft, validate it against common academic standards:
+Nachdem der User einen Entwurf akzeptiert, validiere ihn gegen gängige akademische Standards:
 
-- **Red thread** (roter Faden) — Does every chapter contribute to answering the research question?
-- **Balance** — Are chapters roughly proportional? Flag chapters that are too thin or too heavy.
-- **Completeness** — Are introduction, theoretical framework, methodology, analysis/results, and conclusion present?
-- **Sub-question mapping** — Can each sub-question be traced to at least one chapter?
-- **No orphans** — Does every chapter connect logically to its neighbors?
+- **Roter Faden** — Trägt jedes Kapitel zur Beantwortung der Forschungsfrage bei?
+- **Balance** — Sind die Kapitel ungefähr proportional? Zu dünne oder zu dicke Kapitel flaggen.
+- **Vollständigkeit** — Sind Einleitung, theoretischer Rahmen, Methodik, Analyse/Ergebnisse und Fazit vorhanden?
+- **Unterfragen-Mapping** — Lässt sich jede Unterfrage mindestens einem Kapitel zuordnen?
+- **Keine Waisen** — Hängt jedes Kapitel logisch an seinen Nachbarn an?
 
-Report issues as warnings with suggested fixes.
+Probleme als Warnungen mit Lösungsvorschlägen berichten.
 
-### 4. Literature Availability Check
+### 4. Literatur-Abdeckungs-Check
 
-If `literature_state.md` exists, cross-reference the outline with available sources. For each chapter, report:
+Falls `literature_state.md` existiert, Gliederung gegen vorhandene Quellen abgleichen. Pro Kapitel berichten:
 
-- Number of assigned sources
-- Whether peer-reviewed sources are present
-- Gaps where no literature is assigned
+- Anzahl zugeordneter Quellen
+- Ob Peer-Review-Quellen vorhanden sind
+- Lücken, in denen keine Literatur zugewiesen ist
 
-If gaps are found, offer to trigger `/search` for specific chapters with targeted queries derived from chapter titles and key concepts.
+Bei Lücken biete an, `/search` für einzelne Kapitel zu triggern — mit gezielten Queries aus Kapiteltiteln und Schlüsselkonzepten.
 
-### 5. Expose Generation
+### 5. Exposé-Generierung
 
-When the user requests an expose, use the template at `${CLAUDE_PLUGIN_ROOT}/skills/advisor/expose-template.md` as the base structure. Fill in sections from the academic context and outline:
+Fordert der User ein Exposé an, nutze das Template unter `${CLAUDE_PLUGIN_ROOT}/skills/advisor/expose-template.md` als Basis. Fülle die Abschnitte aus Kontext und Gliederung:
 
-- Problemstellung (problem statement)
-- Zielsetzung (objective)
-- Forschungsfrage und Unterfragen (research question and sub-questions)
-- Theoretischer Rahmen (theoretical framework)
-- Methodik (methodology)
-- Vorläufige Gliederung (preliminary outline)
-- Zeitplan (timeline)
-- Vorläufige Literaturliste (preliminary bibliography)
+- Problemstellung
+- Zielsetzung
+- Forschungsfrage und Unterfragen
+- Theoretischer Rahmen
+- Methodik
+- Vorläufige Gliederung
+- Zeitplan
+- Vorläufige Literaturliste
 
-Generate the timeline based on the deadline from `academic_context.md`. Work backwards from the deadline, allocating roughly: 20% research, 10% outline/expose, 50% writing, 10% revision, 10% buffer.
+Erzeuge den Zeitplan auf Basis des Abgabetermins aus `academic_context.md`. Rechne vom Abgabetermin rückwärts und teile grob auf: 20 % Recherche, 10 % Gliederung/Exposé, 50 % Schreiben, 10 % Revision, 10 % Puffer.
 
-### 6. Save Updates
+### 6. Änderungen speichern
 
-After the user confirms the outline or expose:
+Nachdem der User die Gliederung oder das Exposé bestätigt hat:
 
-1. Read `academic_context.md` again (prevent stale overwrites)
-2. Update only the `## Gliederung` section with the new outline
-3. Update `## Fortschritt` if applicable
+1. `academic_context.md` erneut lesen (veraltete Überschreibungen vermeiden)
+2. Nur den Abschnitt `## Gliederung` mit der neuen Gliederung aktualisieren
+3. `## Fortschritt` ergänzen, falls anwendbar
 
-## Outline Refinement
+## Verfeinerung einer bestehenden Gliederung
 
-When an outline already exists and the user wants changes:
+Wenn bereits eine Gliederung existiert und der User Änderungen wünscht:
 
-- **Add chapter** — Insert at the correct position, renumber subsequent chapters
-- **Remove chapter** — Confirm with the user, check if literature was assigned
-- **Reorder** — Show before/after comparison, validate red thread
-- **Split/merge** — Suggest appropriate sub-section structure
-- **Rename** — Update title, check if it still matches the content scope
+- **Kapitel hinzufügen** — An korrekter Position einfügen, nachfolgende Kapitel neu nummerieren
+- **Kapitel entfernen** — Beim User rückbestätigen, prüfen ob Literatur zugeordnet war
+- **Umsortieren** — Vorher/Nachher-Vergleich zeigen, roten Faden validieren
+- **Aufteilen/Zusammenlegen** — Geeignete Unterabschnitt-Struktur vorschlagen
+- **Umbenennen** — Titel aktualisieren, prüfen ob er noch zum Inhalt passt
 
-Always show the full updated outline after changes and ask for confirmation.
+Nach Änderungen immer die komplette aktualisierte Gliederung zeigen und bestätigen lassen.
 
-## Important Rules
+## Wichtige Regeln
 
-- **Never auto-generate an outline without dialog** — Always involve the user in structural decisions
-- **Respect existing work** — When refining, preserve what works and suggest targeted changes
-- **German chapter titles by default** — Match the thesis language from academic context
-- **Show reasoning** — Explain why a particular structure is recommended
-- **One change at a time** — When multiple issues are found, address them sequentially
-- **Confirm before saving** — Always get explicit approval before writing to memory
+- **Nie ohne Dialog automatisch eine Gliederung generieren** — Den User immer in Strukturentscheidungen einbinden
+- **Bestehende Arbeit respektieren** — Beim Verfeinern bewahren, was funktioniert, und gezielt Änderungen vorschlagen
+- **Deutsche Kapiteltitel als Default** — Sprache aus dem akademischen Kontext übernehmen
+- **Begründung zeigen** — Erklären, warum eine bestimmte Struktur empfohlen wird
+- **Eine Änderung nach der anderen** — Mehrere Probleme sequenziell angehen
+- **Vor dem Speichern bestätigen lassen** — Immer explizite Freigabe einholen, bevor ins Memory geschrieben wird

--- a/skills/advisor/SKILL.md
+++ b/skills/advisor/SKILL.md
@@ -14,6 +14,21 @@ führen zu nachträglichen Überarbeitungen nach Abgabe. Arbeite ausschließlich
 `literature_state.md` oder direkt geladenen PDFs. Fehlen Daten: frag den User,
 rate nicht.
 
+## Bewertungskriterien (PASS/FAIL)
+
+Prüfe die Outline gegen diese 7 Kriterien. Jedes ist PASS oder FAIL — kein
+Zwischenstufen-Urteil:
+
+1. **Forschungsfrage formuliert** — ≤ 25 Wörter, eine W-Frage (Was/Wie/Warum/Inwiefern)
+2. **Outline mit ≥ 3 Kapiteln** — Haupt-Kapitel, nicht nur Gliederungspunkte
+3. **Literaturbasis ≥ 15 Quellen** in `literature_state.md`
+4. **Methodik benannt** — qualitativ / quantitativ / Mixed / Literatur-Review etc.
+5. **Zeitplan mit Meilensteinen** — mindestens 3 Meilensteine mit Datum
+6. **Supervisor identifiziert** — Name in `academic_context.md`
+7. **Abgabetermin fixiert** — konkretes Datum in `academic_context.md`
+
+Ausgabe: Tabelle mit Kriterium + PASS/FAIL + Begründung bei FAIL.
+
 ## Aktivierung dieses Skills
 
 - Der User möchte eine Gliederung erstellen oder überarbeiten

--- a/skills/advisor/SKILL.md
+++ b/skills/advisor/SKILL.md
@@ -19,9 +19,10 @@ Beratung liefern, weil ich gegen unbekannte Vorgaben beraten würde."
 
 ## Keine Fabrikation
 
-Erfundene Kapitelstruktur-Standards oder Gliederungsempfehlungen sind für die FH Leibniz ein Plagiatsbefund und
-führen zu nachträglichen Überarbeitungen nach Abgabe. Arbeite ausschließlich mit Daten aus
-`literature_state.md` oder direkt geladenen PDFs. Fehlen Daten: frag den User,
+Erfundene Kapitelstruktur-Standards oder Gliederungsempfehlungen führen zu
+nachträglichen Überarbeitungen nach Abgabe und gefährden den Zeitplan. Arbeite
+ausschließlich mit `academic_context.md` (Arbeitstyp, Forschungsfrage,
+Supervisor-Vorgaben) und `literature_state.md`. Fehlen Daten: frag den User,
 rate nicht.
 
 ## Bewertungskriterien (PASS/FAIL)

--- a/skills/chapter-writer/SKILL.md
+++ b/skills/chapter-writer/SKILL.md
@@ -1,142 +1,142 @@
 ---
 name: Chapter Writer
-description: This skill should be used when the user wants to write, draft, or compose a thesis chapter or section. Triggers on "Kapitel schreiben", "verfassen", "entwerfen", "Abschnitt schreiben", "write chapter", "draft section", "Kapitel formulieren", "Textarbeit", or when the user asks for help composing academic prose for a specific part of their work.
+description: Dieser Skill wird genutzt, wenn der User ein Thesis-Kapitel oder einen Abschnitt schreiben, entwerfen oder formulieren möchte. Triggers on "Kapitel schreiben", "verfassen", "entwerfen", "Abschnitt schreiben", "write chapter", "draft section", "Kapitel formulieren", "Textarbeit", oder wenn der User Hilfe beim Verfassen akademischer Prosa für einen konkreten Teil seiner Arbeit braucht.
 ---
 
-# Chapter Writer
+# Kapitel-Autor
 
-Draft individual thesis chapters and sections using the research context, outline, available literature, and citations. Produce academic prose that the user reviews, edits, and approves section by section.
+Verfasst einzelne Thesis-Kapitel und Abschnitte auf Basis von Forschungskontext, Gliederung, verfügbarer Literatur und Zitaten. Produziert akademische Prosa, die der User Abschnitt für Abschnitt reviewt, editiert und freigibt.
 
-## When This Skill Activates
+## Aktivierung dieses Skills
 
-- The user wants to write or draft a specific chapter or section
-- The user asks for help formulating academic text for their thesis
-- The user wants to expand bullet points or notes into full prose
-- The user needs help with transitions between sections
+- Der User möchte ein bestimmtes Kapitel oder einen Abschnitt schreiben oder entwerfen
+- Der User bittet um Hilfe beim Formulieren akademischen Texts für seine Arbeit
+- Der User möchte Stichpunkte oder Notizen zu Fließtext ausbauen
+- Der User braucht Hilfe bei Übergängen zwischen Abschnitten
 
-## Memory Files
+## Memory-Dateien
 
-### Read
+### Lesen
 
-- `academic_context.md` — Thesis profile, research question, outline, key concepts
-- `literature_state.md` — Available sources, chapter-to-source assignments
-- `writing_state.md` — Current writing progress, word counts, style scores
+- `academic_context.md` — Arbeitsprofil, Forschungsfrage, Gliederung, Schlüsselkonzepte
+- `literature_state.md` — Verfügbare Quellen, Kapitel-Quellen-Zuordnungen
+- `writing_state.md` — Aktueller Schreibfortschritt, Wortzahlen, Style-Scores
 
-### Write
+### Schreiben
 
-- `writing_state.md` — Update word counts, current chapter, and progress after writing
+- `writing_state.md` — Wortzahlen, aktuelles Kapitel und Fortschritt nach dem Schreiben aktualisieren
 
-## Core Workflow
+## Core-Workflow
 
-### 1. Load Context
+### 1. Kontext laden
 
-Read all three memory files. If `academic_context.md` does not exist, inform the user and trigger the Academic Context skill first. If no outline exists, suggest triggering the Advisor skill to create one before writing.
+Lies alle drei Memory-Dateien. Existiert `academic_context.md` nicht, informiere den User und triggere zuerst den Academic-Context-Skill. Gibt es noch keine Gliederung, schlage vor, den Advisor-Skill zu triggern, bevor geschrieben wird.
 
-Extract: target chapter from the outline, assigned sources from literature state, citation style, thesis language, and any existing drafts.
+Extrahiere: Ziel-Kapitel aus der Gliederung, zugeordnete Quellen aus dem Literaturstatus, Zitationsstil, Sprache der Arbeit und vorhandene Entwürfe.
 
-### 2. Identify Target Chapter
+### 2. Ziel-Kapitel bestimmen
 
-Ask the user which chapter or section to write if not already clear. Confirm:
+Frage den User, welches Kapitel oder welcher Abschnitt geschrieben werden soll, falls nicht klar. Kläre:
 
-- Chapter number and title from the outline
-- Scope — What should this chapter accomplish?
-- Available sources assigned to this chapter
-- Expected length (page estimate from outline)
+- Kapitelnummer und -titel aus der Gliederung
+- Scope — Was soll das Kapitel leisten?
+- Verfügbare zugeordnete Quellen
+- Erwarteter Umfang (Seitenschätzung aus der Gliederung)
 
-### 3. Chapter Planning
+### 3. Kapitelplanung
 
-Before writing, create a brief internal plan:
+Bevor geschrieben wird, erstelle einen kurzen internen Plan:
 
-1. **Section breakdown** — Sub-sections with 2-3 sentence descriptions of content
-2. **Source mapping** — Which sources support which sections
-3. **Argument flow** — How the chapter builds toward its contribution to the research question
-4. **Key definitions** — Terms that need to be introduced or referenced
+1. **Abschnitts-Aufbau** — Unterabschnitte mit 2-3 Sätzen Inhaltsbeschreibung
+2. **Quellen-Mapping** — Welche Quellen stützen welche Abschnitte
+3. **Argumentationsfluss** — Wie das Kapitel seinen Beitrag zur Forschungsfrage aufbaut
+4. **Schlüsseldefinitionen** — Begriffe, die eingeführt oder referenziert werden müssen
 
-Present the plan to the user for approval before drafting.
+Plan dem User zur Freigabe vorlegen, bevor gedraftet wird.
 
-### 4. Drafting
+### 4. Draften
 
-Write the chapter section by section. For each section:
+Schreibe das Kapitel Abschnitt für Abschnitt. Für jeden Abschnitt:
 
-1. Draft the text in the thesis language (default: German)
-2. Embed in-text citations using the configured citation style (default: APA7)
-3. Use formal academic register — no colloquialisms, no first person unless methodology requires it
-4. Connect to the research question explicitly where appropriate
-5. Present the draft to the user for review
+1. Text in der Sprache der Arbeit entwerfen (Default: Deutsch)
+2. In-Text-Zitate im konfigurierten Zitationsstil einbauen (Default: APA7)
+3. Formales akademisches Register nutzen — keine Umgangssprache, keine Ich-Form, außer die Methodik verlangt es
+4. Wo sinnvoll, explizit an die Forschungsfrage anknüpfen
+5. Entwurf dem User zur Durchsicht vorlegen
 
-#### Writing Guidelines
+#### Schreibrichtlinien
 
-- **Paragraph structure** — Topic sentence, elaboration, evidence, synthesis
-- **Citation density** — At least one citation per substantive claim in theory chapters; less in methodology/analysis
-- **Transitions** — Each section ends with a bridge to the next
-- **Hedging language** — Use appropriate hedging for claims ("suggests", "indicates", "according to")
-- **No filler** — Every sentence must contribute to the argument
+- **Absatzstruktur** — Topic Sentence, Ausarbeitung, Evidenz, Synthese
+- **Zitationsdichte** — In Theoriekapiteln mindestens ein Zitat pro substanzieller Aussage; weniger in Methodik/Analyse
+- **Übergänge** — Jeder Abschnitt endet mit einer Brücke zum nächsten
+- **Hedging-Sprache** — Angemessene Abschwächung bei Aussagen ("deutet darauf hin", "weist darauf hin", "laut")
+- **Keine Füllwörter** — Jeder Satz muss zur Argumentation beitragen
 
-#### Source Integration
+#### Quellenintegration
 
-When citing sources, use the citation data produced by the Citation Extraction skill (inline-formatiert nach dem in `academic_context.md` konfigurierten Stil). Reference papers by their formatted citation. Support these integration patterns:
+Beim Zitieren die Daten aus dem Citation-Extraction-Skill nutzen (inline-formatiert nach dem in `academic_context.md` konfigurierten Stil). Paper über das formatierte Zitat referenzieren. Folgende Integrationsmuster werden unterstützt:
 
-- **Direct quote** — Exact wording in quotation marks with page number
-- **Paraphrase** — Restate in own words with citation
-- **Summary** — Condense a source's argument with citation
-- **Synthesis** — Combine multiple sources to support a point
+- **Direktzitat** — Exakter Wortlaut in Anführungszeichen mit Seitenzahl
+- **Paraphrase** — In eigenen Worten wiedergeben, mit Zitat
+- **Zusammenfassung** — Argumentation einer Quelle verdichten, mit Zitat
+- **Synthese** — Mehrere Quellen kombinieren, um einen Punkt zu stützen
 
-### 5. User Review Cycle
+### 5. User-Review-Zyklus
 
-After presenting each section draft:
+Nach dem Vorstellen jedes Abschnittsentwurfs:
 
-- Wait for user feedback before proceeding
-- Accept edits, rewrites, or approval
-- Incorporate feedback into the next section
-- Never proceed to the next section without user confirmation
+- Auf User-Feedback warten, bevor weitergeschrieben wird
+- Edits, Rewrites oder Freigaben akzeptieren
+- Feedback in den nächsten Abschnitt übernehmen
+- Nie ohne Bestätigung des Users zum nächsten Abschnitt übergehen
 
-If the user provides their own notes or bullet points, expand them into academic prose while preserving the user's intended meaning.
+Liefert der User eigene Notizen oder Stichpunkte, bau sie zu akademischer Prosa aus und bewahre die inhaltliche Absicht.
 
-### 6. Chapter Assembly
+### 6. Kapitel-Zusammensetzung
 
-After all sections are reviewed and approved:
+Nachdem alle Abschnitte reviewt und freigegeben sind:
 
-1. Combine sections into the complete chapter
-2. Check internal consistency (terminology, argument flow)
-3. Verify all citations are present and correctly formatted
-4. Add chapter introduction (if not the thesis introduction) and chapter summary
-5. Report final word count
+1. Abschnitte zum Gesamtkapitel zusammenführen
+2. Interne Konsistenz prüfen (Terminologie, Argumentationsfluss)
+3. Alle Zitate auf Vollständigkeit und Formatierung prüfen
+4. Kapitel-Einleitung (außer bei Thesis-Einleitung) und Kapitel-Zusammenfassung ergänzen
+5. Finale Wortzahl berichten
 
-### 7. Update Writing State
+### 7. Writing-State aktualisieren
 
-After the user approves the chapter:
+Nach der Freigabe des Kapitels durch den User:
 
-1. Read `writing_state.md` (prevent stale overwrites)
-2. Update current chapter, word count, and progress status
-3. Mark the chapter as "draft complete" in progress tracking
+1. `writing_state.md` lesen (veraltete Überschreibungen vermeiden)
+2. Aktuelles Kapitel, Wortzahl und Fortschrittsstatus aktualisieren
+3. Kapitel im Fortschrittstracking als "draft complete" markieren
 
-## Special Chapter Types
+## Spezielle Kapiteltypen
 
-### Introduction (Einleitung)
+### Einleitung
 
-Follow this structure: topic relevance, problem statement, research question, methodology overview, outline preview. Write last or revise after all other chapters are done.
+Struktur: Themenrelevanz, Problemstellung, Forschungsfrage, Methodik-Überblick, Gliederungs-Vorschau. Zuletzt schreiben oder nach Fertigstellung der anderen Kapitel überarbeiten.
 
-### Theoretical Framework (Theoretischer Rahmen)
+### Theoretischer Rahmen
 
-Heavy citation density. Define all key concepts. Compare perspectives from different authors. Build toward the analytical framework used later.
+Hohe Zitationsdichte. Alle Schlüsselkonzepte definieren. Perspektiven verschiedener Autoren vergleichen. Auf den später verwendeten Analyserahmen hinarbeiten.
 
-### Methodology (Methodik)
+### Methodik
 
-Justify the chosen approach. Describe data collection and analysis methods. Address limitations. Reference methodology literature.
+Den gewählten Ansatz begründen. Datenerhebung und -analyse beschreiben. Limitationen adressieren. Methodik-Literatur referenzieren.
 
-### Analysis / Results (Analyse / Ergebnisse)
+### Analyse / Ergebnisse
 
-Apply the theoretical framework to the data. Present findings structured by sub-questions or themes. Use evidence from primary or secondary sources.
+Den theoretischen Rahmen auf die Daten anwenden. Befunde entlang der Unterfragen oder Themen strukturieren. Evidenz aus Primär- oder Sekundärquellen nutzen.
 
-### Conclusion (Fazit)
+### Fazit
 
-Summarize findings per sub-question. Answer the main research question. Discuss limitations and future research. No new sources.
+Befunde pro Unterfrage zusammenfassen. Die Hauptfrage beantworten. Limitationen und zukünftige Forschung diskutieren. Keine neuen Quellen.
 
-## Important Rules
+## Wichtige Regeln
 
-- **Never write without user review** — Present each section for feedback before continuing
-- **Never fabricate citations** — Only use sources that exist in the literature state
-- **Preserve user voice** — When the user provides notes, respect their phrasing and intent
-- **Match thesis language** — Write in the language specified in academic context
-- **Track progress** — Always update writing_state.md after approved drafts
-- **Flag gaps** — If a section needs a source that is not available, flag it and offer to trigger `/search`
+- **Nie ohne User-Review schreiben** — Jeden Abschnitt zur Durchsicht vorlegen, bevor weitergearbeitet wird
+- **Nie Zitate fabrizieren** — Nur Quellen nutzen, die im Literaturstatus existieren
+- **User-Voice bewahren** — Wenn der User Notizen liefert, Formulierung und Intention respektieren
+- **Sprache der Arbeit einhalten** — In der Sprache schreiben, die im akademischen Kontext angegeben ist
+- **Fortschritt tracken** — Nach freigegebenen Drafts immer `writing_state.md` aktualisieren
+- **Lücken flaggen** — Fehlt für einen Abschnitt eine Quelle, das melden und `/search` anbieten

--- a/skills/chapter-writer/SKILL.md
+++ b/skills/chapter-writer/SKILL.md
@@ -20,10 +20,10 @@ Arbeit passt."
 
 ## Keine Fabrikation
 
-Erfundene Belege, Zitate oder Faktenaussagen im Fließtext sind für die FH Leibniz ein Plagiatsbefund und
-führen zu einem Plagiatsbefund laut FH-Leibniz-Regelung. Arbeite ausschließlich mit Daten aus
-`literature_state.md` oder direkt geladenen PDFs. Fehlen Daten: frag den User,
-rate nicht.
+Erfundene Belege, Zitate oder Faktenaussagen im Fließtext sind laut FH-Leibniz-
+Prüfungsordnung ein Plagiatsbefund und führen zum Verlust der Prüfungsleistung
+(Note 5). Arbeite ausschließlich mit Zitaten aus `literature_state.md` und
+direkt geladenen PDFs. Fehlen Daten: frag den User, rate nicht.
 
 ## Few-Shot-Beispiele (pro Kapiteltyp)
 

--- a/skills/chapter-writer/SKILL.md
+++ b/skills/chapter-writer/SKILL.md
@@ -7,6 +7,13 @@ description: Dieser Skill wird genutzt, wenn der User ein Thesis-Kapitel oder ei
 
 Verfasst einzelne Thesis-Kapitel und Abschnitte auf Basis von Forschungskontext, Gliederung, verfügbarer Literatur und Zitaten. Produziert akademische Prosa, die der User Abschnitt für Abschnitt reviewt, editiert und freigibt.
 
+## Keine Fabrikation
+
+Erfundene Belege, Zitate oder Faktenaussagen im Fließtext sind für die FH Leibniz ein Plagiatsbefund und
+führen zu einem Plagiatsbefund laut FH-Leibniz-Regelung. Arbeite ausschließlich mit Daten aus
+`literature_state.md` oder direkt geladenen PDFs. Fehlen Daten: frag den User,
+rate nicht.
+
 ## Aktivierung dieses Skills
 
 - Der User möchte ein bestimmtes Kapitel oder einen Abschnitt schreiben oder entwerfen

--- a/skills/chapter-writer/SKILL.md
+++ b/skills/chapter-writer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Chapter Writer
-description: Dieser Skill wird genutzt, wenn der User ein Thesis-Kapitel oder einen Abschnitt schreiben, entwerfen oder formulieren möchte. Triggers on "Kapitel schreiben", "verfassen", "entwerfen", "Abschnitt schreiben", "write chapter", "draft section", "Kapitel formulieren", "Textarbeit", oder wenn der User Hilfe beim Verfassen akademischer Prosa für einen konkreten Teil seiner Arbeit braucht.
+description: Dieser Skill wird genutzt, wenn der User ein Thesis-Kapitel oder einen Abschnitt schreiben, entwerfen oder formulieren möchte. Triggers on "Kapitel schreiben", "verfassen", "entwerfen", "Abschnitt schreiben", "write chapter", "draft section", "Kapitel formulieren", "Textarbeit", "Kapitelentwurf prüfen / Kapitelentwurf pruefen", oder wenn der User Hilfe beim Verfassen akademischer Prosa für einen konkreten Teil seiner Arbeit braucht.
 ---
 
 # Kapitel-Autor

--- a/skills/chapter-writer/SKILL.md
+++ b/skills/chapter-writer/SKILL.md
@@ -14,6 +14,54 @@ führen zu einem Plagiatsbefund laut FH-Leibniz-Regelung. Arbeite ausschließlic
 `literature_state.md` oder direkt geladenen PDFs. Fehlen Daten: frag den User,
 rate nicht.
 
+## Few-Shot-Beispiele (pro Kapiteltyp)
+
+### Kapitel: Theorie
+
+**Schlecht** (Grund: Definitionen aneinandergereiht, keine Struktur-Argumentation):
+
+> "Führung ist wichtig. Transformationale Führung ist eine Führungsart.
+> Sie wurde von Bass beschrieben."
+
+**Gut** (Grund: Definition + Einordnung + Abgrenzung, mit Beleg):
+
+> "Transformationale Führung bezeichnet ein Führungskonzept, bei dem
+> Vorgesetzte Mitarbeiter durch Vision und individuelle Förderung über
+> transaktionale Anreize hinaus motivieren (Bass 1985, S. 22). Abgrenzung
+> zur transaktionalen Führung: Transaktional beruht auf Leistungs-
+> Gegenleistungs-Tausch, transformational auf intrinsischer Motivation
+> (Bass & Riggio 2006)."
+
+### Kapitel: Methoden
+
+**Schlecht** (Grund: keine Begründung, keine Operationalisierung):
+
+> "Wir haben eine Umfrage gemacht."
+
+**Gut** (Grund: Wahl + Begründung + Operationalisierung + Grenzen):
+
+> "Gewählt wurde ein standardisierter Online-Fragebogen, weil nur so die
+> angestrebte Stichprobengröße n ≥ 100 im Zeitrahmen erreichbar war.
+> Führungsstil wurde mittels MLQ-5X operationalisiert (Avolio & Bass
+> 2004). Limitation: Selbstauskunft der Mitarbeiter zur Führungs-
+> Wahrnehmung, keine Beobachtungsdaten."
+
+### Kapitel: Diskussion
+
+**Schlecht** (Grund: Ergebnis-Wiederholung ohne Einordnung):
+
+> "Die Umfrage hat gezeigt, dass transformationale Führung besser wirkt.
+> Das passt zu den Erwartungen."
+
+**Gut** (Grund: Befund + Literatur-Kontext + Abweichungs-Erklärung):
+
+> "Der gefundene positive Effekt transformationaler Führung auf
+> Mitarbeiterzufriedenheit (β=0,38, p<0,01) deckt sich mit der Meta-
+> Analyse von Judge & Piccolo (2004), fällt aber schwächer aus als dort
+> berichtet (β=0,59). Mögliche Erklärung: Branchenspezifika in
+> Metallverarbeitung (hohe Arbeitsteilung) dämpfen Führungseffekte —
+> konsistent mit Liao & Chuang (2007)."
+
 ## Aktivierung dieses Skills
 
 - Der User möchte ein bestimmtes Kapitel oder einen Abschnitt schreiben oder entwerfen

--- a/skills/chapter-writer/SKILL.md
+++ b/skills/chapter-writer/SKILL.md
@@ -7,6 +7,17 @@ description: Dieser Skill wird genutzt, wenn der User ein Thesis-Kapitel oder ei
 
 Verfasst einzelne Thesis-Kapitel und Abschnitte auf Basis von Forschungskontext, Gliederung, verfügbarer Literatur und Zitaten. Produziert akademische Prosa, die der User Abschnitt für Abschnitt reviewt, editiert und freigibt.
 
+## Vorbedingungen
+
+Bevor du startest: Prüfe, ob `academic_context.md` und `literature_state.md`
+vorhanden und aktuell sind. Fehlt Kontext → triggere den `academic-context`-
+Skill und warte auf dessen Abschluss.
+
+Lehnt der User den Trigger ab → brich diesen Skill ab und erkläre:
+"Ohne Kapitelstruktur in `literature_state.md` kann ich keinen passenden
+Kapiteltext liefern, weil ich einen Kapiteltyp annehmen würde, der nicht zur
+Arbeit passt."
+
 ## Keine Fabrikation
 
 Erfundene Belege, Zitate oder Faktenaussagen im Fließtext sind für die FH Leibniz ein Plagiatsbefund und

--- a/skills/citation-extraction/SKILL.md
+++ b/skills/citation-extraction/SKILL.md
@@ -7,6 +7,17 @@ description: Dieser Skill wird genutzt, wenn der User Zitate und Quellenangaben 
 
 Extrahiert relevante Zitate aus akademischen PDFs, formatiert sie im gewünschten Stil und organisiert Zitatdaten nach Kapitel. Nutzt den Agent `quote-extractor` für die Extraktion und die Inline-Zitationslogik (siehe Abschnitt "Zitat-Formatierung" unten).
 
+## Vorbedingungen
+
+Bevor du startest: Prüfe, ob `academic_context.md` und `literature_state.md`
+vorhanden und aktuell sind. Fehlt Kontext → triggere den `academic-context`-
+Skill und warte auf dessen Abschluss.
+
+Lehnt der User den Trigger ab → brich diesen Skill ab und erkläre:
+"Ohne Quellenliste in `literature_state.md` kann ich keine Zitate mit
+Zuordnung liefern, weil ich Zitate zu nicht-registrierten Quellen bauen
+würde."
+
 ## Keine Fabrikation
 
 Erfundene Zitate, Seitenzahlen oder Quellenangaben sind für die FH Leibniz ein Plagiatsbefund und

--- a/skills/citation-extraction/SKILL.md
+++ b/skills/citation-extraction/SKILL.md
@@ -1,54 +1,54 @@
 ---
 name: Citation Extraction
-description: This skill should be used when the user wants to extract, format, or manage citations and quotes from academic PDFs. Triggers on "Zitate finden", "zitieren", "Quellenarbeit", "Belege suchen", "citations", "Zitate extrahieren", "quote extraction", "Literaturverzeichnis", "bibliography", or when another skill identifies that citation data is needed for a chapter.
+description: Dieser Skill wird genutzt, wenn der User Zitate und Quellenangaben aus akademischen PDFs extrahieren, formatieren oder verwalten möchte. Triggers on "Zitate finden", "zitieren", "Quellenarbeit", "Belege suchen", "citations", "Zitate extrahieren", "quote extraction", "Literaturverzeichnis", "bibliography", oder wenn ein anderer Skill feststellt, dass Zitatdaten für ein Kapitel gebraucht werden.
 ---
 
-# Citation Extraction
+# Zitat-Extraktion
 
-Extract relevant quotes from academic PDFs, format citations in the required style, and organize citation data by chapter. Uses the quote-extractor agent for extraction and inline citation formatting logic (see "Citation Formatting" below).
+Extrahiert relevante Zitate aus akademischen PDFs, formatiert sie im gewünschten Stil und organisiert Zitatdaten nach Kapitel. Nutzt den Agent `quote-extractor` für die Extraktion und die Inline-Zitationslogik (siehe Abschnitt "Zitat-Formatierung" unten).
 
-## When This Skill Activates
+## Aktivierung dieses Skills
 
-- The user wants to extract quotes or citations from downloaded PDFs
-- The user needs to format a bibliography or reference list
-- The user wants to find supporting evidence for a specific claim or chapter
-- The user asks to organize citations by chapter or topic
+- Der User möchte Zitate oder Belege aus heruntergeladenen PDFs extrahieren
+- Der User braucht eine Bibliografie oder ein Literaturverzeichnis
+- Der User sucht Belege für eine konkrete Aussage oder ein bestimmtes Kapitel
+- Der User möchte Zitate nach Kapitel oder Thema ordnen
 
-## Memory Files
+## Memory-Dateien
 
-### Read
+### Lesen
 
-- `academic_context.md` — Outline structure, citation style, research question
-- `literature_state.md` — Available sources, PDF download status, chapter assignments
+- `academic_context.md` — Gliederungsstruktur, Zitationsstil, Forschungsfrage
+- `literature_state.md` — Verfügbare Quellen, PDF-Download-Status, Kapitelzuordnungen
 
-### Write
+### Schreiben
 
-- `literature_state.md` — Update citation counts and extraction status per source
+- `literature_state.md` — Zitatanzahl und Extraktionsstatus pro Quelle aktualisieren
 
-## Prerequisites
+## Voraussetzungen
 
-If `academic_context.md` does not exist, inform the user and trigger the Academic Context skill first. Citation style must be known before formatting.
+Existiert `academic_context.md` nicht, informiere den User und triggere zuerst den Academic-Context-Skill. Der Zitationsstil muss vor der Formatierung bekannt sein.
 
-## Core Workflow
+## Core-Workflow
 
-### 1. Identify Extraction Scope
+### 1. Extraktions-Scope bestimmen
 
-Determine what the user needs:
+Kläre, was der User braucht:
 
-- **Full extraction** — Process all downloaded PDFs in the session
-- **Chapter-targeted** — Extract quotes relevant to a specific chapter
-- **Source-targeted** — Extract from one or more specific papers
-- **Topic-targeted** — Find quotes about a specific concept across all sources
+- **Vollextraktion** — Alle in der Session heruntergeladenen PDFs verarbeiten
+- **Kapitelbezogen** — Zitate für ein bestimmtes Kapitel extrahieren
+- **Quellenbezogen** — Aus einem oder mehreren bestimmten Papern extrahieren
+- **Themenbezogen** — Zitate zu einem Konzept über alle Quellen hinweg suchen
 
-### 2. Locate PDFs
+### 2. PDFs lokalisieren
 
-Read `literature_state.md` to identify which papers have downloaded PDFs. PDFs are stored in session directories under `~/.academic-research/sessions/*/pdfs/`.
+Lies `literature_state.md`, um zu ermitteln, welche Paper ein heruntergeladenes PDF haben. PDFs liegen unter `~/.academic-research/sessions/*/pdfs/`.
 
-If the user references papers that have no PDFs, offer to trigger `/search` to find and download them.
+Verweist der User auf Paper ohne PDFs, biete an, `/search` zu triggern, um sie zu finden und herunterzuladen.
 
-### 3. Quote Extraction
+### 3. Zitat-Extraktion
 
-For each PDF, spawn the `quote-extractor` agent (defined at `${CLAUDE_PLUGIN_ROOT}/agents/quote-extractor.md`). Provide:
+Für jedes PDF den Agent `quote-extractor` spawnen (definiert in `${CLAUDE_PLUGIN_ROOT}/agents/quote-extractor.md`). Übergebe:
 
 ```json
 {
@@ -63,33 +63,33 @@ For each PDF, spawn the `quote-extractor` agent (defined at `${CLAUDE_PLUGIN_ROO
 }
 ```
 
-When doing chapter-targeted extraction, derive the `research_query` from the chapter title and key concepts in the outline. Use the TOC structure from `academic_context.md` to match papers to chapters.
+Bei kapitelbezogener Extraktion den `research_query` aus Kapiteltitel und Schlüsselkonzepten der Gliederung ableiten. Die Gliederungs-Struktur aus `academic_context.md` nutzen, um Paper zu Kapiteln zu matchen.
 
-### 4. Quality Check
+### 4. Qualitätsprüfung
 
-After extraction, review results:
+Nach der Extraktion die Ergebnisse prüfen:
 
-- Discard quotes with `extraction_quality: "failed"`
-- Flag papers with `possible_pdf_mismatch: true` for manual review
-- Check that quotes are relevant to the target chapter/topic
-- Remove duplicates across papers (same idea, different wording)
+- Zitate mit `extraction_quality: "failed"` verwerfen
+- Paper mit `possible_pdf_mismatch: true` für manuelles Review flaggen
+- Prüfen, ob Zitate tatsächlich für das Zielkapitel/-thema relevant sind
+- Duplikate über Paper hinweg entfernen (gleiche Idee, andere Formulierung)
 
-Present extracted quotes to the user grouped by source, showing:
+Extrahierte Zitate dem User gruppiert nach Quelle präsentieren, mit:
 
-- Quote text
-- Page number (if available)
-- Section of origin
-- Relevance score
-- Paper title and authors
+- Zitattext
+- Seitenzahl (falls verfügbar)
+- Ursprungs-Abschnitt
+- Relevanz-Score
+- Paper-Titel und Autoren
 
-### 5. Citation Formatting
+### 5. Zitat-Formatierung
 
 Formatiere Zitate inline nach dem in `academic_context.md` konfigurierten Stil. Keine externe Skript-Pipeline — Claude generiert die Formate direkt aus den strukturierten Paper-Daten.
 
-#### Supported Styles
+#### Unterstützte Stile
 
-| Style | In-text Example | Bibliography Example |
-|-------|----------------|----------------------|
+| Stil | In-Text-Beispiel | Bibliografie-Beispiel |
+|------|-------------------|-----------------------|
 | APA7 | (Müller, 2023, S. 45) | Müller, H. (2023). *Title*. Journal, 12(3), 44-67. |
 | IEEE | [1, p. 45] | [1] H. Müller, "Title," *Journal*, vol. 12, no. 3, pp. 44-67, 2023. |
 | Harvard | (Müller 2023, p. 45) | Müller, H. 2023, 'Title', *Journal*, vol. 12, no. 3, pp. 44-67. |
@@ -102,50 +102,50 @@ Claude erzeugt bei Bedarf:
 - **In-text-Zitat** — exakt im konfigurierten Stil mit Seitenzahl
 - **Literaturverzeichnis-Eintrag** — formatiert pro Quelle
 - **BibTeX-Datei** — für LaTeX-Integration (in `~/.academic-research/citations.bib` persistieren)
-- **Markdown-Bibliographie** — für Review, sortiert nach Autor/Jahr
+- **Markdown-Bibliografie** — für Review, sortiert nach Autor/Jahr
 - **JSON** — wenn andere Skills die Daten strukturiert brauchen
 
-### 6. Chapter Assignment
+### 6. Kapitelzuordnung
 
-When quotes are extracted for a specific chapter:
+Wenn Zitate für ein bestimmtes Kapitel extrahiert werden:
 
-1. Group quotes by relevance to chapter sub-sections
-2. Suggest placement within the chapter structure
-3. Identify which sub-sections still lack supporting evidence
-4. If gaps are found, offer to search for additional literature
+1. Zitate nach Relevanz für die Unterabschnitte gruppieren
+2. Platzierung innerhalb der Kapitelstruktur vorschlagen
+3. Unterabschnitte identifizieren, in denen noch stützende Evidenz fehlt
+4. Bei Lücken weitere Literatursuche anbieten
 
-### 7. Update Literature State
+### 7. Literaturstatus aktualisieren
 
-After extraction and formatting:
+Nach Extraktion und Formatierung:
 
-1. Read `literature_state.md` (prevent stale overwrites)
-2. Update per-source fields: quote count, extraction quality, assigned chapters
-3. Update aggregate statistics: total quotes extracted, coverage percentage
+1. `literature_state.md` lesen (veraltete Überschreibungen vermeiden)
+2. Pro-Quelle-Felder aktualisieren: Zitatanzahl, Extraktionsqualität, zugewiesene Kapitel
+3. Aggregierte Statistiken aktualisieren: extrahierte Zitate gesamt, Coverage-Prozentsatz
 
-## Gap Detection
+## Lückenerkennung
 
-During extraction, watch for these patterns:
+Während der Extraktion auf diese Muster achten:
 
-- **Chapters with zero quotes** — Flag as needing literature
-- **One-source chapters** — Flag as potentially under-supported
-- **Missing counter-arguments** — If all quotes support the same position, suggest looking for opposing views
-- **Outdated sources** — Flag quotes from sources older than 10 years unless they are seminal works
+- **Kapitel ohne Zitate** — Als literaturbedürftig flaggen
+- **Kapitel mit nur einer Quelle** — Als potenziell unzureichend flaggen
+- **Fehlende Gegenargumente** — Wenn alle Zitate dieselbe Position stützen, nach Gegenpositionen suchen
+- **Veraltete Quellen** — Zitate aus Quellen älter als 10 Jahre flaggen, außer es sind Standardwerke
 
-When gaps are detected, offer to trigger `/search` with targeted queries or trigger the Literature Gap Analysis skill for a comprehensive review.
+Bei erkannten Lücken `/search` mit gezielten Queries anbieten oder den Skill "Literature Gap Analysis" für ein umfassendes Review triggern.
 
-## Export Formats
+## Export-Formate
 
-Support these output formats (inline generiert, kein externes Skript):
+Diese Output-Formate werden unterstützt (inline generiert, kein externes Skript):
 
-- **BibTeX** — For LaTeX integration
-- **Markdown** — For review and manual editing
-- **JSON** — For programmatic use by other skills
+- **BibTeX** — für LaTeX-Integration
+- **Markdown** — für Review und manuelles Editieren
+- **JSON** — für die programmatische Nutzung durch andere Skills
 
-## Important Rules
+## Wichtige Regeln
 
-- **Never fabricate quotes** — Only use text extracted directly from PDFs
-- **Preserve exact wording** — Quotes must be verbatim from the source
-- **Include page numbers** — Always include page numbers when available
-- **Respect citation style** — Use the style configured in academic context consistently
-- **Flag mismatches** — If PDF content does not match the expected paper, report it
-- **User confirms assignments** — Let the user approve chapter-to-quote assignments before saving
+- **Nie Zitate fabrizieren** — Nur Text nutzen, der direkt aus PDFs extrahiert wurde
+- **Exakten Wortlaut bewahren** — Zitate müssen wörtlich der Quelle entsprechen
+- **Seitenzahlen angeben** — Wenn verfügbar, immer Seitenzahlen mitführen
+- **Zitationsstil respektieren** — Durchgehend den im akademischen Kontext konfigurierten Stil verwenden
+- **Mismatches flaggen** — Stimmt ein PDF-Inhalt nicht mit dem erwarteten Paper überein, das melden
+- **User bestätigt Zuordnungen** — Kapitel-Zitat-Zuordnungen vor dem Speichern freigeben lassen

--- a/skills/citation-extraction/SKILL.md
+++ b/skills/citation-extraction/SKILL.md
@@ -7,6 +7,13 @@ description: Dieser Skill wird genutzt, wenn der User Zitate und Quellenangaben 
 
 Extrahiert relevante Zitate aus akademischen PDFs, formatiert sie im gewünschten Stil und organisiert Zitatdaten nach Kapitel. Nutzt den Agent `quote-extractor` für die Extraktion und die Inline-Zitationslogik (siehe Abschnitt "Zitat-Formatierung" unten).
 
+## Keine Fabrikation
+
+Erfundene Zitate, Seitenzahlen oder Quellenangaben sind für die FH Leibniz ein Plagiatsbefund und
+führen zu Zitaten, die in der Plagiatsprüfung als nicht-auffindbar markiert werden. Arbeite ausschließlich mit Daten aus
+`literature_state.md` oder direkt geladenen PDFs. Fehlen Daten: frag den User,
+rate nicht.
+
 ## Aktivierung dieses Skills
 
 - Der User möchte Zitate oder Belege aus heruntergeladenen PDFs extrahieren

--- a/skills/citation-extraction/SKILL.md
+++ b/skills/citation-extraction/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Citation Extraction
-description: Dieser Skill wird genutzt, wenn der User Zitate und Quellenangaben aus akademischen PDFs extrahieren, formatieren oder verwalten möchte. Triggers on "Zitate finden", "zitieren", "Quellenarbeit", "Belege suchen", "citations", "Zitate extrahieren", "quote extraction", "Literaturverzeichnis", "bibliography", oder wenn ein anderer Skill feststellt, dass Zitatdaten für ein Kapitel gebraucht werden.
+description: Dieser Skill wird genutzt, wenn der User Zitate und Quellenangaben aus akademischen PDFs extrahieren, formatieren oder verwalten möchte. Triggers on "Zitate finden", "zitieren", "Quellenarbeit", "Belege suchen", "citations", "Zitate extrahieren", "quote extraction", "Literaturverzeichnis prüfen / Literaturverzeichnis pruefen", "bibliography", oder wenn ein anderer Skill feststellt, dass Zitatdaten für ein Kapitel gebraucht werden.
 ---
 
 # Zitat-Extraktion

--- a/skills/citation-extraction/SKILL.md
+++ b/skills/citation-extraction/SKILL.md
@@ -20,10 +20,10 @@ würde."
 
 ## Keine Fabrikation
 
-Erfundene Zitate, Seitenzahlen oder Quellenangaben sind für die FH Leibniz ein Plagiatsbefund und
-führen zu Zitaten, die in der Plagiatsprüfung als nicht-auffindbar markiert werden. Arbeite ausschließlich mit Daten aus
-`literature_state.md` oder direkt geladenen PDFs. Fehlen Daten: frag den User,
-rate nicht.
+Erfundene Zitate, Seitenzahlen oder Quellenangaben werden in der Plagiats-
+prüfung als nicht-auffindbar markiert und gelten als Täuschungsversuch. Arbeite
+ausschließlich mit den geladenen PDFs und Einträgen aus `literature_state.md`.
+Fehlen Daten: frag den User, rate nicht.
 
 ## Aktivierung dieses Skills
 

--- a/skills/literature-gap-analysis/SKILL.md
+++ b/skills/literature-gap-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Literature Gap Analysis
-description: Dieser Skill wird genutzt, wenn der User seine Literaturabdeckung analysieren, fehlende Quellen finden oder Lücken in seiner Forschungsbasis identifizieren möchte. Triggers on "Literaturlücken", "Coverage", "fehlende Quellen", "Gap Analysis", "Quellenabdeckung", "literature gaps", "missing sources", "Abdeckung prüfen", oder wenn ein anderer Skill erkennt, dass Kapitel nicht ausreichend quellengestützt sind.
+description: Dieser Skill wird genutzt, wenn der User seine Literaturabdeckung analysieren, fehlende Quellen finden oder Lücken in seiner Forschungsbasis identifizieren möchte. Triggers on "Literaturlücken / Literaturluecken", "Coverage", "fehlende Quellen", "Gap Analysis", "Quellenabdeckung", "literature gaps", "missing sources", "Abdeckung prüfen / Abdeckung pruefen", oder wenn ein anderer Skill erkennt, dass Kapitel nicht ausreichend quellengestützt sind.
 ---
 
 # Literatur-Lückenanalyse

--- a/skills/literature-gap-analysis/SKILL.md
+++ b/skills/literature-gap-analysis/SKILL.md
@@ -7,6 +7,13 @@ description: Dieser Skill wird genutzt, wenn der User seine Literaturabdeckung a
 
 Analysiert die Thesis-Gliederung gegen die bestehende Literatursammlung und erzeugt einen kapitelweisen Abdeckungsbericht. Identifiziert gut abgedeckte Themen, fehlende Quellen, fehlende Gegenargumente und methodische Lücken. Bietet gezielte Suche zur Lückenschließung an.
 
+## Keine Fabrikation
+
+Erfundene Abdeckungs-Statements oder Quellenlisten sind für die FH Leibniz ein Plagiatsbefund und
+führen zu einem Plagiatsverdacht, wenn behauptete Quellen nicht existieren. Arbeite ausschließlich mit Daten aus
+`literature_state.md` oder direkt geladenen PDFs. Fehlen Daten: frag den User,
+rate nicht.
+
 ## Aktivierung dieses Skills
 
 - Der User fragt nach Literatur-Abdeckung oder Vollständigkeit

--- a/skills/literature-gap-analysis/SKILL.md
+++ b/skills/literature-gap-analysis/SKILL.md
@@ -14,6 +14,23 @@ führen zu einem Plagiatsverdacht, wenn behauptete Quellen nicht existieren. Arb
 `literature_state.md` oder direkt geladenen PDFs. Fehlen Daten: frag den User,
 rate nicht.
 
+## Coverage-Metriken (numerisch)
+
+Berechne und berichte jede dieser 3 Metriken:
+
+1. **Coverage** — Anteil abgedeckter Schlüsselthemen aus `academic_context.md`
+   - Schwelle: ≥ 80 %
+   - Formel: `abgedeckte_Themen / gesamte_Schluesselthemen * 100`
+2. **Diversity** — Zahl eigenständiger Autor*innen-Gruppen (Co-Autor-Cluster)
+   - Schwelle: ≥ 5 Gruppen
+   - Zählweise: Autor*innen, die nur untereinander zusammen publizieren, zählen als 1 Gruppe
+3. **Recency** — Anteil Quellen ab Publikationsjahr 2020
+   - Schwelle: ≥ 40 %
+   - Formel: `Quellen_ab_2020 / Gesamtquellen * 100`
+
+Ausgabe: Tabelle Metrik + Ist-Wert + Schwelle + PASS/FAIL + bei FAIL: konkreter
+Verbesserungsvorschlag (welches Thema, welche Autor*innen, welcher Zeitraum fehlt).
+
 ## Aktivierung dieses Skills
 
 - Der User fragt nach Literatur-Abdeckung oder Vollständigkeit

--- a/skills/literature-gap-analysis/SKILL.md
+++ b/skills/literature-gap-analysis/SKILL.md
@@ -7,6 +7,16 @@ description: Dieser Skill wird genutzt, wenn der User seine Literaturabdeckung a
 
 Analysiert die Thesis-Gliederung gegen die bestehende Literatursammlung und erzeugt einen kapitelweisen Abdeckungsbericht. Identifiziert gut abgedeckte Themen, fehlende Quellen, fehlende Gegenargumente und methodische Lücken. Bietet gezielte Suche zur Lückenschließung an.
 
+## Vorbedingungen
+
+Bevor du startest: Prüfe, ob `academic_context.md` und `literature_state.md`
+vorhanden und aktuell sind. Fehlt Kontext → triggere den `academic-context`-
+Skill und warte auf dessen Abschluss.
+
+Lehnt der User den Trigger ab → brich diesen Skill ab und erkläre:
+"Ohne Themenliste in `academic_context.md` kann ich keine Gap-Bewertung
+liefern, weil ich gegen unbekannte Ziele vergleichen würde."
+
 ## Keine Fabrikation
 
 Erfundene Abdeckungs-Statements oder Quellenlisten sind für die FH Leibniz ein Plagiatsbefund und

--- a/skills/literature-gap-analysis/SKILL.md
+++ b/skills/literature-gap-analysis/SKILL.md
@@ -19,10 +19,10 @@ liefern, weil ich gegen unbekannte Ziele vergleichen würde."
 
 ## Keine Fabrikation
 
-Erfundene Abdeckungs-Statements oder Quellenlisten sind für die FH Leibniz ein Plagiatsbefund und
-führen zu einem Plagiatsverdacht, wenn behauptete Quellen nicht existieren. Arbeite ausschließlich mit Daten aus
-`literature_state.md` oder direkt geladenen PDFs. Fehlen Daten: frag den User,
-rate nicht.
+Erfundene Abdeckungs-Statements oder Quellenlisten führen zu einem
+Plagiatsverdacht, wenn behauptete Quellen nicht existieren. Arbeite
+ausschließlich mit `literature_state.md` (Quelleninventar) und
+`academic_context.md` (Themenliste). Fehlen Daten: frag den User, rate nicht.
 
 ## Abgrenzung
 

--- a/skills/literature-gap-analysis/SKILL.md
+++ b/skills/literature-gap-analysis/SKILL.md
@@ -24,6 +24,22 @@ führen zu einem Plagiatsverdacht, wenn behauptete Quellen nicht existieren. Arb
 `literature_state.md` oder direkt geladenen PDFs. Fehlen Daten: frag den User,
 rate nicht.
 
+## Abgrenzung
+
+Dieser Skill bewertet **Korpus-Vollständigkeit**:
+- Fehlende Schlüsselthemen aus `academic_context.md`
+- Fehlende Autor*innen-Gruppen (Cluster-Diversität)
+- Fehlende Methoden-Perspektiven (qualitativ/quantitativ/mixed)
+- Fehlende Zeitperioden (Aktualitäts-Lücken)
+- Fehlende disziplinäre Sichtweisen (Mono- vs. Multi-Disziplinarität)
+
+Für die Bewertung **einzelner Quellen** (Impact, Methodik der Einzelquelle,
+Peer-Review-Status) → `source-quality-audit`.
+
+Beide Skills greifen auf `literature_state.md` zu, aber mit unterschiedlichem
+Fokus. Wenn der User „Peer-Review" oder „Quellenqualität einzelner Artikel"
+erwähnt → delegiere an `source-quality-audit`.
+
 ## Coverage-Metriken (numerisch)
 
 Berechne und berichte jede dieser 3 Metriken:

--- a/skills/literature-gap-analysis/SKILL.md
+++ b/skills/literature-gap-analysis/SKILL.md
@@ -1,75 +1,75 @@
 ---
 name: Literature Gap Analysis
-description: This skill should be used when the user wants to analyze literature coverage, find missing sources, or identify gaps in their research base. Triggers on "Literaturlücken", "Coverage", "fehlende Quellen", "Gap Analysis", "Quellenabdeckung", "literature gaps", "missing sources", "Abdeckung prüfen", or when another skill detects that chapters lack sufficient source support.
+description: Dieser Skill wird genutzt, wenn der User seine Literaturabdeckung analysieren, fehlende Quellen finden oder Lücken in seiner Forschungsbasis identifizieren möchte. Triggers on "Literaturlücken", "Coverage", "fehlende Quellen", "Gap Analysis", "Quellenabdeckung", "literature gaps", "missing sources", "Abdeckung prüfen", oder wenn ein anderer Skill erkennt, dass Kapitel nicht ausreichend quellengestützt sind.
 ---
 
-# Literature Gap Analysis
+# Literatur-Lückenanalyse
 
-Analyze the thesis outline against the existing literature collection to produce a per-chapter coverage report. Identify well-covered topics, missing sources, missing counter-arguments, and methodological gaps. Offer targeted search to fill gaps.
+Analysiert die Thesis-Gliederung gegen die bestehende Literatursammlung und erzeugt einen kapitelweisen Abdeckungsbericht. Identifiziert gut abgedeckte Themen, fehlende Quellen, fehlende Gegenargumente und methodische Lücken. Bietet gezielte Suche zur Lückenschließung an.
 
-## When This Skill Activates
+## Aktivierung dieses Skills
 
-- The user asks to check literature coverage or completeness
-- The user wants to know which chapters need more sources
-- Another skill (Advisor, Chapter Writer, Citation Extraction) flags insufficient sources
-- The user is preparing for a supervisor meeting and wants a status overview
+- Der User fragt nach Literatur-Abdeckung oder Vollständigkeit
+- Der User möchte wissen, welche Kapitel mehr Quellen brauchen
+- Ein anderer Skill (Advisor, Chapter Writer, Citation Extraction) meldet unzureichende Quellenlage
+- Der User bereitet ein Betreuer-Gespräch vor und möchte einen Statusüberblick
 
-## Memory Files
+## Memory-Dateien
 
-### Read
+### Lesen
 
-- `academic_context.md` — Outline structure, research question, sub-questions, key concepts
-- `literature_state.md` — Source inventory, chapter assignments, PDF status, citation counts
+- `academic_context.md` — Gliederung, Forschungsfrage, Unterfragen, Schlüsselkonzepte
+- `literature_state.md` — Quelleninventar, Kapitelzuordnungen, PDF-Status, Zitatanzahlen
 
-### Write
+### Schreiben
 
-- `literature_state.md` — Update gap analysis results and coverage scores
+- `literature_state.md` — Ergebnisse der Gap-Analyse und Coverage-Scores aktualisieren
 
-## Prerequisites
+## Voraussetzungen
 
-Both `academic_context.md` (with an outline) and `literature_state.md` (with at least some sources) must exist. If either is missing:
+Beide Dateien, `academic_context.md` (mit Gliederung) und `literature_state.md` (mit mindestens einigen Quellen), müssen existieren. Fehlt eines:
 
-- No academic context — trigger the Academic Context skill
-- No literature state — suggest running `/search` first to build a source base
+- Kein akademischer Kontext — Academic-Context-Skill triggern
+- Kein Literaturstatus — zuerst `/search` vorschlagen, um einen Quellenbestand aufzubauen
 
-## Core Workflow
+## Core-Workflow
 
-### 1. Load and Cross-Reference
+### 1. Laden und Gegenüberstellen
 
-Read both memory files. Build a matrix:
+Beide Memory-Dateien lesen. Eine Matrix aufbauen:
 
-- **Rows** — Chapters and sub-sections from the outline
-- **Columns** — Coverage dimensions (see below)
+- **Zeilen** — Kapitel und Unterabschnitte aus der Gliederung
+- **Spalten** — Coverage-Dimensionen (siehe unten)
 
-### 2. Coverage Dimensions
+### 2. Coverage-Dimensionen
 
-Evaluate each chapter along these dimensions:
+Jedes Kapitel entlang dieser Dimensionen bewerten:
 
-#### Source Count
-- 0 sources — CRITICAL: no coverage
-- 1-2 sources — WARNING: thin coverage
-- 3-5 sources — OK for sub-sections
-- 5+ sources — Good for main chapters
+#### Quellenanzahl
+- 0 Quellen — KRITISCH: keine Abdeckung
+- 1-2 Quellen — WARNUNG: dünne Abdeckung
+- 3-5 Quellen — OK für Unterabschnitte
+- 5+ Quellen — Gut für Hauptkapitel
 
-#### Source Quality
-- Percentage of peer-reviewed sources per chapter
-- Presence of seminal/foundational works
-- Recency — percentage of sources from the last 5 years
-- Source diversity — multiple authors, not just one research group
+#### Quellen-Qualität
+- Anteil Peer-Review-Quellen pro Kapitel
+- Präsenz von Standard-/Grundlagenwerken
+- Aktualität — Anteil Quellen aus den letzten 5 Jahren
+- Quellen-Diversität — mehrere Autoren, nicht nur eine Forschungsgruppe
 
-#### Argument Balance
-- Are supporting AND opposing viewpoints represented?
-- Are alternative theories or frameworks mentioned?
-- Is there at least one source that challenges the main argument?
+#### Argumentations-Balance
+- Sind stützende UND gegensätzliche Positionen vertreten?
+- Werden alternative Theorien oder Frameworks erwähnt?
+- Gibt es mindestens eine Quelle, die das Hauptargument hinterfragt?
 
-#### Methodological Alignment
-- Do methodology chapters reference established method literature?
-- Is the chosen method justified by cited precedents?
-- Are limitations of the method discussed with source support?
+#### Methodische Passung
+- Referenzieren die Methodikkapitel etablierte Methodenliteratur?
+- Wird die gewählte Methode durch zitierte Präzedenzen gestützt?
+- Werden Limitationen der Methode mit Quellen diskutiert?
 
-### 3. Generate Coverage Report
+### 3. Coverage-Report erstellen
 
-Produce a structured report with the following format:
+Einen strukturierten Report im folgenden Format erzeugen:
 
 ```
 ## Literatur-Coverage-Report
@@ -83,83 +83,83 @@ Produce a structured report with the following format:
 
 ### Kapitelweise Analyse
 
-#### [Chapter Title]
+#### [Kapiteltitel]
 - Zugewiesene Quellen: [N]
 - Peer-reviewed: [N]%
 - Status: [KRITISCH / LÜCKE / AUSREICHEND / GUT]
-- Fehlend: [specific gap description]
-- Empfehlung: [targeted action]
+- Fehlend: [konkrete Lückenbeschreibung]
+- Empfehlung: [gezielte Aktion]
 ```
 
-### 4. Gap Classification
+### 4. Lücken-Klassifikation
 
-Classify each identified gap:
+Jede identifizierte Lücke einordnen:
 
-| Gap Type | Description | Priority |
-|----------|-------------|----------|
-| CRITICAL | Chapter has zero sources | Immediate |
-| STRUCTURAL | Missing foundational/seminal work | High |
-| BALANCE | No counter-arguments or alternative views | High |
-| RECENCY | All sources older than 5 years | Medium |
-| DEPTH | Too few sources for chapter scope | Medium |
-| DIVERSITY | All sources from same author/group | Low |
+| Lücken-Typ | Beschreibung | Priorität |
+|------------|--------------|-----------|
+| KRITISCH | Kapitel hat keine Quellen | Sofort |
+| STRUKTURELL | Fehlendes Grundlagen-/Standardwerk | Hoch |
+| BALANCE | Keine Gegenargumente oder Alternativsichten | Hoch |
+| AKTUALITÄT | Alle Quellen älter als 5 Jahre | Mittel |
+| TIEFE | Zu wenige Quellen für den Kapitel-Scope | Mittel |
+| DIVERSITÄT | Alle Quellen von derselben Autor/Gruppe | Niedrig |
 
-### 5. Search Recommendations
+### 5. Such-Empfehlungen
 
-For each gap, generate a targeted search recommendation:
+Für jede Lücke eine gezielte Such-Empfehlung erzeugen:
 
-- **Search query** — Derived from chapter title, key concepts, and gap type
-- **Suggested modules** — Which search modules are most likely to yield results
-- **Suggested mode** — quick for minor gaps, deep for critical gaps
-- **Expected source type** — Journal article, conference paper, book chapter, report
+- **Such-Query** — Abgeleitet aus Kapiteltitel, Schlüsselkonzepten und Lücken-Typ
+- **Vorgeschlagene Module** — Welche Such-Module liefern am wahrscheinlichsten Treffer
+- **Vorgeschlagener Modus** — quick bei kleinen Lücken, deep bei kritischen Lücken
+- **Erwarteter Quellentyp** — Journal-Artikel, Konferenzbeitrag, Buchkapitel, Report
 
-Example:
+Beispiel:
 ```
 GAP: Kapitel 3.2 "DevOps Governance Modelle" — keine Gegenargumente
 QUERY: "DevOps governance challenges limitations criticism"
 MODULE: semantic_scholar, crossref
 MODE: standard
-EXPECTED: Journal articles discussing governance limitations
+EXPECTED: Journal-Artikel zu Governance-Limitationen
 ```
 
-### 6. Automated Gap Filling
+### 6. Automatisiertes Lücken-Schließen
 
-When the user approves, trigger `/search` for each gap with the recommended queries. After search completes:
+Mit User-Freigabe `/search` für jede Lücke mit den empfohlenen Queries triggern. Nach Abschluss:
 
-1. Review new results against the gap requirements
-2. Suggest chapter assignments for new sources
-3. Update the coverage report
-4. Re-evaluate coverage scores
+1. Neue Treffer gegen die Lücken-Anforderungen prüfen
+2. Kapitelzuordnung für neue Quellen vorschlagen
+3. Coverage-Report aktualisieren
+4. Coverage-Scores neu berechnen
 
-### 7. Update Literature State
+### 7. Literaturstatus aktualisieren
 
-After analysis:
+Nach der Analyse:
 
-1. Read `literature_state.md` (prevent stale overwrites)
-2. Write gap analysis results: per-chapter coverage scores, identified gaps, recommendations
-3. Update timestamp of last analysis
+1. `literature_state.md` lesen (veraltete Überschreibungen vermeiden)
+2. Ergebnisse schreiben: pro-Kapitel-Coverage-Scores, identifizierte Lücken, Empfehlungen
+3. Zeitstempel der letzten Analyse aktualisieren
 
-## Comparison with Similar Works
+## Vergleich mit ähnlichen Arbeiten
 
-When evaluating completeness, consider:
+Bei der Vollständigkeitsbewertung berücksichtigen:
 
-- **Standard references** — Are commonly cited foundational works in the field present?
-- **Recent surveys** — Has the user included recent literature reviews or meta-analyses?
-- **Methodological references** — Are standard methodology textbooks cited?
-- **Institutional requirements** — Does the source count meet the minimum expected for the work type?
+- **Standardreferenzen** — Sind die üblichen Grundlagenwerke des Felds enthalten?
+- **Aktuelle Reviews** — Gibt es aktuelle Literaturreviews oder Meta-Analysen?
+- **Methodenreferenzen** — Werden Standard-Methodenlehrbücher zitiert?
+- **Institutionelle Anforderungen** — Erfüllt die Quellenzahl das für den Arbeitstyp erwartete Minimum?
 
-Typical minimums by work type:
+Typische Minima nach Arbeitstyp:
 
-| Work Type | Minimum Sources | Peer-reviewed Minimum |
-|-----------|-----------------|-----------------------|
+| Arbeitstyp | Minimum Quellen | Peer-Review-Minimum |
+|------------|-----------------|---------------------|
 | Bachelorarbeit | 25-35 | 60% |
 | Masterarbeit | 40-60 | 70% |
 | Hausarbeit | 10-20 | 50% |
 
-## Important Rules
+## Wichtige Regeln
 
-- **Report facts, not judgments** — Present coverage data objectively; let the user decide priorities
-- **Suggest, do not auto-execute** — Always ask before triggering searches for gaps
-- **Acknowledge limitations** — Gap analysis depends on correct chapter assignments in literature state
-- **Re-run after changes** — Suggest re-running analysis after new literature is added
-- **No false positives** — Only flag gaps where the outline clearly requires source support
+- **Fakten berichten, nicht werten** — Coverage-Daten objektiv präsentieren; der User setzt Prioritäten
+- **Vorschlagen, nicht automatisch ausführen** — Vor Such-Triggern immer nachfragen
+- **Limitationen anerkennen** — Die Gap-Analyse hängt von korrekten Kapitelzuordnungen im Literaturstatus ab
+- **Nach Änderungen neu laufen lassen** — Nach Literatur-Updates eine erneute Analyse vorschlagen
+- **Keine Fehlalarme** — Nur Lücken flaggen, wo die Gliederung klar Quellenbedarf vorsieht

--- a/skills/methodology-advisor/SKILL.md
+++ b/skills/methodology-advisor/SKILL.md
@@ -14,6 +14,26 @@ führen zu Note 5 für das Forschungsdesign. Arbeite ausschließlich mit Daten a
 `literature_state.md` oder direkt geladenen PDFs. Fehlen Daten: frag den User,
 rate nicht.
 
+## Methoden-Scoring-Matrix
+
+Bewerte jede Methoden-Option auf einer Skala 1–5 in 4 Dimensionen:
+
+| Dimension | 1 = schlecht | 3 = okay | 5 = ideal |
+|---|---|---|---|
+| **Datenqualität** | Zugriff fraglich, Daten veraltet/unvollständig | Zugriff gegeben, Daten ausreichend | Zugriff gesichert, Daten aktuell und vollständig |
+| **Zeitaufwand** | > Rahmen der Arbeit | passt eng in den Rahmen | deutlich unter Maximalrahmen |
+| **Supervisor-Präferenz** | explizit abgelehnt | neutral / nicht erwähnt | explizit empfohlen |
+| **Fit zur Forschungsfrage** | beantwortet Frage nicht | beantwortet Frage teilweise | beantwortet Frage direkt |
+
+Gesamt-Score = Summe der 4 Dimensionen (Min 4, Max 20).
+
+**Schwellen zur Empfehlung:**
+- Score ≥ 16: starker Fit, klare Empfehlung
+- Score 10–15: tragfähig, aber mit Hinweis auf die schwächste Dimension
+- Score < 10: nicht empfehlen, alternative Methode suchen
+
+Bei Gleichstand: Supervisor-Präferenz entscheidet. Dokumentiere Scoring in der Ausgabe, nicht nur die Empfehlung.
+
 ## Aktivierung dieses Skills
 
 - Der User muss eine Forschungsmethodik wählen

--- a/skills/methodology-advisor/SKILL.md
+++ b/skills/methodology-advisor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Methodology Advisor
-description: Dieser Skill wird genutzt, wenn der User Hilfe bei Wahl, Begründung oder Verfeinerung seiner Forschungsmethodik braucht. Triggers on "Methodik", "Forschungsdesign", "Methodenwahl", "Vorgehensmodell", "research design", "methodology", "qualitative vs quantitative", "Forschungsmethode", oder wenn der User unsicher ist, wie er seine Forschung systematisch angehen soll.
+description: Dieser Skill wird genutzt, wenn der User Hilfe bei Wahl, Begründung oder Verfeinerung seiner Forschungsmethodik braucht. Triggers on "Methodik", "Forschungsdesign", "Methodenwahl", "Vorgehensmodell", "research design", "methodology", "qualitative vs quantitative", "Forschungsmethode", "Methodik prüfen / Methodik pruefen", "Methoden-Check", oder wenn der User unsicher ist, wie er seine Forschung systematisch angehen soll.
 ---
 
 # Methodik-Berater

--- a/skills/methodology-advisor/SKILL.md
+++ b/skills/methodology-advisor/SKILL.md
@@ -7,6 +7,17 @@ description: Dieser Skill wird genutzt, wenn der User Hilfe bei Wahl, Begründun
 
 Hilft bei Wahl, Begründung und Dokumentation der Forschungsmethodik. Vergleicht Ansätze, prüft die Passung zur Forschungsfrage und produziert Methodik-Texte, die akademischen Standards genügen.
 
+## Vorbedingungen
+
+Bevor du startest: Prüfe, ob `academic_context.md` und `literature_state.md`
+vorhanden und aktuell sind. Fehlt Kontext → triggere den `academic-context`-
+Skill und warte auf dessen Abschluss.
+
+Lehnt der User den Trigger ab → brich diesen Skill ab und erkläre:
+"Ohne Forschungsfrage und Datenzugriffs-Infos kann ich keine Methoden-
+Empfehlung liefern, weil ich Methoden empfehlen würde, die die Frage nicht
+beantworten."
+
 ## Keine Fabrikation
 
 Erfundene Methodik-Standards, Begründungen oder Vergleiche sind für die FH Leibniz ein Plagiatsbefund und

--- a/skills/methodology-advisor/SKILL.md
+++ b/skills/methodology-advisor/SKILL.md
@@ -20,10 +20,11 @@ beantworten."
 
 ## Keine Fabrikation
 
-Erfundene Methodik-Standards, Begründungen oder Vergleiche sind für die FH Leibniz ein Plagiatsbefund und
-führen zu Note 5 für das Forschungsdesign. Arbeite ausschließlich mit Daten aus
-`literature_state.md` oder direkt geladenen PDFs. Fehlen Daten: frag den User,
-rate nicht.
+Erfundene Methodik-Standards, Begründungen oder Vergleiche führen zu Note 5
+für das Forschungsdesign und einer methodisch angreifbaren Arbeit. Arbeite
+ausschließlich mit `academic_context.md` und dem Methoden-Katalog unter
+`${CLAUDE_PLUGIN_ROOT}/skills/methodology-advisor/methodology-catalog.md`.
+Fehlen Daten: frag den User, rate nicht.
 
 ## Methoden-Scoring-Matrix
 

--- a/skills/methodology-advisor/SKILL.md
+++ b/skills/methodology-advisor/SKILL.md
@@ -1,150 +1,150 @@
 ---
 name: Methodology Advisor
-description: This skill should be used when the user needs help choosing, justifying, or refining their research methodology. Triggers on "Methodik", "Forschungsdesign", "Methodenwahl", "Vorgehensmodell", "research design", "methodology", "qualitative vs quantitative", "Forschungsmethode", or when the user is unsure how to approach their research systematically.
+description: Dieser Skill wird genutzt, wenn der User Hilfe bei Wahl, Begründung oder Verfeinerung seiner Forschungsmethodik braucht. Triggers on "Methodik", "Forschungsdesign", "Methodenwahl", "Vorgehensmodell", "research design", "methodology", "qualitative vs quantitative", "Forschungsmethode", oder wenn der User unsicher ist, wie er seine Forschung systematisch angehen soll.
 ---
 
-# Methodology Advisor
+# Methodik-Berater
 
-Help choose, justify, and document the research methodology for the thesis. Compare approaches, evaluate fit with the research question, and produce methodology text that meets academic standards.
+Hilft bei Wahl, Begründung und Dokumentation der Forschungsmethodik. Vergleicht Ansätze, prüft die Passung zur Forschungsfrage und produziert Methodik-Texte, die akademischen Standards genügen.
 
-## When This Skill Activates
+## Aktivierung dieses Skills
 
-- The user needs to choose a research methodology
-- The user wants to compare qualitative vs. quantitative approaches
-- The user needs to justify their chosen method for a supervisor or expose
-- The user is writing the methodology chapter and needs structural guidance
+- Der User muss eine Forschungsmethodik wählen
+- Der User möchte qualitative vs. quantitative Ansätze vergleichen
+- Der User muss seine Methodenwahl gegenüber Betreuer oder Exposé begründen
+- Der User schreibt das Methodik-Kapitel und braucht strukturelle Orientierung
 
-## Memory Files
+## Memory-Dateien
 
-### Read
+### Lesen
 
-- `academic_context.md` — Research question, sub-questions, work type, topic, existing methodology choice
+- `academic_context.md` — Forschungsfrage, Unterfragen, Arbeitstyp, Thema, vorhandene Methodenwahl
 
-### Write
+### Schreiben
 
-- `academic_context.md` — Update the methodology field after a decision is made
+- `academic_context.md` — Methodik-Feld nach der Entscheidung aktualisieren
 
-## Reference
+## Referenz
 
-Consult the methodology catalog at `${CLAUDE_PLUGIN_ROOT}/skills/methodology-advisor/methodology-catalog.md` for detailed descriptions, strengths, weaknesses, and use cases of each methodology type.
+Konsultiere den Methoden-Katalog unter `${CLAUDE_PLUGIN_ROOT}/skills/methodology-advisor/methodology-catalog.md` für detaillierte Beschreibungen, Stärken, Schwächen und Einsatzszenarien jedes Methodentyps.
 
-## Core Workflow
+## Core-Workflow
 
-### 1. Load Context
+### 1. Kontext laden
 
-Read `academic_context.md`. If it does not exist, trigger the Academic Context skill first. Extract: research question, sub-questions, work type, topic, and any preliminary methodology choice.
+Lies `academic_context.md`. Existiert sie nicht, triggere zuerst den Academic-Context-Skill. Extrahiere: Forschungsfrage, Unterfragen, Arbeitstyp, Thema und eine eventuell vorhandene Methodik-Wahl.
 
-### 2. Assess Research Question Type
+### 2. Typ der Forschungsfrage einschätzen
 
-Classify the research question to narrow down suitable methodologies:
+Die Forschungsfrage klassifizieren, um geeignete Methoden einzugrenzen:
 
-| Question Type | Indicators | Suitable Methods |
-|---------------|------------|------------------|
-| Exploratory | "How does...", "What factors..." | Qualitative, Case Study, Grounded Theory |
-| Descriptive | "What is the state of...", "How is...structured" | Literature Review, Survey, Content Analysis |
-| Explanatory | "Why does...", "What causes..." | Quantitative, Experiment, Regression |
-| Evaluative | "How effective...", "What impact..." | Mixed Methods, Case Study, Comparative |
-| Design-oriented | "How can...be designed" | Design Science, Action Research |
+| Fragentyp | Indikatoren | Geeignete Methoden |
+|-----------|-------------|--------------------|
+| Explorativ | "Wie funktioniert...", "Welche Faktoren..." | Qualitativ, Fallstudie, Grounded Theory |
+| Deskriptiv | "Wie ist der Stand von...", "Wie ist...gestaltet" | Literaturreview, Survey, Inhaltsanalyse |
+| Erklärend | "Warum...", "Was verursacht..." | Quantitativ, Experiment, Regression |
+| Evaluativ | "Wie wirksam...", "Welchen Einfluss..." | Mixed Methods, Fallstudie, Vergleich |
+| Gestaltungsorientiert | "Wie kann...gestaltet werden" | Design Science, Action Research |
 
-Present the classification and reasoning to the user for confirmation.
+Klassifikation und Begründung dem User zur Bestätigung vorlegen.
 
-### 3. Methodology Comparison
+### 3. Methodenvergleich
 
-Based on the question type, present 2-3 candidate methodologies. For each, cover:
+Basierend auf dem Fragentyp 2-3 Kandidaten-Methodiken präsentieren. Pro Methode behandeln:
 
-#### Systematic Literature Review (SLR)
-- **When:** Synthesizing existing research on a well-defined topic
-- **Strengths:** Reproducible, comprehensive, no primary data needed
-- **Weaknesses:** Limited to published work, time-intensive search phase
-- **Fit for:** Bachelorarbeit (common), Masterarbeit (as foundation)
-- **Key references:** Kitchenham (2004), Webster & Watson (2002), Tranfield et al. (2003)
+#### Systematisches Literaturreview (SLR)
+- **Wann:** Synthese bestehender Forschung zu einem abgegrenzten Thema
+- **Stärken:** Reproduzierbar, umfassend, keine Primärdaten nötig
+- **Schwächen:** Auf publizierte Arbeiten beschränkt, zeitintensive Suchphase
+- **Passung:** Bachelorarbeit (verbreitet), Masterarbeit (als Grundlage)
+- **Kernreferenzen:** Kitchenham (2004), Webster & Watson (2002), Tranfield et al. (2003)
 
-#### Qualitative Research
-- **When:** Understanding perspectives, experiences, or processes
-- **Subtypes:** Interviews, Focus Groups, Ethnography, Grounded Theory
-- **Strengths:** Rich data, context-sensitive, emergent findings
-- **Weaknesses:** Small samples, subjectivity, not generalizable
-- **Fit for:** Masterarbeit, exploratory Bachelorarbeit
-- **Key references:** Mayring (2015), Flick (2022), Yin (2018)
+#### Qualitative Forschung
+- **Wann:** Perspektiven, Erfahrungen oder Prozesse verstehen
+- **Subtypen:** Interviews, Fokusgruppen, Ethnographie, Grounded Theory
+- **Stärken:** Reichhaltige Daten, kontextsensitiv, emergente Befunde
+- **Schwächen:** Kleine Stichproben, Subjektivität, nicht verallgemeinerbar
+- **Passung:** Masterarbeit, explorative Bachelorarbeit
+- **Kernreferenzen:** Mayring (2015), Flick (2022), Yin (2018)
 
-#### Quantitative Research
-- **When:** Measuring, testing hypotheses, establishing correlations
-- **Subtypes:** Survey, Experiment, Secondary Data Analysis
-- **Strengths:** Generalizable, statistical rigor, reproducible
-- **Weaknesses:** Requires sufficient sample size, may miss context
-- **Fit for:** Masterarbeit, data-driven Bachelorarbeit
-- **Key references:** Bortz & Döring (2006), Field (2018)
+#### Quantitative Forschung
+- **Wann:** Messen, Hypothesen testen, Korrelationen feststellen
+- **Subtypen:** Survey, Experiment, Sekundärdatenanalyse
+- **Stärken:** Verallgemeinerbar, statistische Rigorosität, reproduzierbar
+- **Schwächen:** Braucht ausreichende Stichprobengröße, Kontext kann verloren gehen
+- **Passung:** Masterarbeit, datenbasierte Bachelorarbeit
+- **Kernreferenzen:** Bortz & Döring (2006), Field (2018)
 
 #### Mixed Methods
-- **When:** Research question requires both breadth and depth
-- **Subtypes:** Sequential Explanatory, Sequential Exploratory, Convergent
-- **Strengths:** Comprehensive, triangulation, compensates weaknesses
-- **Weaknesses:** Complex, time-intensive, requires dual competence
-- **Fit for:** Masterarbeit
-- **Key references:** Creswell & Creswell (2018), Tashakkori & Teddlie (2010)
+- **Wann:** Forschungsfrage braucht Breite und Tiefe
+- **Subtypen:** Sequential Explanatory, Sequential Exploratory, Convergent
+- **Stärken:** Umfassend, Triangulation, Schwächen kompensiert
+- **Schwächen:** Komplex, zeitintensiv, doppelte Kompetenz nötig
+- **Passung:** Masterarbeit
+- **Kernreferenzen:** Creswell & Creswell (2018), Tashakkori & Teddlie (2010)
 
-#### Case Study
-- **When:** Investigating a phenomenon in its real-world context
-- **Subtypes:** Single Case, Multiple Case, Embedded
-- **Strengths:** In-depth analysis, real-world relevance
-- **Weaknesses:** Limited generalizability, selection bias
-- **Fit for:** Bachelorarbeit, Masterarbeit
-- **Key references:** Yin (2018), Eisenhardt (1989), Stake (1995)
+#### Fallstudie
+- **Wann:** Ein Phänomen im realen Kontext untersuchen
+- **Subtypen:** Single Case, Multiple Case, Embedded
+- **Stärken:** Tiefe Analyse, Realitätsbezug
+- **Schwächen:** Eingeschränkte Generalisierbarkeit, Selektionsbias
+- **Passung:** Bachelorarbeit, Masterarbeit
+- **Kernreferenzen:** Yin (2018), Eisenhardt (1989), Stake (1995)
 
 #### Design Science Research (DSR)
-- **When:** Creating and evaluating an artifact (framework, model, tool)
-- **Strengths:** Practical contribution, iterative refinement
-- **Weaknesses:** Evaluation criteria must be defined upfront
-- **Fit for:** Wirtschaftsinformatik, engineering-oriented works
-- **Key references:** Hevner et al. (2004), Peffers et al. (2007)
+- **Wann:** Ein Artefakt (Framework, Modell, Tool) entwickeln und evaluieren
+- **Stärken:** Praxisbeitrag, iterative Verfeinerung
+- **Schwächen:** Evaluationskriterien müssen vorab definiert sein
+- **Passung:** Wirtschaftsinformatik, ingenieurorientierte Arbeiten
+- **Kernreferenzen:** Hevner et al. (2004), Peffers et al. (2007)
 
-### 4. Interactive Decision
+### 4. Interaktive Entscheidung
 
-Guide the user to a decision through targeted questions:
+Den User mit gezielten Fragen zur Entscheidung führen:
 
-1. **Data availability** — Does primary data collection require ethics approval, access, or time?
-2. **Skills and tools** — Is the user comfortable with statistical software, interview techniques, etc.?
-3. **Supervisor expectations** — Has the supervisor indicated a preference?
-4. **Time constraints** — How much time is available for data collection and analysis?
-5. **Work type fit** — Is the method realistic for the scope of the work?
+1. **Datenverfügbarkeit** — Braucht Primärdatenerhebung Ethikvotum, Zugang oder viel Zeit?
+2. **Fähigkeiten und Tools** — Ist der User fit in Statistik-Software, Interviewtechniken etc.?
+3. **Betreuer-Erwartungen** — Hat der Betreuer eine Präferenz geäußert?
+4. **Zeit-Constraints** — Wie viel Zeit bleibt für Datenerhebung und -analyse?
+5. **Passung zum Arbeitstyp** — Ist die Methode realistisch für den Scope?
 
-Present a recommendation with clear reasoning. Let the user decide.
+Eine Empfehlung mit klarer Begründung präsentieren. Den User entscheiden lassen.
 
-### 5. Methodology Justification
+### 5. Methodik-Begründung
 
-After the user chooses a method, help formulate the justification text:
+Nach der Wahl den Begründungstext formulieren:
 
-- **Why this method** — Connect to the research question type
-- **Why not alternatives** — Brief reasoning for rejecting other options
-- **Precedent** — Reference published studies in the same field using this method
-- **Limitations** — Acknowledge known limitations and mitigation strategies
+- **Warum diese Methode** — Bezug zum Typ der Forschungsfrage
+- **Warum keine Alternativen** — Kurze Begründung gegen andere Optionen
+- **Präzedenzen** — Veröffentlichte Studien im gleichen Feld mit dieser Methode nennen
+- **Limitationen** — Bekannte Grenzen und Mitigationen transparent machen
 
-This justification can be used directly in the expose or methodology chapter.
+Dieser Text kann direkt in Exposé oder Methodik-Kapitel übernommen werden.
 
-### 6. Methodology Chapter Structure
+### 6. Struktur des Methodik-Kapitels
 
-Provide a recommended structure for the methodology chapter:
+Empfohlene Struktur für das Methodik-Kapitel:
 
-1. **Forschungsdesign** — Overview of the chosen approach
-2. **Begründung der Methodenwahl** — Justification (from step 5)
-3. **Datenerhebung** — How data is collected (or how literature is searched)
-4. **Datenanalyse** — How data is analyzed (coding, statistics, comparison)
-5. **Gütekriterien** — Quality criteria (validity, reliability, or trustworthiness)
-6. **Limitationen** — Methodological limitations
+1. **Forschungsdesign** — Überblick über den gewählten Ansatz
+2. **Begründung der Methodenwahl** — Begründung (aus Schritt 5)
+3. **Datenerhebung** — Wie Daten erhoben werden (oder wie Literatur gesucht wird)
+4. **Datenanalyse** — Wie Daten analysiert werden (Coding, Statistik, Vergleich)
+5. **Gütekriterien** — Validität, Reliabilität oder Trustworthiness
+6. **Limitationen** — Methodische Grenzen
 
-### 7. Save Decision
+### 7. Entscheidung speichern
 
-After the user confirms:
+Nach Bestätigung des Users:
 
-1. Read `academic_context.md` (prevent stale overwrites)
-2. Update the `Methodik` field with the chosen methodology
-3. Add key methodology references to `## Schlüsselkonzepte` if not already present
+1. `academic_context.md` lesen (veraltete Überschreibungen vermeiden)
+2. Das Feld `Methodik` mit der gewählten Methodik aktualisieren
+3. Zentrale Methoden-Referenzen zu `## Schlüsselkonzepte` hinzufügen, falls noch nicht vorhanden
 
-## Important Rules
+## Wichtige Regeln
 
-- **Never choose for the user** — Present options with clear trade-offs, let the user decide
-- **Match scope to work type** — Do not recommend complex mixed methods for a Hausarbeit
-- **Cite methodology literature** — Every recommended method should reference established sources
-- **Be honest about limitations** — Every method has weaknesses; present them transparently
-- **Consider supervisor preferences** — If mentioned, factor them into the recommendation
-- **Revisit if needed** — Methodology can be refined as the work progresses; note this to the user
+- **Nie für den User entscheiden** — Optionen mit klaren Trade-offs zeigen, User entscheidet
+- **Scope zum Arbeitstyp passen lassen** — Keine komplexen Mixed-Methods-Designs für eine Hausarbeit
+- **Methodik-Literatur zitieren** — Jede empfohlene Methode mit etablierten Quellen belegen
+- **Ehrlich zu Limitationen** — Jede Methode hat Schwächen; diese transparent darstellen
+- **Betreuer-Präferenzen berücksichtigen** — Wenn erwähnt, in die Empfehlung einbeziehen
+- **Bei Bedarf revidieren** — Die Methodik kann sich im Projektverlauf anpassen; das dem User mitteilen

--- a/skills/methodology-advisor/SKILL.md
+++ b/skills/methodology-advisor/SKILL.md
@@ -7,6 +7,13 @@ description: Dieser Skill wird genutzt, wenn der User Hilfe bei Wahl, Begründun
 
 Hilft bei Wahl, Begründung und Dokumentation der Forschungsmethodik. Vergleicht Ansätze, prüft die Passung zur Forschungsfrage und produziert Methodik-Texte, die akademischen Standards genügen.
 
+## Keine Fabrikation
+
+Erfundene Methodik-Standards, Begründungen oder Vergleiche sind für die FH Leibniz ein Plagiatsbefund und
+führen zu Note 5 für das Forschungsdesign. Arbeite ausschließlich mit Daten aus
+`literature_state.md` oder direkt geladenen PDFs. Fehlen Daten: frag den User,
+rate nicht.
+
 ## Aktivierung dieses Skills
 
 - Der User muss eine Forschungsmethodik wählen

--- a/skills/plagiarism-check/SKILL.md
+++ b/skills/plagiarism-check/SKILL.md
@@ -7,6 +7,17 @@ description: Dieser Skill wird genutzt, wenn der User Text auf unbeabsichtigtes 
 
 Prüft akademischen Text auf unbeabsichtigte Nähe zum Quellmaterial. Erkennt zu nahe Paraphrasen, unzureichend umformulierte Passagen und fehlende Quellenangaben via N-Gramm-Overlap-Detection. Schlägt Umformulierungen für markierte Passagen vor.
 
+## Vorbedingungen
+
+Bevor du startest: Prüfe, ob `academic_context.md` und `literature_state.md`
+vorhanden und aktuell sind. Fehlt Kontext → triggere den `academic-context`-
+Skill und warte auf dessen Abschluss.
+
+Lehnt der User den Trigger ab → brich diesen Skill ab und erkläre:
+"Ohne Quellenlisten in `literature_state.md` kann ich kein Similarity-Urteil
+liefern, weil ich gegen unbekannte Quellen prüfen und False-Negatives
+produzieren würde."
+
 ## Keine Fabrikation
 
 Erfundene Similarity-Urteile oder N-Gramm-Matches sind für die FH Leibniz ein Plagiatsbefund und

--- a/skills/plagiarism-check/SKILL.md
+++ b/skills/plagiarism-check/SKILL.md
@@ -20,10 +20,11 @@ produzieren würde."
 
 ## Keine Fabrikation
 
-Erfundene Similarity-Urteile oder N-Gramm-Matches sind für die FH Leibniz ein Plagiatsbefund und
-führen zu unentdecktem Plagiat, das später auffliegt. Arbeite ausschließlich mit Daten aus
-`literature_state.md` oder direkt geladenen PDFs. Fehlen Daten: frag den User,
-rate nicht.
+Erfundene Similarity-Urteile oder N-Gramm-Matches lassen unentdecktes Plagiat
+durch und führen dazu, dass Textstellen, die beim offiziellen Plagiats-Check
+der FH Leibniz auffliegen, hier unbemerkt geblieben sind. Arbeite ausschließlich
+mit dem User-Text und den PDF-Extrakten aus `literature_state.md`. Fehlen
+Daten: frag den User, rate nicht.
 
 ## Aktivierung dieses Skills
 

--- a/skills/plagiarism-check/SKILL.md
+++ b/skills/plagiarism-check/SKILL.md
@@ -1,144 +1,144 @@
 ---
 name: Plagiarism Check
-description: This skill should be used when the user wants to check text for unintentional plagiarism, too-close paraphrases, or source proximity. Triggers on "Plagiat pruefen", "Textaehnlichkeit", "Paraphrase checken", "plagiarism", "zu nah am Original", "Plagiatspruefung", "source similarity", "text similarity check", or when the user is concerned about paraphrasing quality.
+description: Dieser Skill wird genutzt, wenn der User Text auf unbeabsichtigtes Plagiat, zu nahe Paraphrasen oder Nähe zum Quellmaterial prüfen möchte. Triggers on "Plagiat pruefen", "Textaehnlichkeit", "Paraphrase checken", "plagiarism", "zu nah am Original", "Plagiatspruefung", "source similarity", "text similarity check", oder wenn der User Sorge um seine Paraphrasierungs-Qualität hat.
 ---
 
-# Plagiarism Check
+# Plagiatsprüfung
 
-Check academic text for unintentional proximity to source material. Detect too-close paraphrases, insufficiently reworded passages, and missing attributions using n-gram overlap detection. Suggest reformulations for flagged passages.
+Prüft akademischen Text auf unbeabsichtigte Nähe zum Quellmaterial. Erkennt zu nahe Paraphrasen, unzureichend umformulierte Passagen und fehlende Quellenangaben via N-Gramm-Overlap-Detection. Schlägt Umformulierungen für markierte Passagen vor.
 
-## When This Skill Activates
+## Aktivierung dieses Skills
 
-- The user submits text to check against their sources
-- The user is paraphrasing a source and wants verification
-- Pre-submission quality assurance before final hand-in
-- Another skill (e.g., Chapter Writer) requests a plagiarism gate
+- Der User reicht Text zur Prüfung gegen seine Quellen ein
+- Der User paraphrasiert eine Quelle und möchte verifizieren
+- Qualitätssicherung vor der finalen Abgabe
+- Ein anderer Skill (z. B. Chapter Writer) fordert ein Plagiats-Gate an
 
-## Memory Files
+## Memory-Dateien
 
-- Read `academic_context.md` for citation style and language
-- Read `literature_state.md` for the list of sources used per chapter
-- Read `writing_state.md` for current writing progress context
+- Lies `academic_context.md` für Zitationsstil und Sprache
+- Lies `literature_state.md` für die Liste der pro Kapitel genutzten Quellen
+- Lies `writing_state.md` für aktuellen Schreibkontext
 
-## Scripts
+## Skripte
 
-Use `${CLAUDE_PLUGIN_ROOT}/scripts/text_utils.py` for tokenization (`tokenize()` function) and text normalization utilities.
+Nutze `${CLAUDE_PLUGIN_ROOT}/scripts/text_utils.py` für Tokenisierung (`tokenize()`-Funktion) und Textnormalisierung.
 
-## Detection Methods
+## Detektions-Methoden
 
-### 1. N-Gram Overlap Detection
+### 1. N-Gramm-Overlap-Detection
 
-Compare the user's text against source texts (PDF extracts from the session).
+User-Text gegen Quelltexte (PDF-Extrakte aus der Session) vergleichen.
 
-**Procedure:**
-1. Tokenize both user text and source text into lowercase word sequences
-2. Generate n-grams for n = 3, 4, 5, 6, 7
-3. Compute overlap ratio: `overlap = matching_ngrams / total_ngrams_in_user_text`
-4. Apply thresholds per n-gram size:
-   - 3-grams: flag if overlap > 40% (common phrases tolerated)
-   - 4-grams: flag if overlap > 25%
-   - 5-grams: flag if overlap > 15%
-   - 6-grams: flag if overlap > 8%
-   - 7-grams: flag if overlap > 5% (near-verbatim)
+**Ablauf:**
+1. User-Text und Quelltext in lowercase Wortfolgen tokenisieren
+2. N-Gramme für n = 3, 4, 5, 6, 7 erzeugen
+3. Overlap-Ratio berechnen: `overlap = matching_ngrams / total_ngrams_in_user_text`
+4. Schwellen pro N-Gramm-Größe anwenden:
+   - 3-Gramme: flag bei Overlap > 40 % (gängige Phrasen toleriert)
+   - 4-Gramme: flag bei Overlap > 25 %
+   - 5-Gramme: flag bei Overlap > 15 %
+   - 6-Gramme: flag bei Overlap > 8 %
+   - 7-Gramme: flag bei Overlap > 5 % (fast wörtlich)
 
-### 2. Sentence-Level Similarity
+### 2. Satz-Ähnlichkeit
 
-For each sentence in the user's text:
-1. Compare against all sentences in available source material
-2. Use sequence matching (difflib SequenceMatcher) for similarity ratio
-3. Flag sentences with similarity > 0.70 to any single source sentence
-4. Mark as critical if similarity > 0.85
+Für jeden Satz im User-Text:
+1. Gegen alle Sätze im verfügbaren Quellmaterial vergleichen
+2. Sequence Matching (difflib SequenceMatcher) für Similarity-Ratio nutzen
+3. Sätze mit Ähnlichkeit > 0.70 zu einem einzelnen Quellsatz flaggen
+4. Als kritisch markieren, wenn Ähnlichkeit > 0.85
 
-### 3. Structural Mimicry Detection
+### 3. Struktur-Mimikry-Check
 
-Check whether the user's text follows the source's argument structure too closely:
-- Same sequence of claims in the same order
-- Paragraph-by-paragraph correspondence with a single source
-- Identical example progression
+Prüfen, ob der User-Text der Argumentationsstruktur der Quelle zu nahe folgt:
+- Gleiche Abfolge von Aussagen in derselben Reihenfolge
+- Absatz-für-Absatz-Entsprechung zu einer einzelnen Quelle
+- Identische Beispielabfolge
 
-## Source Material Handling
+## Quellmaterial-Handling
 
-### Available Sources
+### Verfügbare Quellen
 
-Check for source texts in this priority order:
-1. PDF texts extracted during the current session (stored in working context)
-2. Source snippets referenced in `literature_state.md`
-3. User-provided original text for direct comparison
+Quelltexte in dieser Priorität suchen:
+1. In der aktuellen Session extrahierte PDF-Texte (im Kontext)
+2. In `literature_state.md` referenzierte Quellen-Snippets
+3. Vom User gelieferter Originaltext für Direktvergleich
 
-### When No Source Text Is Available
+### Wenn kein Quelltext verfügbar ist
 
-If no source PDFs or texts are accessible:
-1. Inform the user that comparison is limited to internal analysis
-2. Still perform internal duplication checks (repeated passages within the text)
-3. Flag passages that exhibit signs of close paraphrasing (stilted phrasing, unusual vocabulary choices inconsistent with surrounding text)
-4. Offer to compare if the user provides the original text
+Sind keine Quell-PDFs oder Texte zugänglich:
+1. Dem User mitteilen, dass der Vergleich auf interne Analyse beschränkt ist
+2. Interne Duplikationsprüfung dennoch durchführen (wiederholte Passagen im Text)
+3. Passagen flaggen, die Hinweise auf enges Paraphrasieren zeigen (steife Formulierungen, untypisches Vokabular im Kontext)
+4. Anbieten, zu vergleichen, wenn der User den Originaltext bereitstellt
 
-## Evaluation Workflow
+## Evaluations-Workflow
 
-1. Receive the user's text (chapter, section, or specific passage)
-2. Identify available source material for comparison
-3. Tokenize all texts using `text_utils.tokenize()`
-4. Run n-gram overlap detection per source
-5. Run sentence-level similarity per source
-6. Run structural mimicry check
-7. Compile flagged passages with severity ratings
-8. Generate reformulation suggestions for flagged passages
-9. Present results in structured format
+1. Den User-Text empfangen (Kapitel, Abschnitt oder konkrete Passage)
+2. Verfügbares Quellmaterial zum Vergleich identifizieren
+3. Alle Texte mit `text_utils.tokenize()` tokenisieren
+4. N-Gramm-Overlap-Detection pro Quelle durchführen
+5. Satz-Ähnlichkeit pro Quelle durchführen
+6. Struktur-Mimikry-Check durchführen
+7. Geflaggte Passagen mit Severity-Stufen zusammenstellen
+8. Umformulierungsvorschläge für geflaggte Passagen erzeugen
+9. Ergebnisse in strukturiertem Format präsentieren
 
-## Output Format
+## Output-Format
 
 ```
-## Plagiarism Check: [Section/Chapter Name]
+## Plagiatsprüfung: [Abschnitt/Kapitel]
 
-**Quellen verglichen:** [N sources]
-**Saetze analysiert:** [N sentences]
+**Quellen verglichen:** [N Quellen]
+**Sätze analysiert:** [N Sätze]
 **Gesamtergebnis:** [OK / WARNUNG / KRITISCH]
 
-### Flagged Passages
+### Geflaggte Passagen
 
 #### 1. [Severity: HOCH/MITTEL/NIEDRIG]
-- **Position:** [Paragraph X, Sentence Y]
-- **User Text:** "[flagged passage]"
-- **Source:** [Author (Year), Title]
-- **Similarity:** [X%]
-- **Type:** [Verbatim / Close Paraphrase / Structural]
-- **Reformulation:** "[suggested alternative phrasing]"
+- **Position:** [Absatz X, Satz Y]
+- **User-Text:** "[geflaggte Passage]"
+- **Quelle:** [Autor (Jahr), Titel]
+- **Ähnlichkeit:** [X %]
+- **Typ:** [Wörtlich / Enge Paraphrase / Strukturell]
+- **Umformulierung:** "[vorgeschlagene Alternative]"
 
 #### 2. ...
 
-### Summary
-| Severity | Count |
-|----------|-------|
-| HOCH     | X     |
-| MITTEL   | X     |
-| NIEDRIG  | X     |
+### Zusammenfassung
+| Severity | Anzahl |
+|----------|--------|
+| HOCH     | X      |
+| MITTEL   | X      |
+| NIEDRIG  | X      |
 
-### Recommendations
-[Actionable steps to address flagged passages]
+### Empfehlungen
+[Konkrete Schritte zur Behebung der geflaggten Passagen]
 ```
 
-## Reformulation Guidelines
+## Umformulierungs-Richtlinien
 
-When suggesting reformulations for flagged passages:
+Beim Vorschlagen von Umformulierungen für geflaggte Passagen:
 
-1. **Preserve meaning** -- The academic content and argument must remain identical
-2. **Change structure** -- Restructure the sentence (active/passive, clause order, emphasis shift)
-3. **Replace vocabulary** -- Use discipline-appropriate synonyms (not random thesaurus substitutions)
-4. **Integrate citations** -- Ensure proper attribution is part of the reformulation
-5. **Maintain register** -- Keep the same academic tone and formality level
-6. **Respect language** -- Reformulate in the same language as the original (German or English)
+1. **Bedeutung bewahren** -- Der akademische Inhalt und das Argument müssen identisch bleiben
+2. **Struktur ändern** -- Satz umstellen (Aktiv/Passiv, Nebensatzreihenfolge, Fokusverschiebung)
+3. **Vokabular ersetzen** -- Fachlich passende Synonyme nutzen (keine zufälligen Thesaurus-Ersatz)
+4. **Zitate einbauen** -- Korrekte Quellenangabe als Teil der Umformulierung sicherstellen
+5. **Register halten** -- Gleicher akademischer Ton und Formalitätsgrad
+6. **Sprache respektieren** -- In derselben Sprache umformulieren (Deutsch oder Englisch)
 
-## Severity Classification
+## Severity-Klassifikation
 
-- **HOCH (High):** 7-gram overlap > 5% or sentence similarity > 0.85 -- likely verbatim copy
-- **MITTEL (Medium):** 5-gram overlap > 15% or sentence similarity 0.70-0.85 -- close paraphrase
-- **NIEDRIG (Low):** 4-gram overlap > 25% -- minor phrasing similarity, may be acceptable with proper citation
+- **HOCH:** 7-Gramm-Overlap > 5 % oder Satz-Ähnlichkeit > 0.85 -- wahrscheinlich wörtliche Kopie
+- **MITTEL:** 5-Gramm-Overlap > 15 % oder Satz-Ähnlichkeit 0.70-0.85 -- enge Paraphrase
+- **NIEDRIG:** 4-Gramm-Overlap > 25 % -- minimale Formulierungsähnlichkeit, mit korrekter Zitation meist akzeptabel
 
-## Important Rules
+## Wichtige Regeln
 
-- This is a supportive tool, not a replacement for institutional plagiarism software (Turnitin, PlagScan)
-- Always recommend running institutional tools before final submission
-- Never accuse the user of intentional plagiarism -- frame all findings as opportunities to improve paraphrasing
-- Common academic phrases ("in this context", "the results show") generate expected overlap -- exclude standard academic collocations from flagging
-- Direct quotes with proper citation are not plagiarism -- exclude properly cited quotations from analysis
-- Maintain a list of discipline-specific standard phrases to reduce false positives
+- Dieses Tool ist unterstützend, kein Ersatz für institutionelle Plagiatssoftware (Turnitin, PlagScan)
+- Vor finaler Abgabe immer empfehlen, institutionelle Tools zu nutzen
+- Den User niemals des vorsätzlichen Plagiats beschuldigen -- Funde als Verbesserungschance einordnen
+- Gängige akademische Phrasen ("in diesem Kontext", "die Ergebnisse zeigen") erzeugen erwarteten Overlap -- Standardkollokationen von der Flagging-Logik ausnehmen
+- Direktzitate mit korrekter Quellenangabe sind kein Plagiat -- richtig zitierte Passagen von der Analyse ausnehmen
+- Eine Liste fachspezifischer Standardphrasen pflegen, um False Positives zu reduzieren

--- a/skills/plagiarism-check/SKILL.md
+++ b/skills/plagiarism-check/SKILL.md
@@ -7,6 +7,13 @@ description: Dieser Skill wird genutzt, wenn der User Text auf unbeabsichtigtes 
 
 Prüft akademischen Text auf unbeabsichtigte Nähe zum Quellmaterial. Erkennt zu nahe Paraphrasen, unzureichend umformulierte Passagen und fehlende Quellenangaben via N-Gramm-Overlap-Detection. Schlägt Umformulierungen für markierte Passagen vor.
 
+## Keine Fabrikation
+
+Erfundene Similarity-Urteile oder N-Gramm-Matches sind für die FH Leibniz ein Plagiatsbefund und
+führen zu unentdecktem Plagiat, das später auffliegt. Arbeite ausschließlich mit Daten aus
+`literature_state.md` oder direkt geladenen PDFs. Fehlen Daten: frag den User,
+rate nicht.
+
 ## Aktivierung dieses Skills
 
 - Der User reicht Text zur Prüfung gegen seine Quellen ein

--- a/skills/plagiarism-check/SKILL.md
+++ b/skills/plagiarism-check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Plagiarism Check
-description: Dieser Skill wird genutzt, wenn der User Text auf unbeabsichtigtes Plagiat, zu nahe Paraphrasen oder Nähe zum Quellmaterial prüfen möchte. Triggers on "Plagiat pruefen", "Textaehnlichkeit", "Paraphrase checken", "plagiarism", "zu nah am Original", "Plagiatspruefung", "source similarity", "text similarity check", oder wenn der User Sorge um seine Paraphrasierungs-Qualität hat.
+description: Dieser Skill wird genutzt, wenn der User Text auf unbeabsichtigtes Plagiat, zu nahe Paraphrasen oder Nähe zum Quellmaterial prüfen möchte. Triggers on "Plagiat prüfen / Plagiat pruefen", "Textähnlichkeit / Textaehnlichkeit", "Paraphrase checken", "plagiarism", "zu nah am Original", "Plagiatsprüfung / Plagiatspruefung", "source similarity", "text similarity check", oder wenn der User Sorge um seine Paraphrasierungs-Qualität hat.
 ---
 
 # Plagiatsprüfung

--- a/skills/research-question-refiner/SKILL.md
+++ b/skills/research-question-refiner/SKILL.md
@@ -1,61 +1,61 @@
 ---
 name: Research Question Refiner
-description: This skill should be used when the user wants to formulate, sharpen, or evaluate their research question. Triggers on "Forschungsfrage formulieren", "Research Question", "Fragestellung", "Forschungsfrage", "Forschungsfrage schärfen", "research question refine", "Fragestellung präzisieren", or when another skill identifies that the research question is too broad, too narrow, or not answerable.
+description: Dieser Skill wird genutzt, wenn der User seine Forschungsfrage formulieren, schärfen oder bewerten möchte. Triggers on "Forschungsfrage formulieren", "Research Question", "Fragestellung", "Forschungsfrage", "Forschungsfrage schärfen", "research question refine", "Fragestellung präzisieren", oder wenn ein anderer Skill erkennt, dass die Forschungsfrage zu breit, zu eng oder nicht beantwortbar ist.
 ---
 
-# Research Question Refiner
+# Forschungsfragen-Schärfer
 
-Help precision-craft the main research question and sub-questions. Evaluate whether a question is too broad, too narrow, or unanswerable. Compare with similar works to ensure originality and feasibility.
+Hilft beim präzisen Formulieren von Hauptfrage und Unterfragen. Bewertet, ob eine Frage zu breit, zu eng oder nicht beantwortbar ist. Vergleicht mit ähnlichen Arbeiten, um Originalität und Machbarkeit sicherzustellen.
 
-## When This Skill Activates
+## Aktivierung dieses Skills
 
-- The user wants to formulate a new research question
-- The user wants to refine or sharpen an existing research question
-- The user is unsure if their question is good enough
-- A supervisor has flagged the research question as problematic
-- Another skill (Advisor, Academic Context) identifies a weak research question
+- Der User möchte eine neue Forschungsfrage formulieren
+- Der User möchte eine bestehende Forschungsfrage verfeinern oder schärfen
+- Der User ist unsicher, ob seine Frage gut genug ist
+- Ein Betreuer hat die Forschungsfrage als problematisch markiert
+- Ein anderer Skill (Advisor, Academic Context) erkennt eine schwache Forschungsfrage
 
-## Memory Files
+## Memory-Dateien
 
-### Read
+### Lesen
 
-- `academic_context.md` — Current research question, topic, work type, methodology, outline
+- `academic_context.md` — Aktuelle Forschungsfrage, Thema, Arbeitstyp, Methodik, Gliederung
 
-### Write
+### Schreiben
 
-- `academic_context.md` — Update the research question and sub-questions after refinement
+- `academic_context.md` — Forschungsfrage und Unterfragen nach der Verfeinerung aktualisieren
 
-## Core Workflow
+## Core-Workflow
 
-### 1. Load Context
+### 1. Kontext laden
 
-Read `academic_context.md`. If it does not exist, trigger the Academic Context skill to gather baseline information. Extract: topic, current research question (if any), sub-questions, work type, and methodology.
+Lies `academic_context.md`. Existiert sie nicht, triggere den Academic-Context-Skill, um Basisdaten zu erheben. Extrahiere: Thema, aktuelle Forschungsfrage (falls vorhanden), Unterfragen, Arbeitstyp und Methodik.
 
-### 2. Assess Current Question
+### 2. Aktuelle Frage bewerten
 
-If a research question already exists, evaluate it against these criteria:
+Existiert bereits eine Forschungsfrage, bewerte sie gegen diese Kriterien:
 
-#### Specificity
-- **Too broad:** "How does digitalization affect companies?" — Cannot be answered in one thesis
-- **Too narrow:** "How did Company X's Q3 2024 cloud migration affect ticket count?" — Too specific to generalize
-- **Good:** "How does cloud migration affect IT service management processes in mid-sized German companies?"
+#### Spezifität
+- **Zu breit:** "Wie wirkt sich Digitalisierung auf Unternehmen aus?" — Nicht in einer Thesis beantwortbar
+- **Zu eng:** "Wie wirkte sich die Cloud-Migration von Firma X im Q3 2024 auf die Ticketzahl aus?" — Zu spezifisch, kaum generalisierbar
+- **Gut:** "Wie beeinflusst Cloud-Migration das IT-Service-Management in mittelständischen deutschen Unternehmen?"
 
-#### Answerability
-- Can the question be answered with the chosen methodology?
-- Is the required data accessible?
-- Is the scope realistic for the work type and timeline?
+#### Beantwortbarkeit
+- Lässt sich die Frage mit der gewählten Methodik beantworten?
+- Sind die benötigten Daten zugänglich?
+- Ist der Scope realistisch für Arbeitstyp und Zeitplan?
 
-#### Relevance
-- Does the question address a real gap in the literature?
-- Is the answer useful for academia or practice?
-- Does the topic have sufficient existing literature to build on?
+#### Relevanz
+- Adressiert die Frage eine reale Literaturlücke?
+- Ist die Antwort für Wissenschaft oder Praxis nützlich?
+- Gibt es ausreichend Literatur, auf der aufgebaut werden kann?
 
-#### Structure
-- Is it a single, clear question (not a compound question)?
-- Does it avoid yes/no answers (open-ended)?
-- Does it contain the key variables or concepts?
+#### Struktur
+- Ist es eine einzige, klare Frage (keine Mehrfachfrage)?
+- Vermeidet sie Ja/Nein-Antworten (offen formuliert)?
+- Enthält sie die Schlüsselvariablen oder -konzepte?
 
-Present the assessment with a score per criterion:
+Die Bewertung mit Score pro Kriterium präsentieren:
 
 ```
 ## Bewertung der Forschungsfrage
@@ -70,103 +70,103 @@ Aktuelle Frage: "[...]"
 | Struktur | [gut/verbesserbar] | [...] |
 ```
 
-### 3. Refinement Dialog
+### 3. Verfeinerungs-Dialog
 
-Based on the assessment, guide the user through targeted improvements:
+Basierend auf der Bewertung gezielt Verbesserungen anstoßen:
 
-#### If Too Broad
-- Add constraints: time period, geography, industry, company size
-- Narrow the phenomenon: instead of "digitalization," specify "cloud migration" or "AI adoption"
-- Focus on a specific relationship between variables
-- Propose 2-3 narrower alternatives
+#### Wenn zu breit
+- Einschränkungen ergänzen: Zeitraum, Geografie, Branche, Unternehmensgröße
+- Phänomen verengen: statt "Digitalisierung" z. B. "Cloud-Migration" oder "KI-Adoption"
+- Auf einen konkreten Zusammenhang zwischen Variablen fokussieren
+- 2-3 engere Alternativen vorschlagen
 
-#### If Too Narrow
-- Remove overly specific constraints
-- Generalize from a single case to a category
-- Broaden the context while keeping the core phenomenon
-- Propose 2-3 broader alternatives
+#### Wenn zu eng
+- Zu spezifische Einschränkungen entfernen
+- Von einem Einzelfall auf eine Kategorie abstrahieren
+- Kontext erweitern, Kernphänomen behalten
+- 2-3 breitere Alternativen vorschlagen
 
-#### If Not Answerable
-- Adjust to match available data and methods
-- Reframe from causal ("Why does...") to descriptive ("How does...") if causal evidence is not obtainable
-- Break into answerable sub-questions
-- Suggest alternative approaches
+#### Wenn nicht beantwortbar
+- An verfügbare Daten und Methoden anpassen
+- Von kausal ("Warum...") auf deskriptiv ("Wie...") umformulieren, wenn Kausalevidenz nicht erhältlich ist
+- In beantwortbare Unterfragen zerlegen
+- Alternative Ansätze vorschlagen
 
-#### If Structurally Weak
-- Rewrite as an open-ended question
-- Separate compound questions into main + sub-questions
-- Ensure key concepts are named explicitly
-- Remove ambiguous terms
+#### Wenn strukturell schwach
+- Offen formulieren
+- Mehrfachfragen in Haupt- plus Unterfragen trennen
+- Schlüsselkonzepte explizit benennen
+- Mehrdeutige Begriffe entfernen
 
-### 4. Sub-Question Development
+### 4. Unterfragen entwickeln
 
-After the main question is refined, develop 2-4 sub-questions that:
+Nach der Verfeinerung der Hauptfrage 2-4 Unterfragen entwickeln, die:
 
-1. **Decompose** the main question into manageable parts
-2. **Map to chapters** — Each sub-question corresponds to a section of the thesis
-3. **Build on each other** — Sub-questions follow a logical sequence
-4. **Cover the scope** — Together, answering all sub-questions answers the main question
+1. **Zerlegen** die Hauptfrage in handhabbare Teile
+2. **Kapitelzuordnung** — Jede Unterfrage entspricht einem Abschnitt der Thesis
+3. **Aufeinander aufbauen** — Unterfragen folgen einer logischen Reihenfolge
+4. **Scope abdecken** — Zusammen beantworten sie die Hauptfrage
 
-Present the sub-question structure:
+Unterfragen-Struktur präsentieren:
 
 ```
-Hauptfrage: [Main Research Question]
+Hauptfrage: [Forschungshauptfrage]
 
 Unterfragen:
-1. [Sub-question 1] → Kapitel [N]: [Chapter Title]
-2. [Sub-question 2] → Kapitel [N]: [Chapter Title]
-3. [Sub-question 3] → Kapitel [N]: [Chapter Title]
+1. [Unterfrage 1] → Kapitel [N]: [Kapiteltitel]
+2. [Unterfrage 2] → Kapitel [N]: [Kapiteltitel]
+3. [Unterfrage 3] → Kapitel [N]: [Kapiteltitel]
 ```
 
-### 5. Comparison with Similar Works
+### 5. Vergleich mit ähnlichen Arbeiten
 
-Search for existing research with similar questions to evaluate:
+Nach bestehender Forschung mit ähnlichen Fragen suchen, um zu bewerten:
 
-- **Originality** — Has this exact question been answered already? If yes, what angle makes this work unique?
-- **Feasibility** — Have others successfully answered similar questions with comparable methods?
-- **Positioning** — Where does this question fit in the field? What does it add?
+- **Originalität** — Wurde genau diese Frage schon beantwortet? Wenn ja, was ist das Unterscheidungsmerkmal?
+- **Machbarkeit** — Haben andere ähnliche Fragen mit vergleichbaren Methoden erfolgreich beantwortet?
+- **Positionierung** — Wo fügt sich die Frage ins Feld ein? Was trägt sie bei?
 
-If the question overlaps significantly with published work, suggest differentiators:
-- Different context (industry, country, time period)
-- Different methodology
-- Different theoretical lens
-- Extended scope (adding variables or perspectives)
+Bei signifikantem Überlapp Differenzierungsoptionen vorschlagen:
+- Anderer Kontext (Branche, Land, Zeitraum)
+- Andere Methodik
+- Andere theoretische Linse
+- Erweiterter Scope (Variablen oder Perspektiven ergänzen)
 
-### 6. Final Formulation
+### 6. Finale Formulierung
 
-Present the refined research question and sub-questions for user approval. Include:
+Verfeinerte Forschungsfrage und Unterfragen zur Freigabe präsentieren. Einschließen:
 
-- The final main question
-- 2-4 sub-questions with chapter mapping
-- Brief justification of why this formulation works
-- Comparison with the original question (if one existed)
+- Finale Hauptfrage
+- 2-4 Unterfragen mit Kapitelzuordnung
+- Kurze Begründung, warum diese Formulierung funktioniert
+- Vergleich mit der ursprünglichen Frage (falls vorhanden)
 
-### 7. Save Updates
+### 7. Änderungen speichern
 
-After the user confirms:
+Nach der Bestätigung durch den User:
 
-1. Read `academic_context.md` (prevent stale overwrites)
-2. Update `Forschungsfrage` with the new main question
-3. Update `Unterfragen` with the new sub-questions
-4. If sub-questions map to chapters, update the `## Gliederung` section accordingly
+1. `academic_context.md` lesen (veraltete Überschreibungen vermeiden)
+2. `Forschungsfrage` mit der neuen Hauptfrage aktualisieren
+3. `Unterfragen` mit den neuen Unterfragen aktualisieren
+4. Entsprechen Unterfragen Kapiteln, `## Gliederung` anpassen
 
-## Research Question Templates
+## Forschungsfragen-Templates
 
-Provide these templates as starting points when the user has no question yet:
+Diese Templates als Einstiege anbieten, wenn der User noch keine Frage hat:
 
-| Template | Example |
-|----------|---------|
-| Explorative | "Welche Faktoren beeinflussen [Phänomen] in [Kontext]?" |
-| Deskriptive | "Wie ist [Phänomen] in [Kontext] gestaltet?" |
-| Kausale | "Welchen Einfluss hat [Variable A] auf [Variable B] in [Kontext]?" |
-| Evaluative | "Wie effektiv ist [Maßnahme] zur [Zielsetzung] in [Kontext]?" |
-| Gestaltungsorientierte | "Wie kann [Artefakt] zur [Zielsetzung] in [Kontext] gestaltet werden?" |
+| Template | Beispiel |
+|----------|----------|
+| Explorativ | "Welche Faktoren beeinflussen [Phänomen] in [Kontext]?" |
+| Deskriptiv | "Wie ist [Phänomen] in [Kontext] gestaltet?" |
+| Kausal | "Welchen Einfluss hat [Variable A] auf [Variable B] in [Kontext]?" |
+| Evaluativ | "Wie effektiv ist [Maßnahme] zur [Zielsetzung] in [Kontext]?" |
+| Gestaltungsorientiert | "Wie kann [Artefakt] zur [Zielsetzung] in [Kontext] gestaltet werden?" |
 
-## Important Rules
+## Wichtige Regeln
 
-- **Never impose a question** — Guide the user to their own formulation
-- **Show alternatives** — Always present 2-3 options, not just one
-- **Be honest about weaknesses** — If a question is problematic, explain why clearly
-- **Respect the user's topic** — Refine within their chosen domain, do not redirect to a different topic
-- **Connect to methodology** — Ensure the refined question is answerable with the chosen or available methods
-- **Confirm before saving** — Always get explicit approval before updating memory files
+- **Keine Frage aufdrängen** — Den User zu seiner eigenen Formulierung führen
+- **Alternativen zeigen** — Immer 2-3 Optionen präsentieren, nicht nur eine
+- **Schwächen ehrlich benennen** — Ist eine Frage problematisch, klar erklären warum
+- **Thema des Users respektieren** — Innerhalb seines Gebiets verfeinern, nicht umleiten
+- **An Methodik anbinden** — Sicherstellen, dass die verfeinerte Frage mit der gewählten oder verfügbaren Methode beantwortbar ist
+- **Vor dem Speichern bestätigen** — Immer explizite Freigabe einholen, bevor in Memory geschrieben wird

--- a/skills/research-question-refiner/SKILL.md
+++ b/skills/research-question-refiner/SKILL.md
@@ -7,6 +7,13 @@ description: Dieser Skill wird genutzt, wenn der User seine Forschungsfrage form
 
 Hilft beim präzisen Formulieren von Hauptfrage und Unterfragen. Bewertet, ob eine Frage zu breit, zu eng oder nicht beantwortbar ist. Vergleicht mit ähnlichen Arbeiten, um Originalität und Machbarkeit sicherzustellen.
 
+## Keine Fabrikation
+
+Erfundene Bezüge zu Vorarbeiten oder Forschungslücken sind für die FH Leibniz ein Plagiatsbefund und
+führen zu einer Fragestellung, die beim ersten Supervisor-Feedback kollabiert. Arbeite ausschließlich mit Daten aus
+`literature_state.md` oder direkt geladenen PDFs. Fehlen Daten: frag den User,
+rate nicht.
+
 ## Aktivierung dieses Skills
 
 - Der User möchte eine neue Forschungsfrage formulieren

--- a/skills/research-question-refiner/SKILL.md
+++ b/skills/research-question-refiner/SKILL.md
@@ -14,6 +14,54 @@ führen zu einer Fragestellung, die beim ersten Supervisor-Feedback kollabiert. 
 `literature_state.md` oder direkt geladenen PDFs. Fehlen Daten: frag den User,
 rate nicht.
 
+## Few-Shot-Beispiele
+
+### Template: Zu eng
+
+**Schlecht** (Grund: Frage lässt keinen Erkenntnisgewinn zu, rein deskriptiv auf einen Fall):
+
+> "Wie hoch war der Umsatz von BMW im Geschäftsjahr 2022?"
+
+**Gut** (Grund: Frage erlaubt Vergleich, Theorie-Anwendung und Erkenntnisgewinn):
+
+> "Welche Faktoren erklären die Umsatzentwicklung deutscher Automobilhersteller
+> 2019–2023 im Vergleich zur Branchenentwicklung?"
+
+### Template: Zu weit
+
+**Schlecht** (Grund: nicht im Bachelor-Zeitrahmen beantwortbar, kein klarer Scope):
+
+> "Wie beeinflusst Digitalisierung die Gesellschaft?"
+
+**Gut** (Grund: klarer Scope, konkreter Kontext, messbare Dimensionen):
+
+> "Wie beeinflusst der Einsatz generativer KI in Hochschulseminaren die
+> Prüfungsleistungen in textbasierten Fächern an der FH Leibniz 2024?"
+
+### Template: Nicht-falsifizierbar
+
+**Schlecht** (Grund: tautologisch/meinungsbasiert, keine empirische Antwort möglich):
+
+> "Ist Nachhaltigkeit wichtig für Unternehmen?"
+
+**Gut** (Grund: falsifizierbar, operationalisierbar):
+
+> "Korreliert die ESG-Rating-Verbesserung börsennotierter DAX-Unternehmen
+> 2018–2024 mit ihrer Aktienkurs-Entwicklung?"
+
+### Template: Mehrdimensional
+
+**Schlecht** (Grund: verknüpft drei eigenständige Fragen in einer):
+
+> "Welche Führungsstile wirken, was kostet ihre Einführung, und wie
+> akzeptieren Mitarbeiter sie?"
+
+**Gut** (Grund: eine Kernfrage, Nebenaspekte als Sub-Questions):
+
+> "Welcher Führungsstil (transformational/transaktional) erklärt
+> Mitarbeiterzufriedenheit in KMU der Metallverarbeitung 2023 am besten?
+> (Nebenaspekte: Einführungskosten, Akzeptanzraten)"
+
 ## Aktivierung dieses Skills
 
 - Der User möchte eine neue Forschungsfrage formulieren

--- a/skills/research-question-refiner/SKILL.md
+++ b/skills/research-question-refiner/SKILL.md
@@ -20,10 +20,10 @@ optimieren würde."
 
 ## Keine Fabrikation
 
-Erfundene Bezüge zu Vorarbeiten oder Forschungslücken sind für die FH Leibniz ein Plagiatsbefund und
-führen zu einer Fragestellung, die beim ersten Supervisor-Feedback kollabiert. Arbeite ausschließlich mit Daten aus
-`literature_state.md` oder direkt geladenen PDFs. Fehlen Daten: frag den User,
-rate nicht.
+Erfundene Bezüge zu Vorarbeiten oder Forschungslücken führen zu einer
+Fragestellung, die beim ersten Supervisor-Feedback kollabiert. Arbeite
+ausschließlich mit `academic_context.md` und `literature_state.md`. Fehlen
+Daten: frag den User, rate nicht.
 
 ## Few-Shot-Beispiele
 

--- a/skills/research-question-refiner/SKILL.md
+++ b/skills/research-question-refiner/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Research Question Refiner
-description: Dieser Skill wird genutzt, wenn der User seine Forschungsfrage formulieren, schärfen oder bewerten möchte. Triggers on "Forschungsfrage formulieren", "Research Question", "Fragestellung", "Forschungsfrage", "Forschungsfrage schärfen", "research question refine", "Fragestellung präzisieren", oder wenn ein anderer Skill erkennt, dass die Forschungsfrage zu breit, zu eng oder nicht beantwortbar ist.
+description: Dieser Skill wird genutzt, wenn der User seine Forschungsfrage formulieren, schärfen oder bewerten möchte. Triggers on "Forschungsfrage formulieren", "Research Question", "Fragestellung", "Forschungsfrage", "Forschungsfrage schärfen / Forschungsfrage schaerfen", "research question refine", "Fragestellung präzisieren / Fragestellung praezisieren", oder wenn ein anderer Skill erkennt, dass die Forschungsfrage zu breit, zu eng oder nicht beantwortbar ist.
 ---
 
 # Forschungsfragen-Schärfer

--- a/skills/research-question-refiner/SKILL.md
+++ b/skills/research-question-refiner/SKILL.md
@@ -7,6 +7,17 @@ description: Dieser Skill wird genutzt, wenn der User seine Forschungsfrage form
 
 Hilft beim präzisen Formulieren von Hauptfrage und Unterfragen. Bewertet, ob eine Frage zu breit, zu eng oder nicht beantwortbar ist. Vergleicht mit ähnlichen Arbeiten, um Originalität und Machbarkeit sicherzustellen.
 
+## Vorbedingungen
+
+Bevor du startest: Prüfe, ob `academic_context.md` und `literature_state.md`
+vorhanden und aktuell sind. Fehlt Kontext → triggere den `academic-context`-
+Skill und warte auf dessen Abschluss.
+
+Lehnt der User den Trigger ab → brich diesen Skill ab und erkläre:
+"Ohne Thema und Kontext in `academic_context.md` kann ich keine Fragen-
+Schärfung liefern, weil ich gegen unbekannte Disziplin-Konventionen
+optimieren würde."
+
 ## Keine Fabrikation
 
 Erfundene Bezüge zu Vorarbeiten oder Forschungslücken sind für die FH Leibniz ein Plagiatsbefund und

--- a/skills/source-quality-audit/SKILL.md
+++ b/skills/source-quality-audit/SKILL.md
@@ -24,6 +24,22 @@ führen zu einer Quellenprüfung, die der Arbeit die Zitierbarkeit entzieht. Arb
 `literature_state.md` oder direkt geladenen PDFs. Fehlen Daten: frag den User,
 rate nicht.
 
+## Abgrenzung
+
+Dieser Skill bewertet **einzelne Quellen** auf:
+- Impact-Faktor / SJR / SNIP der Publikationsquelle
+- Methodik der Einzelquelle (empirisch / theoretisch / Review / Primär-/Sekundär)
+- Peer-Review-Status
+- Aktualität der Einzelquelle
+
+Für die Bewertung der **Korpus-Vollständigkeit** (fehlende Themen, fehlende
+Autor*innen-Gruppen, fehlende Methoden, fehlende Zeitperioden, disziplinäre
+Blindstellen) → `literature-gap-analysis`.
+
+Beide Skills greifen auf `literature_state.md` zu, aber mit unterschiedlichem
+Fokus. Wenn der User „Coverage" oder „Gaps" erwähnt → delegiere an
+`literature-gap-analysis`.
+
 ## Aktivierung dieses Skills
 
 - Der User möchte die Qualität seiner Quellen oder Literaturbasis bewerten

--- a/skills/source-quality-audit/SKILL.md
+++ b/skills/source-quality-audit/SKILL.md
@@ -1,169 +1,169 @@
 ---
 name: Source Quality Audit
-description: This skill should be used when the user wants to evaluate the quality, balance, and adequacy of their literature base. Triggers on "Quellenqualitaet", "Quellen-Check", "Literaturqualitaet pruefen", "Source audit", "Quellenbewertung", "literature quality", "Quellenmix", "peer-reviewed Anteil", or when the user is unsure whether their sources are sufficient for submission.
+description: Dieser Skill wird genutzt, wenn der User Qualität, Balance und Angemessenheit seiner Literaturbasis bewerten möchte. Triggers on "Quellenqualitaet", "Quellen-Check", "Literaturqualitaet pruefen", "Source audit", "Quellenbewertung", "literature quality", "Quellenmix", "peer-reviewed Anteil", oder wenn der User unsicher ist, ob seine Quellen für die Abgabe ausreichen.
 ---
 
-# Source Quality Audit
+# Quellenqualitäts-Audit
 
-Evaluate the overall quality, balance, recency, and diversity of the literature base for an academic paper. Score each dimension (0-100), identify weaknesses, and provide concrete recommendations for improvement.
+Bewertet die Gesamtqualität, Balance, Aktualität und Diversität der Literaturbasis einer akademischen Arbeit. Scort jede Dimension (0-100), identifiziert Schwächen und liefert konkrete Verbesserungsempfehlungen.
 
-## When This Skill Activates
+## Aktivierung dieses Skills
 
-- The user asks to evaluate their source quality or literature base
-- The user is unsure whether their sources are adequate
-- Pre-submission quality gate for literature
-- After a literature search session, to assess the collected pool
+- Der User möchte die Qualität seiner Quellen oder Literaturbasis bewerten
+- Der User ist unsicher, ob seine Quellen ausreichen
+- Qualitätsgate vor der Abgabe für die Literatur
+- Nach einer Literatursuche, um den gesammelten Pool zu bewerten
 
-## Memory Files
+## Memory-Dateien
 
-- Read `literature_state.md` for the current source inventory (total count, type breakdown, chapter assignments, identified gaps)
-- Read `academic_context.md` for work type, discipline, research question, and citation style
+- Lies `literature_state.md` für das aktuelle Quelleninventar (Gesamtzahl, Typenverteilung, Kapitelzuordnungen, identifizierte Lücken)
+- Lies `academic_context.md` für Arbeitstyp, Disziplin, Forschungsfrage und Zitationsstil
 
-## Scoring Dimensions
+## Scoring-Dimensionen
 
-Evaluate each dimension on a 0-100 scale.
+Jede Dimension auf einer 0-100-Skala bewerten.
 
-### 1. Peer-Review Ratio (weight: 0.25)
+### 1. Peer-Review-Anteil (Gewicht: 0.25)
 
-Assess the proportion of peer-reviewed sources in the total literature base.
-
-**Scoring:**
-- 90-100: >70% peer-reviewed journal articles or conference papers
-- 70-89: 50-70% peer-reviewed
-- 50-69: 30-50% peer-reviewed
-- 30-49: 15-30% peer-reviewed
-- 0-29: <15% peer-reviewed
-
-**Classification of source types:**
-- Peer-reviewed: Journal articles (impact factor journals), peer-reviewed conference proceedings
-- Semi-academic: Working papers, preprints, institutional reports, dissertations
-- Non-academic: Websites, blog posts, news articles, company publications, Wikipedia
-
-Flag if non-academic sources exceed 20% of total.
-
-### 2. Recency (weight: 0.20)
-
-Assess whether the literature base is current enough.
+Anteil peer-reviewter Quellen am Gesamtbestand.
 
 **Scoring:**
-- 90-100: >60% of sources from the last 5 years, key sources current
-- 70-89: >40% from last 5 years
-- 50-69: >25% from last 5 years
-- 30-49: Mostly older sources, few recent additions
-- 0-29: Literature base is outdated
+- 90-100: >70 % peer-reviewte Journal-Artikel oder Konferenzbeiträge
+- 70-89: 50-70 % peer-reviewt
+- 50-69: 30-50 % peer-reviewt
+- 30-49: 15-30 % peer-reviewt
+- 0-29: <15 % peer-reviewt
 
-**Exceptions:**
-- Foundational/seminal works are exempt from recency requirements (flag as "Grundlagenwerk")
-- Historical or philosophical topics have relaxed recency expectations
-- Methodological texts may be older without penalty
+**Klassifikation der Quellen-Typen:**
+- Peer-reviewt: Journal-Artikel (Impact-Factor-Journals), peer-reviewte Konferenzbände
+- Semi-akademisch: Working Papers, Preprints, institutionelle Reports, Dissertationen
+- Nicht-akademisch: Websites, Blog-Posts, Presseartikel, Unternehmenspublikationen, Wikipedia
+
+Flag bei mehr als 20 % nicht-akademischer Quellen.
+
+### 2. Aktualität (Gewicht: 0.20)
+
+Bewertet, ob die Literaturbasis aktuell genug ist.
+
+**Scoring:**
+- 90-100: >60 % der Quellen aus den letzten 5 Jahren, Kernquellen aktuell
+- 70-89: >40 % aus den letzten 5 Jahren
+- 50-69: >25 % aus den letzten 5 Jahren
+- 30-49: Überwiegend ältere Quellen, wenige aktuelle Ergänzungen
+- 0-29: Literaturbasis veraltet
+
+**Ausnahmen:**
+- Grundlagen-/Standardwerke sind von der Aktualitätsanforderung ausgenommen (als "Grundlagenwerk" flaggen)
+- Historische oder philosophische Themen mit gelockerten Aktualitätserwartungen
+- Methodentexte dürfen älter sein ohne Abzug
 
 Berechne Recency inline: `recency = exp(-ln(2) * (current_year - year) / 5)` — exponentieller Decay, 5-Jahres-Halbwertszeit.
 
-### 3. Source Diversity (weight: 0.20)
+### 3. Quellen-Diversität (Gewicht: 0.20)
 
-Assess whether the literature comes from varied perspectives and publication venues.
+Bewertet, ob die Literatur aus verschiedenen Perspektiven und Publikationskanälen stammt.
 
-**Check for:**
-- **Author diversity** -- Flag if more than 3 sources from the same author (over-reliance)
-- **Venue diversity** -- Flag if more than 5 sources from the same journal or publisher
-- **Geographic diversity** -- Flag if all sources come from one country or language
-- **Perspective diversity** -- Flag if all sources support the same position (confirmation bias)
-- **Type diversity** -- Mix of journals, books, conference papers, reports
-
-**Scoring:**
-- 90-100: Diverse across all sub-dimensions
-- 70-89: Good diversity with minor concentration in one area
-- 50-69: Notable concentration in 2+ sub-dimensions
-- 30-49: Heavy reliance on narrow source pool
-- 0-29: Almost all sources from same venue, author, or perspective
-
-### 4. Web Source Proportion (weight: 0.15)
-
-Assess the balance between web-only sources and traditional academic publications.
+**Prüfen auf:**
+- **Autoren-Diversität** -- Flag bei mehr als 3 Quellen derselben Autor:in (Überabhängigkeit)
+- **Venue-Diversität** -- Flag bei mehr als 5 Quellen aus demselben Journal/Verlag
+- **Geografische Diversität** -- Flag, wenn alle Quellen aus einem Land oder einer Sprache stammen
+- **Perspektiven-Diversität** -- Flag, wenn alle Quellen dieselbe Position stützen (Confirmation Bias)
+- **Typen-Diversität** -- Mischung aus Journals, Büchern, Konferenzbeiträgen, Reports
 
 **Scoring:**
-- 90-100: Web sources <10%, all with clear institutional backing
-- 70-89: Web sources 10-20%, mostly institutional (Statista, government sites, NGOs)
-- 50-69: Web sources 20-30%, some non-institutional
-- 30-49: Web sources 30-50%, several unverifiable
-- 0-29: Web sources >50%, many without institutional authority
+- 90-100: In allen Subdimensionen divers
+- 70-89: Gute Diversität mit leichter Konzentration in einem Bereich
+- 50-69: Deutliche Konzentration in 2+ Subdimensionen
+- 30-49: Starke Abhängigkeit von schmalem Quellenpool
+- 0-29: Fast alle Quellen von derselben Venue, Person oder Perspektive
 
-**Acceptable web sources:** Government statistics (destatis.de), official reports (EU, OECD, WHO), established data providers (Statista), corporate annual reports.
+### 4. Anteil Web-Quellen (Gewicht: 0.15)
 
-**Problematic web sources:** Personal blogs, undated pages, pages without clear authorship, Wikipedia as primary source.
-
-### 5. Topical Coverage (weight: 0.20)
-
-Assess whether all major aspects of the research question are backed by literature.
-
-**Procedure:**
-1. Extract key concepts from the research question and outline (via `academic_context.md`)
-2. Map each concept to available sources
-3. Identify concepts with insufficient source coverage (<2 sources per key concept)
-4. Check that each main chapter has adequate literature support
+Bewertet die Balance zwischen reinen Web-Quellen und klassischen akademischen Publikationen.
 
 **Scoring:**
-- 90-100: All key concepts covered by 3+ sources, no gaps
-- 70-89: Most concepts covered, 1-2 minor gaps
-- 50-69: Several concepts undercovered
-- 30-49: Major gaps in central topics
-- 0-29: Core research question insufficiently supported by literature
+- 90-100: Web-Quellen <10 %, alle mit klarem institutionellen Träger
+- 70-89: Web-Quellen 10-20 %, überwiegend institutionell (Statista, Behörden, NGOs)
+- 50-69: Web-Quellen 20-30 %, teils nicht-institutionell
+- 30-49: Web-Quellen 30-50 %, mehrere nicht verifizierbar
+- 0-29: Web-Quellen >50 %, viele ohne institutionelle Autorität
 
-## Evaluation Workflow
+**Akzeptable Web-Quellen:** Behördenstatistiken (destatis.de), offizielle Reports (EU, OECD, WHO), etablierte Datenanbieter (Statista), Geschäftsberichte.
 
-1. Read `literature_state.md` for the source inventory
-2. Read `academic_context.md` for research context
-3. Classify each source by type (peer-reviewed, semi-academic, non-academic, web)
-4. Score each of the 5 dimensions
-5. Compute weighted total: `total = 0.25*peer_review + 0.20*recency + 0.20*diversity + 0.15*web_ratio + 0.20*coverage`
-6. Generate specific recommendations for each dimension scoring below 70
-7. Present results in structured format
+**Problematische Web-Quellen:** Persönliche Blogs, undatierte Seiten, Seiten ohne klare Autorenschaft, Wikipedia als Primärquelle.
 
-## Output Format
+### 5. Thematische Abdeckung (Gewicht: 0.20)
+
+Bewertet, ob alle wichtigen Aspekte der Forschungsfrage durch Literatur abgedeckt sind.
+
+**Ablauf:**
+1. Schlüsselkonzepte aus Forschungsfrage und Gliederung (via `academic_context.md`) extrahieren
+2. Jedes Konzept den verfügbaren Quellen zuordnen
+3. Konzepte mit unzureichender Abdeckung identifizieren (<2 Quellen je Schlüsselkonzept)
+4. Prüfen, ob jedes Hauptkapitel ausreichend Literaturstütze hat
+
+**Scoring:**
+- 90-100: Alle Schlüsselkonzepte durch 3+ Quellen abgedeckt, keine Lücken
+- 70-89: Die meisten Konzepte abgedeckt, 1-2 kleinere Lücken
+- 50-69: Mehrere Konzepte unterversorgt
+- 30-49: Große Lücken in zentralen Themen
+- 0-29: Kernforschungsfrage unzureichend literaturgestützt
+
+## Evaluations-Workflow
+
+1. `literature_state.md` für das Quelleninventar lesen
+2. `academic_context.md` für den Forschungskontext lesen
+3. Jede Quelle klassifizieren (peer-reviewt, semi-akademisch, nicht-akademisch, Web)
+4. Jede der 5 Dimensionen bepunkten
+5. Gewichteten Gesamtwert berechnen: `total = 0.25*peer_review + 0.20*recency + 0.20*diversity + 0.15*web_ratio + 0.20*coverage`
+6. Konkrete Empfehlungen für jede Dimension mit Score unter 70 erstellen
+7. Ergebnisse im strukturierten Format präsentieren
+
+## Output-Format
 
 ```
-## Quellen-Audit: [Work Title]
+## Quellen-Audit: [Arbeitstitel]
 
-**Quellen gesamt:** [N] | **Typ:** [Work Type] | **Ziel:** [min required sources]
+**Quellen gesamt:** [N] | **Typ:** [Arbeitstyp] | **Ziel:** [min. erforderliche Quellen]
 
-### Ergebnis-Uebersicht
+### Ergebnis-Übersicht
 
 | Dimension              | Score | Status         |
 |------------------------|-------|----------------|
 | Peer-Review-Anteil     | XX    | OK/WARN/FAIL   |
-| Aktualitaet            | XX    | OK/WARN/FAIL   |
-| Quellen-Diversitaet    | XX    | OK/WARN/FAIL   |
+| Aktualität             | XX    | OK/WARN/FAIL   |
+| Quellen-Diversität     | XX    | OK/WARN/FAIL   |
 | Web-Quellen-Anteil     | XX    | OK/WARN/FAIL   |
 | Thematische Abdeckung  | XX    | OK/WARN/FAIL   |
 | **Gesamt**             | **XX**| **STATUS**     |
 
 ### Quellenverteilung
 - Peer-reviewed Journals: [N] ([X%])
-- Buecher/Monographien: [N] ([X%])
-- Konferenzbeitraege: [N] ([X%])
+- Bücher/Monographien: [N] ([X%])
+- Konferenzbeiträge: [N] ([X%])
 - Berichte/Working Papers: [N] ([X%])
 - Web-Quellen: [N] ([X%])
 - Sonstige: [N] ([X%])
 
-### Identifizierte Luecken
-[List specific topic areas or concepts lacking source coverage]
+### Identifizierte Lücken
+[Konkrete Themen oder Konzepte ohne ausreichende Quellenabdeckung auflisten]
 
 ### Empfehlungen
-[Prioritized, actionable recommendations]
-1. [Most critical action]
-2. [Second priority]
+[Priorisierte, umsetzbare Empfehlungen]
+1. [Wichtigste Aktion]
+2. [Zweitwichtigste Aktion]
 ...
 ```
 
-Status thresholds: OK >= 70, WARN 50-69, FAIL < 50.
+Status-Schwellen: OK >= 70, WARN 50-69, FAIL < 50.
 
-## Important Rules
+## Wichtige Regeln
 
-- Base the audit on actual source data from `literature_state.md`, not assumptions
-- If `literature_state.md` is incomplete, ask the user to provide their source list
+- Audit auf tatsächlichen Daten aus `literature_state.md` basieren, nicht auf Annahmen
+- Ist `literature_state.md` unvollständig, den User um die Quellenliste bitten
 - Klassifiziere Venues inline: 1.0 für Top-Venues (IEEE, ACM, Springer, Nature, Elsevier), 0.7 für indexierte Journals, 0.4 für Konferenzen, 0.2 sonst
-- Never dismiss web sources categorically -- evaluate each on institutional authority
-- Foundational works (e.g., Porter 1985, Rogers 2003) should be flagged as "Grundlagenwerk" and exempted from recency penalties
-- Recommendations must be specific ("Add 2-3 peer-reviewed sources on [specific topic]") not generic ("Find more sources")
-- Consider discipline norms: computer science values conference papers highly; business studies value journal articles; law values commentaries and court decisions
-- Update `literature_state.md` with audit results and identified gaps
+- Web-Quellen niemals pauschal ablehnen -- jede einzeln auf institutionelle Autorität prüfen
+- Standardwerke (z. B. Porter 1985, Rogers 2003) als "Grundlagenwerk" flaggen und von Aktualitätsabzügen ausnehmen
+- Empfehlungen müssen spezifisch sein ("2-3 peer-reviewte Quellen zu [konkretes Thema] ergänzen"), nicht generisch ("mehr Quellen finden")
+- Disziplinnormen beachten: Informatik wertet Konferenzbeiträge hoch; BWL bevorzugt Journal-Artikel; Rechtswissenschaft schätzt Kommentare und Urteile
+- `literature_state.md` mit Audit-Ergebnissen und identifizierten Lücken aktualisieren

--- a/skills/source-quality-audit/SKILL.md
+++ b/skills/source-quality-audit/SKILL.md
@@ -7,6 +7,16 @@ description: Dieser Skill wird genutzt, wenn der User Qualität, Balance und Ang
 
 Bewertet die Gesamtqualität, Balance, Aktualität und Diversität der Literaturbasis einer akademischen Arbeit. Scort jede Dimension (0-100), identifiziert Schwächen und liefert konkrete Verbesserungsempfehlungen.
 
+## Vorbedingungen
+
+Bevor du startest: Prüfe, ob `academic_context.md` und `literature_state.md`
+vorhanden und aktuell sind. Fehlt Kontext → triggere den `academic-context`-
+Skill und warte auf dessen Abschluss.
+
+Lehnt der User den Trigger ab → brich diesen Skill ab und erkläre:
+"Ohne Quellenliste in `literature_state.md` kann ich kein Qualitätsurteil
+liefern, weil ich gegen leere Menge urteilen würde."
+
 ## Keine Fabrikation
 
 Erfundene Bewertungen oder Quellenangaben sind für die FH Leibniz ein Plagiatsbefund und

--- a/skills/source-quality-audit/SKILL.md
+++ b/skills/source-quality-audit/SKILL.md
@@ -7,6 +7,13 @@ description: Dieser Skill wird genutzt, wenn der User Qualität, Balance und Ang
 
 Bewertet die Gesamtqualität, Balance, Aktualität und Diversität der Literaturbasis einer akademischen Arbeit. Scort jede Dimension (0-100), identifiziert Schwächen und liefert konkrete Verbesserungsempfehlungen.
 
+## Keine Fabrikation
+
+Erfundene Bewertungen oder Quellenangaben sind für die FH Leibniz ein Plagiatsbefund und
+führen zu einer Quellenprüfung, die der Arbeit die Zitierbarkeit entzieht. Arbeite ausschließlich mit Daten aus
+`literature_state.md` oder direkt geladenen PDFs. Fehlen Daten: frag den User,
+rate nicht.
+
 ## Aktivierung dieses Skills
 
 - Der User möchte die Qualität seiner Quellen oder Literaturbasis bewerten

--- a/skills/source-quality-audit/SKILL.md
+++ b/skills/source-quality-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Source Quality Audit
-description: Dieser Skill wird genutzt, wenn der User Qualität, Balance und Angemessenheit seiner Literaturbasis bewerten möchte. Triggers on "Quellenqualitaet", "Quellen-Check", "Literaturqualitaet pruefen", "Source audit", "Quellenbewertung", "literature quality", "Quellenmix", "peer-reviewed Anteil", oder wenn der User unsicher ist, ob seine Quellen für die Abgabe ausreichen.
+description: Dieser Skill wird genutzt, wenn der User Qualität, Balance und Angemessenheit seiner Literaturbasis bewerten möchte. Triggers on "Quellenqualität / Quellenqualitaet", "Quellen-Check", "Literaturqualität prüfen / Literaturqualitaet pruefen", "Source audit", "Quellenbewertung", "literature quality", "Quellenmix", "peer-reviewed Anteil", oder wenn der User unsicher ist, ob seine Quellen für die Abgabe ausreichen.
 ---
 
 # Quellenqualitäts-Audit

--- a/skills/source-quality-audit/SKILL.md
+++ b/skills/source-quality-audit/SKILL.md
@@ -19,10 +19,10 @@ liefern, weil ich gegen leere Menge urteilen würde."
 
 ## Keine Fabrikation
 
-Erfundene Bewertungen oder Quellenangaben sind für die FH Leibniz ein Plagiatsbefund und
-führen zu einer Quellenprüfung, die der Arbeit die Zitierbarkeit entzieht. Arbeite ausschließlich mit Daten aus
-`literature_state.md` oder direkt geladenen PDFs. Fehlen Daten: frag den User,
-rate nicht.
+Erfundene Bewertungen oder Quellenangaben entziehen der Arbeit die
+Zitierbarkeit, wenn behauptete Quellen in der Nachprüfung nicht existieren.
+Arbeite ausschließlich mit den Einträgen aus `literature_state.md` und
+geladenen PDFs. Fehlen Daten: frag den User, rate nicht.
 
 ## Abgrenzung
 

--- a/skills/style-evaluator/SKILL.md
+++ b/skills/style-evaluator/SKILL.md
@@ -7,6 +7,16 @@ description: Dieser Skill wird genutzt, wenn der User Textqualität bewerten, au
 
 Bewertet akademischen Text nach Menschlichkeit, Anfälligkeit für KI-Detektion, Kohärenz, Duplikation und akademischer Qualität. Vergibt einen gewichteten Gesamtscore (0-100) über fünf Dimensionen und formuliert geflaggte Abschnitte bei Bedarf neu.
 
+## Vorbedingungen
+
+Bevor du startest: Prüfe, ob `academic_context.md` und `literature_state.md`
+vorhanden und aktuell sind. Fehlt Kontext → triggere den `academic-context`-
+Skill und warte auf dessen Abschluss.
+
+Lehnt der User den Trigger ab → brich diesen Skill ab und erkläre:
+"Ohne Text-Korpus-Kontext in `writing_state.md` kann ich kein Stil-Urteil
+liefern, weil ich gegen disziplinfremde Normen urteilen würde."
+
 ## Keine Fabrikation
 
 Erfundene Stil-Urteile über nicht gelesenen Text sind für die FH Leibniz ein Plagiatsbefund und

--- a/skills/style-evaluator/SKILL.md
+++ b/skills/style-evaluator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Style Evaluator
-description: Dieser Skill wird genutzt, wenn der User Textqualität bewerten, auf KI-Detektions-Muster prüfen oder seinen akademischen Stil verbessern möchte. Triggers on "Text pruefen", "Stil-Check", "KI-Erkennung", "Text verbessern", "Qualitaetskontrolle", "menschlich klingen", "style check", "AI detection", "text quality", "improve writing", "human-like", oder wenn Text zu künstlich oder schablonenhaft klingt.
+description: Dieser Skill wird genutzt, wenn der User Textqualität bewerten, auf KI-Detektions-Muster prüfen oder seinen akademischen Stil verbessern möchte. Triggers on "Text prüfen / Text pruefen", "Stil-Check", "KI-Erkennung", "Text verbessern", "Qualitätskontrolle / Qualitaetskontrolle", "menschlich klingen", "style check", "AI detection", "text quality", "improve writing", "human-like", oder wenn Text zu künstlich oder schablonenhaft klingt.
 ---
 
 # Stil-Evaluator

--- a/skills/style-evaluator/SKILL.md
+++ b/skills/style-evaluator/SKILL.md
@@ -7,6 +7,13 @@ description: Dieser Skill wird genutzt, wenn der User Textqualität bewerten, au
 
 Bewertet akademischen Text nach Menschlichkeit, Anfälligkeit für KI-Detektion, Kohärenz, Duplikation und akademischer Qualität. Vergibt einen gewichteten Gesamtscore (0-100) über fünf Dimensionen und formuliert geflaggte Abschnitte bei Bedarf neu.
 
+## Keine Fabrikation
+
+Erfundene Stil-Urteile über nicht gelesenen Text sind für die FH Leibniz ein Plagiatsbefund und
+führen zu tatsächlich fragwürdigem Stil, der unentdeckt bleibt. Arbeite ausschließlich mit Daten aus
+`literature_state.md` oder direkt geladenen PDFs. Fehlen Daten: frag den User,
+rate nicht.
+
 ## Aktivierung dieses Skills
 
 - Der User reicht Text zur Qualitäts- oder Stilbewertung ein

--- a/skills/style-evaluator/SKILL.md
+++ b/skills/style-evaluator/SKILL.md
@@ -1,145 +1,145 @@
 ---
 name: Style Evaluator
-description: This skill should be used when the user wants to evaluate text quality, check for AI-detection patterns, or improve academic writing style. Triggers on "Text pruefen", "Stil-Check", "KI-Erkennung", "Text verbessern", "Qualitaetskontrolle", "menschlich klingen", "style check", "AI detection", "text quality", "improve writing", "human-like", or when text sounds too artificial or formulaic.
+description: Dieser Skill wird genutzt, wenn der User Textqualität bewerten, auf KI-Detektions-Muster prüfen oder seinen akademischen Stil verbessern möchte. Triggers on "Text pruefen", "Stil-Check", "KI-Erkennung", "Text verbessern", "Qualitaetskontrolle", "menschlich klingen", "style check", "AI detection", "text quality", "improve writing", "human-like", oder wenn Text zu künstlich oder schablonenhaft klingt.
 ---
 
-# Style Evaluator
+# Stil-Evaluator
 
-Evaluate academic text for human-likeness, AI-detection vulnerability, coherence, duplication, and overall academic quality. Assign a composite score (0-100) across five dimensions and optionally rewrite flagged sections.
+Bewertet akademischen Text nach Menschlichkeit, Anfälligkeit für KI-Detektion, Kohärenz, Duplikation und akademischer Qualität. Vergibt einen gewichteten Gesamtscore (0-100) über fünf Dimensionen und formuliert geflaggte Abschnitte bei Bedarf neu.
 
-## When This Skill Activates
+## Aktivierung dieses Skills
 
-- The user submits text for quality or style evaluation
-- The user suspects text sounds too AI-generated
-- The user asks for text improvement or naturalness
-- Another skill (e.g., Chapter Writer) requests a post-write quality gate
+- Der User reicht Text zur Qualitäts- oder Stilbewertung ein
+- Der User befürchtet, dass der Text zu KI-generiert klingt
+- Der User bittet um Textverbesserung oder natürlicheres Schreiben
+- Ein anderer Skill (z. B. Chapter Writer) fordert ein Post-Write-Qualitätsgate an
 
-## Memory Files
+## Memory-Dateien
 
-- Read `writing_state.md` for current chapter context and previous scores
-- Read `academic_context.md` for citation style, language, and work type
-- Update `writing_state.md` with new evaluation scores after each run
+- Lies `writing_state.md` für aktuellen Kapitelkontext und frühere Scores
+- Lies `academic_context.md` für Zitationsstil, Sprache und Arbeitstyp
+- Aktualisiere `writing_state.md` nach jedem Lauf mit neuen Bewertungsscores
 
 ## Metriken
 
 Die quantitativen Metriken (Satzlängenverteilung, Übergangsfrequenz, Vokabular-Diversität, n-Gramm-Wiederholung) berechnet Claude direkt aus dem Eingabetext — keine externe Pipeline. Siehe Rubrik unten für konkrete Messvorschriften pro Dimension.
 
-## Scoring Rubric (0-100)
+## Scoring-Rubrik (0-100)
 
-Evaluate each dimension independently, then compute a weighted total.
+Jede Dimension unabhängig bewerten, dann gewichteten Gesamtwert bilden.
 
-### 1. Human-Likeness (weight: 0.30)
+### 1. Menschlichkeit (Gewicht: 0.30)
 
-Assess whether the text reads as authentically human-written.
+Wirkt der Text authentisch menschlich geschrieben?
 
-Indicators of LOW human-likeness (deduct points):
-- Sentence length standard deviation below 4 words (too uniform)
-- More than 30% of sentences starting with the same syntactic pattern
-- Absence of hedging language, qualifiers, or tentative phrasing
-- No rhetorical questions, asides, or first-person perspective where appropriate
-- Paragraph lengths too uniform (all within 10% of average)
+Indikatoren für NIEDRIGE Menschlichkeit (Abzüge):
+- Standardabweichung der Satzlänge unter 4 Wörtern (zu uniform)
+- Mehr als 30 % der Sätze beginnen mit demselben syntaktischen Muster
+- Fehlen von Hedging-Sprache, Einschränkungen oder vorsichtigen Formulierungen
+- Keine rhetorischen Fragen, Einschübe oder Ich-Perspektive, wo angemessen
+- Absatzlängen zu uniform (alle innerhalb 10 % des Durchschnitts)
 
-Indicators of HIGH human-likeness (award points):
-- Natural variation in sentence length (short + long mixed)
-- Occasional informal connectors alongside formal ones
-- Topic sentences vary in structure across paragraphs
-- Evidence of personal analytical voice
+Indikatoren für HOHE Menschlichkeit (Pluspunkte):
+- Natürliche Variation der Satzlänge (kurz und lang gemischt)
+- Gelegentliche informelle Konnektoren neben formalen
+- Topic Sentences variieren zwischen Absätzen
+- Spürbare persönliche analytische Stimme
 
-### 2. Anti-AI-Detection (weight: 0.25)
+### 2. Anti-KI-Detektion (Gewicht: 0.25)
 
-Flag patterns that AI-detection tools (GPTZero, Turnitin AI, Originality.ai) commonly identify.
+Muster flaggen, die KI-Detektoren (GPTZero, Turnitin AI, Originality.ai) häufig identifizieren.
 
-Check for:
-- **Uniform sentence lengths** -- Compute standard deviation; flag if below 5 words
-- **Repetitive transitions** -- Flag if "Furthermore", "Moreover", "Additionally", "In conclusion" each appear more than twice per 1000 words
-- **Missing personal voice** -- Flag if zero first-person pronouns in sections where methodology or opinion is expected
-- **Overly perfect structure** -- Flag if every paragraph follows identical topic-evidence-analysis pattern
-- **Lexical predictability** -- Flag if top-10 most frequent content words cover more than 15% of all content words
-- **Burstiness score** -- Measure variation in perplexity across sentences; flag if too flat
+Prüfen auf:
+- **Uniforme Satzlängen** -- Standardabweichung berechnen; flag bei < 5 Wörtern
+- **Wiederholte Übergänge** -- Flag, wenn "Darüber hinaus", "Furthermore", "Moreover", "Zusätzlich", "In conclusion" mehr als zweimal je 1000 Wörter auftauchen
+- **Fehlende persönliche Stimme** -- Flag bei null Ich-Pronomen dort, wo Methodik oder Meinung erwartet werden
+- **Zu perfekte Struktur** -- Flag, wenn jeder Absatz identisch dem Muster Topic-Evidenz-Analyse folgt
+- **Lexikalische Vorhersagbarkeit** -- Flag, wenn die 10 häufigsten Content-Wörter über 15 % aller Content-Wörter ausmachen
+- **Burstiness-Score** -- Variation der Perplexität pro Satz messen; bei zu flachem Verlauf flaggen
 
-### 3. Coherence (weight: 0.20)
+### 3. Kohärenz (Gewicht: 0.20)
 
-Evaluate logical flow between sentences and paragraphs.
+Logischen Fluss zwischen Sätzen und Absätzen bewerten.
 
-Check for:
-- Topic continuity (each paragraph advances the argument)
-- Logical connectors match actual logical relationships
-- No orphaned claims (assertions without preceding context or following evidence)
-- Smooth transitions between sections
-- Consistent terminology (no unexplained synonym switching)
+Prüfen auf:
+- Themen-Kontinuität (jeder Absatz bringt das Argument voran)
+- Logik-Konnektoren passen zur tatsächlichen logischen Relation
+- Keine waisen Aussagen (Behauptungen ohne vorausgehenden Kontext oder nachfolgende Evidenz)
+- Saubere Übergänge zwischen Abschnitten
+- Konsistente Terminologie (kein unerklärter Synonym-Wechsel)
 
-### 4. Duplication Detection (weight: 0.15)
+### 4. Duplikations-Erkennung (Gewicht: 0.15)
 
-Identify internal repetition within the text.
+Interne Wiederholung im Text identifizieren.
 
-Check for:
-- Repeated phrases (3+ word sequences appearing more than twice)
-- Paraphrased duplicates (same idea restated in adjacent paragraphs)
-- Redundant introductory/concluding sentences across sections
-- Copy-paste artifacts
+Prüfen auf:
+- Wiederholte Phrasen (3+ Wörter, mehr als zweimal)
+- Paraphrasierte Duplikate (dieselbe Idee in benachbarten Absätzen)
+- Redundante Einleitungs-/Abschlusssätze über Abschnitte hinweg
+- Copy-Paste-Artefakte
 
-### 5. Academic Quality (weight: 0.10)
+### 5. Akademische Qualität (Gewicht: 0.10)
 
-Evaluate formal academic standards.
+Formale akademische Standards bewerten.
 
-Check for:
-- Proper citation integration (not just parenthetical drops)
-- Argument structure (claim, evidence, analysis)
-- Register consistency (no colloquial breaks in formal text, no overly formal language in applied sections)
-- Terminology precision
-- Appropriate use of passive vs. active voice for the discipline
+Prüfen auf:
+- Saubere Zitat-Integration (nicht nur Klammer-Drops)
+- Argumentationsstruktur (Claim, Evidenz, Analyse)
+- Register-Konsistenz (keine umgangssprachlichen Brüche in formalen Stellen, keine überformale Sprache in Anwendungsabschnitten)
+- Terminologische Präzision
+- Angemessener Einsatz von Passiv vs. Aktiv je nach Disziplin
 
-## Evaluation Workflow
+## Evaluations-Workflow
 
-1. Read the submitted text (full chapter, section, or paragraph)
-2. Read `writing_state.md` and `academic_context.md` for context
+1. Den eingereichten Text lesen (vollständiges Kapitel, Abschnitt oder Absatz)
+2. `writing_state.md` und `academic_context.md` für Kontext lesen
 3. Berechne quantitative Metriken inline aus dem Eingabetext (Satzlängen, Übergänge, n-Gramme, Vokabular-Diversität)
-4. Score each dimension (0-100) using the rubric and script metrics
-5. Compute weighted total: `total = 0.30*human + 0.25*anti_ai + 0.20*coherence + 0.15*duplication + 0.10*academic`
-6. Present results in structured format (see output format below)
-7. Update `writing_state.md` with the new scores
+4. Jede Dimension (0-100) nach Rubrik und Metriken scoren
+5. Gewichteten Gesamtwert berechnen: `total = 0.30*human + 0.25*anti_ai + 0.20*coherence + 0.15*duplication + 0.10*academic`
+6. Ergebnisse strukturiert präsentieren (siehe Output-Format unten)
+7. `writing_state.md` mit den neuen Scores aktualisieren
 
-## Output Format
+## Output-Format
 
-Present results as:
+Ergebnisse präsentieren als:
 
 ```
-## Style Evaluation: [Section/Chapter Name]
+## Stil-Bewertung: [Abschnitt/Kapitel]
 
 | Dimension            | Score | Status |
 |----------------------|-------|--------|
-| Human-Likeness       | XX    | OK/WARN/FAIL |
-| Anti-AI-Detection    | XX    | OK/WARN/FAIL |
-| Coherence            | XX    | OK/WARN/FAIL |
-| Duplication          | XX    | OK/WARN/FAIL |
-| Academic Quality     | XX    | OK/WARN/FAIL |
+| Menschlichkeit       | XX    | OK/WARN/FAIL |
+| Anti-KI-Detektion    | XX    | OK/WARN/FAIL |
+| Kohärenz             | XX    | OK/WARN/FAIL |
+| Duplikation          | XX    | OK/WARN/FAIL |
+| Akademische Qualität | XX    | OK/WARN/FAIL |
 | **Gesamt**           | **XX**| **STATUS** |
 
-### Flagged Issues
-[List each flagged issue with location and severity]
+### Geflaggte Probleme
+[Jedes Problem mit Position und Severity auflisten]
 
-### Rewrite Suggestions
-[Concrete rewrites for WARN/FAIL sections, preserving meaning]
+### Rewrite-Vorschläge
+[Konkrete Neufassungen für WARN/FAIL-Stellen unter Bedeutungserhalt]
 ```
 
-Status thresholds: OK >= 75, WARN 50-74, FAIL < 50.
+Status-Schwellen: OK >= 75, WARN 50-74, FAIL < 50.
 
-## Rewrite Mode
+## Rewrite-Modus
 
-When the user requests rewriting of flagged sections:
+Bei Bitte um Neuformulierung geflaggter Abschnitte:
 
-1. Isolate the flagged passage
-2. Preserve the exact argument and all citations
-3. Vary sentence structure, length, and opening patterns
-4. Introduce natural hedging where appropriate ("This suggests...", "It appears that...")
-5. Break overly symmetric paragraph structures
-6. Re-evaluate the rewritten passage and confirm score improvement
+1. Geflaggte Passage isolieren
+2. Exakte Argumentation und alle Zitate bewahren
+3. Satzstruktur, -länge und Satzanfänge variieren
+4. Wo sinnvoll, natürliches Hedging einbauen ("Dies deutet darauf hin...", "Es erscheint...")
+5. Zu symmetrische Absatzstrukturen aufbrechen
+6. Neufassung bewerten und Score-Verbesserung bestätigen
 
-## Important Rules
+## Wichtige Regeln
 
-- Never fabricate metrics -- berechne alle Werte nachvollziehbar aus dem Text und zeige die Rechenbasis, wenn der User danach fragt
-- Always preserve the author's argument and citations during rewrites
-- Score conservatively -- a perfect 100 is unrealistic for any text
-- Flag but do not auto-rewrite without user consent
-- Use German labels in output when `academic_context.md` specifies German as the language
-- Track score history in `writing_state.md` to show improvement over time
+- Nie Metriken fabrizieren -- berechne alle Werte nachvollziehbar aus dem Text und zeige die Rechenbasis, wenn der User danach fragt
+- Bei Rewrites immer Argumentation und Zitate des Autors erhalten
+- Konservativ scoren -- eine 100 ist für keinen Text realistisch
+- Flaggen ja, automatisch umschreiben ohne User-Zustimmung nein
+- Deutsche Labels im Output, wenn `academic_context.md` Deutsch als Sprache angibt
+- Score-Historie in `writing_state.md` pflegen, um Verbesserung über die Zeit zu zeigen

--- a/skills/style-evaluator/SKILL.md
+++ b/skills/style-evaluator/SKILL.md
@@ -14,6 +14,21 @@ führen zu tatsächlich fragwürdigem Stil, der unentdeckt bleibt. Arbeite aussc
 `literature_state.md` oder direkt geladenen PDFs. Fehlen Daten: frag den User,
 rate nicht.
 
+## Fallback-Rubrik (ohne Script)
+
+Wenn kein externes Stil-Analyse-Script verfügbar ist, prüfe manuell gegen
+diese 5 Schwellen:
+
+| Metrik | Schwelle | Messverfahren |
+|---|---|---|
+| **Satzlänge (Ø)** | 15–25 Wörter | 20 zufällige Sätze, Mittelwert |
+| **Passiv-Quote** | < 30 % | "wird/werden/wurde/wurden + Partizip II" in Stichprobe 20 Sätze |
+| **Nominalstil-Anteil** | < 40 % | Sätze mit ≥ 3 Nominalphrasen (auf "-ung/-heit/-keit/-tion") in Stichprobe |
+| **Füllwörter-Dichte** | < 5 % | "quasi, eigentlich, irgendwie, sozusagen, gewissermaßen" vs. Gesamtwörter |
+| **Code-Switches** | 0 | Englische Wörter außerhalb etablierter Fachbegriffe |
+
+Ausgabe: Tabelle Metrik + Ist-Wert + Schwelle + PASS/FAIL.
+
 ## Aktivierung dieses Skills
 
 - Der User reicht Text zur Qualitäts- oder Stilbewertung ein

--- a/skills/style-evaluator/SKILL.md
+++ b/skills/style-evaluator/SKILL.md
@@ -19,10 +19,10 @@ liefern, weil ich gegen disziplinfremde Normen urteilen würde."
 
 ## Keine Fabrikation
 
-Erfundene Stil-Urteile über nicht gelesenen Text sind für die FH Leibniz ein Plagiatsbefund und
-führen zu tatsächlich fragwürdigem Stil, der unentdeckt bleibt. Arbeite ausschließlich mit Daten aus
-`literature_state.md` oder direkt geladenen PDFs. Fehlen Daten: frag den User,
-rate nicht.
+Erfundene Stil-Urteile über nicht gelesenen Text lassen tatsächlich fragwürdigen
+Stil unentdeckt und untergraben den Wert des Stil-Checks. Arbeite ausschließlich
+mit dem eingereichten User-Text und den Metriken aus `writing_state.md`.
+Fehlen Daten: frag den User, rate nicht.
 
 ## Fallback-Rubrik (ohne Script)
 

--- a/skills/submission-checker/SKILL.md
+++ b/skills/submission-checker/SKILL.md
@@ -1,141 +1,141 @@
 ---
 name: Submission Checker
-description: This skill should be used when the user wants to verify formal requirements before submitting their academic paper. Triggers on "formale Pruefung", "Abgabe-Check", "Formatierung pruefen", "abgabefertig", "submission check", "formal requirements", "Deckblatt pruefen", "Eidesstattliche Erklaerung", "Seitenraender", "Formatvorlage", or when the user is preparing for final submission.
+description: Dieser Skill wird genutzt, wenn der User vor der Abgabe seiner akademischen Arbeit formale Anforderungen prüfen möchte. Triggers on "formale Pruefung", "Abgabe-Check", "Formatierung pruefen", "abgabefertig", "submission check", "formal requirements", "Deckblatt pruefen", "Eidesstattliche Erklaerung", "Seitenraender", "Formatvorlage", oder wenn der User sich auf die finale Abgabe vorbereitet.
 ---
 
-# Submission Checker
+# Abgabe-Prüfer
 
-Validate that an academic paper meets all formal submission requirements: page count, formatting, source count, required sections (cover page, table of contents, declaration of authorship, appendix), and university-specific rules.
+Prüft, ob eine akademische Arbeit alle formalen Abgabeanforderungen erfüllt: Seitenzahl, Formatierung, Quellenzahl, Pflichtabschnitte (Deckblatt, Inhaltsverzeichnis, Eidesstattliche Erklärung, Anhang) und hochschulspezifische Regeln.
 
-## When This Skill Activates
+## Aktivierung dieses Skills
 
-- The user asks to check if their paper is ready for submission
-- The user wants to verify formatting or formal requirements
-- Pre-submission quality assurance
-- The user asks about specific formal elements (Deckblatt, Eidesstattliche Erklaerung, etc.)
+- Der User fragt, ob seine Arbeit abgabefertig ist
+- Der User möchte Formatierung oder formale Anforderungen verifizieren
+- Qualitätssicherung vor der Abgabe
+- Der User fragt nach konkreten formalen Elementen (Deckblatt, Eidesstattliche Erklärung etc.)
 
-## Memory and Reference Files
+## Memory- und Referenzdateien
 
-- Read `academic_context.md` for work type, university, program, and citation style
-- Read `${CLAUDE_PLUGIN_ROOT}/skills/submission-checker/leibniz-fh-requirements.md` for university-specific formal requirements
-- Read `writing_state.md` for current word counts and chapter completion status
+- Lies `academic_context.md` für Arbeitstyp, Universität, Studiengang und Zitationsstil
+- Lies `${CLAUDE_PLUGIN_ROOT}/skills/submission-checker/leibniz-fh-requirements.md` für hochschulspezifische Formalia
+- Lies `writing_state.md` für aktuelle Wortzahlen und Kapitelstatus
 
-## Checklist Dimensions
+## Checklisten-Dimensionen
 
-### 1. Required Sections
+### 1. Pflichtabschnitte
 
-Verify presence of all mandatory sections in correct order:
+Präsenz aller verpflichtenden Abschnitte in der korrekten Reihenfolge prüfen:
 
 **Front Matter:**
-- [ ] Deckblatt (Cover Page) -- title, author, matriculation number, supervisor, submission date, university logo
-- [ ] Abstract (if required by work type)
-- [ ] Inhaltsverzeichnis (Table of Contents) -- with page numbers
-- [ ] Abbildungsverzeichnis (List of Figures) -- if figures are present
-- [ ] Tabellenverzeichnis (List of Tables) -- if tables are present
-- [ ] Abkuerzungsverzeichnis (List of Abbreviations) -- if abbreviations are used
+- [ ] Deckblatt -- Titel, Autor:in, Matrikelnummer, Betreuer:in, Abgabedatum, Hochschullogo
+- [ ] Abstract (falls für den Arbeitstyp erforderlich)
+- [ ] Inhaltsverzeichnis -- mit Seitenzahlen
+- [ ] Abbildungsverzeichnis -- falls Abbildungen enthalten sind
+- [ ] Tabellenverzeichnis -- falls Tabellen enthalten sind
+- [ ] Abkürzungsverzeichnis -- falls Abkürzungen verwendet werden
 
-**Body:**
-- [ ] Einleitung (Introduction) -- with research question, methodology overview, structure preview
-- [ ] Hauptteil (Main chapters) -- as defined in outline
-- [ ] Fazit/Schluss (Conclusion) -- with summary, limitations, outlook
+**Hauptteil:**
+- [ ] Einleitung -- mit Forschungsfrage, Methodik-Überblick, Strukturvorschau
+- [ ] Hauptkapitel -- laut Gliederung
+- [ ] Fazit/Schluss -- mit Zusammenfassung, Limitationen, Ausblick
 
 **Back Matter:**
-- [ ] Literaturverzeichnis (Bibliography) -- all cited sources, correctly formatted
-- [ ] Anhang (Appendix) -- if referenced in text
-- [ ] Eidesstattliche Erklaerung (Declaration of Authorship) -- signed statement of independent work
+- [ ] Literaturverzeichnis -- alle zitierten Quellen, korrekt formatiert
+- [ ] Anhang -- falls im Text referenziert
+- [ ] Eidesstattliche Erklärung -- unterzeichnete Erklärung eigenständiger Arbeit
 
-### 2. Page Count and Length
+### 2. Seitenzahl und Umfang
 
-Check against requirements from `${CLAUDE_PLUGIN_ROOT}/skills/submission-checker/leibniz-fh-requirements.md`:
+Gegen Anforderungen aus `${CLAUDE_PLUGIN_ROOT}/skills/submission-checker/leibniz-fh-requirements.md` prüfen:
 
-| Work Type        | Typical Range (pages) |
-|------------------|-----------------------|
-| Bachelorarbeit   | 30-50                 |
-| Masterarbeit     | 60-80                 |
-| Hausarbeit       | 12-20                 |
-| Seminararbeit    | 15-25                 |
-| Facharbeit       | 8-15                  |
+| Arbeitstyp       | Typischer Umfang (Seiten) |
+|------------------|---------------------------|
+| Bachelorarbeit   | 30-50                     |
+| Masterarbeit     | 60-80                     |
+| Hausarbeit       | 12-20                     |
+| Seminararbeit    | 15-25                     |
+| Facharbeit       | 8-15                      |
 
-Verify:
-- Total page count within allowed range
-- Front matter and back matter excluded from page count (if university requires this)
-- No chapter disproportionately long or short relative to others
+Verifizieren:
+- Gesamtseitenzahl im zulässigen Rahmen
+- Front Matter und Back Matter nicht mitgezählt (falls die Hochschule das verlangt)
+- Kein Kapitel überproportional lang oder kurz
 
-### 3. Formatting
+### 3. Formatierung
 
-Check compliance with standard formatting rules:
+Compliance mit gängigen Formatierungsregeln prüfen:
 
-**Typography:**
-- Font: Times New Roman 12pt or Arial 11pt (per university requirement)
-- Line spacing: 1.5
-- Margins: left 3cm (binding), right 2.5cm, top 2.5cm, bottom 2cm
-- Justified text (Blocksatz)
-- Page numbers: Arabic numerals, starting from introduction (front matter with Roman numerals)
+**Typografie:**
+- Schrift: Times New Roman 12pt oder Arial 11pt (je nach Hochschule)
+- Zeilenabstand: 1.5
+- Ränder: links 3 cm (Bindung), rechts 2.5 cm, oben 2.5 cm, unten 2 cm
+- Blocksatz
+- Seitenzahlen: arabisch ab Einleitung (Front Matter in römischen Ziffern)
 
-**Headings:**
-- Consistent heading hierarchy (no skipped levels)
-- Numbered headings (1, 1.1, 1.1.1 -- max 3 levels)
-- No orphan headings (heading at bottom of page with text on next page)
+**Überschriften:**
+- Konsistente Hierarchie (keine übersprungenen Ebenen)
+- Nummerierte Überschriften (1, 1.1, 1.1.1 -- max. 3 Ebenen)
+- Keine Schuster-Überschriften (Überschrift am Seitenende, Text beginnt erst auf der nächsten Seite)
 
-**Paragraphs:**
-- No single-sentence paragraphs
-- Consistent paragraph indentation or spacing
+**Absätze:**
+- Keine Einzelsatz-Absätze
+- Konsistente Absatz-Einrückung oder -Abstände
 
-### 4. Source Count and Citation Quality
+### 4. Quellenzahl und Zitationsqualität
 
-Verify adequate source usage:
+Ausreichende Quellennutzung prüfen:
 
-| Work Type        | Minimum Sources |
+| Arbeitstyp       | Minimum Quellen |
 |------------------|-----------------|
 | Bachelorarbeit   | 25-40           |
 | Masterarbeit     | 40-60           |
 | Hausarbeit       | 10-20           |
 | Seminararbeit    | 15-25           |
 
-Check:
-- Total number of unique sources in bibliography
-- All in-text citations have corresponding bibliography entry
-- All bibliography entries are cited at least once in text
-- Citation format matches style from `academic_context.md` (APA7, IEEE, Harvard, etc.)
-- No chapter without any citations (except introduction structure preview and conclusion outlook)
+Prüfen:
+- Gesamtzahl eindeutiger Quellen in der Bibliografie
+- Alle In-Text-Zitate haben einen Eintrag im Literaturverzeichnis
+- Alle Literatureinträge werden im Text mindestens einmal zitiert
+- Zitierformat entspricht dem Stil aus `academic_context.md` (APA7, IEEE, Harvard etc.)
+- Kein Kapitel ohne Zitate (Ausnahme: Strukturvorschau in der Einleitung und Ausblick im Fazit)
 
-### 5. Figures and Tables
+### 5. Abbildungen und Tabellen
 
-If figures or tables are present:
-- Each has a caption with number ("Abbildung 1:", "Tabelle 1:")
-- Each is referenced in the text
-- Numbering is sequential and consistent
-- Source attribution below each figure/table
-- List of figures/tables in front matter matches actual content
+Falls Abbildungen oder Tabellen vorhanden:
+- Jede hat eine nummerierte Beschriftung ("Abbildung 1:", "Tabelle 1:")
+- Jede wird im Text referenziert
+- Nummerierung sequenziell und konsistent
+- Quellenangabe unter jeder Abbildung/Tabelle
+- Abbildungs-/Tabellenverzeichnis im Front Matter stimmt mit dem Inhalt überein
 
-### 6. Declaration of Authorship (Eidesstattliche Erklaerung)
+### 6. Eidesstattliche Erklärung
 
-Verify:
-- Present as last page (or per university placement rule)
-- Contains required wording per `${CLAUDE_PLUGIN_ROOT}/skills/submission-checker/leibniz-fh-requirements.md`
-- Includes place and date fields
-- Includes signature line
+Verifizieren:
+- Vorhanden als letzte Seite (oder gemäß hochschulspezifischer Platzierungsregel)
+- Enthält den geforderten Wortlaut gemäß `${CLAUDE_PLUGIN_ROOT}/skills/submission-checker/leibniz-fh-requirements.md`
+- Enthält Ort-/Datum-Feld
+- Enthält Unterschriftenfeld
 
-## Evaluation Workflow
+## Evaluations-Workflow
 
-1. Read `academic_context.md` to determine work type and university
-2. Read `${CLAUDE_PLUGIN_ROOT}/skills/submission-checker/leibniz-fh-requirements.md` for specific requirements
-3. Read `writing_state.md` for current completion status
-4. Analyze the paper structure against the checklist
-5. Score each dimension as PASS, PARTIAL, or FAIL
-6. Compile results in structured output
-7. Prioritize fixes by severity
+1. `academic_context.md` lesen, um Arbeitstyp und Hochschule zu bestimmen
+2. `${CLAUDE_PLUGIN_ROOT}/skills/submission-checker/leibniz-fh-requirements.md` für spezifische Anforderungen lesen
+3. `writing_state.md` für den aktuellen Fertigstellungsgrad lesen
+4. Die Arbeit gegen die Checkliste prüfen
+5. Jede Dimension als PASS, PARTIAL oder FAIL scoren
+6. Ergebnisse strukturiert ausgeben
+7. Fixes nach Schweregrad priorisieren
 
-## Output Format
+## Output-Format
 
 ```
-## Abgabe-Check: [Work Title]
+## Abgabe-Check: [Arbeitstitel]
 
-**Typ:** [Work Type] | **Uni:** [University] | **Datum:** [Check Date]
+**Typ:** [Arbeitstyp] | **Uni:** [Hochschule] | **Datum:** [Prüfdatum]
 
-### Ergebnis-Uebersicht
+### Ergebnis-Übersicht
 
-| Pruefbereich          | Status              | Details           |
+| Prüfbereich           | Status              | Details           |
 |-----------------------|---------------------|-------------------|
 | Pflichtabschnitte     | PASS/PARTIAL/FAIL   | [X/Y vorhanden]   |
 | Seitenumfang          | PASS/PARTIAL/FAIL   | [N Seiten]        |
@@ -144,21 +144,21 @@ Verify:
 | Abbildungen/Tabellen  | PASS/PARTIAL/FAIL   | [Issues count]    |
 | Eidesstattl. Erkl.    | PASS/PARTIAL/FAIL   | [vorhanden/fehlt] |
 
-### Kritische Maengel (sofort beheben)
-[List FAIL items with specific fix instructions]
+### Kritische Mängel (sofort beheben)
+[FAIL-Punkte mit konkreten Fix-Anweisungen auflisten]
 
 ### Empfehlungen (sollte behoben werden)
-[List PARTIAL items with improvement suggestions]
+[PARTIAL-Punkte mit Verbesserungsvorschlägen auflisten]
 
 ### Bestanden
-[List PASS items as confirmation]
+[PASS-Punkte zur Bestätigung auflisten]
 ```
 
-## Important Rules
+## Wichtige Regeln
 
-- Always check `${CLAUDE_PLUGIN_ROOT}/skills/submission-checker/leibniz-fh-requirements.md` first -- university-specific rules override general conventions
-- If `${CLAUDE_PLUGIN_ROOT}/skills/submission-checker/leibniz-fh-requirements.md` is not available, use standard German academic conventions and note that university-specific verification was not possible
-- Never assume formatting is correct without checking -- formatting errors are the most common reason for submission delays
-- Distinguish between hard requirements (FAIL = cannot submit) and soft recommendations (PARTIAL = should fix)
-- If the paper is not yet complete, run the check on available sections and note which checks are pending
-- Present results in German when `academic_context.md` specifies German as language
+- Immer zuerst `${CLAUDE_PLUGIN_ROOT}/skills/submission-checker/leibniz-fh-requirements.md` prüfen -- hochschulspezifische Regeln überschreiben allgemeine Konventionen
+- Ist die Datei nicht verfügbar, deutsche Standard-Konventionen nutzen und vermerken, dass hochschulspezifische Prüfung nicht möglich war
+- Formatierung nie als korrekt annehmen ohne zu prüfen -- Formatfehler sind der häufigste Grund für Abgabeverzögerungen
+- Zwischen harten Anforderungen (FAIL = keine Abgabe möglich) und weichen Empfehlungen (PARTIAL = sollte behoben werden) unterscheiden
+- Ist die Arbeit noch nicht fertig, Check auf vorhandene Abschnitte laufen lassen und offene Prüfpunkte benennen
+- Ergebnisse auf Deutsch präsentieren, wenn `academic_context.md` Deutsch als Sprache angibt

--- a/skills/submission-checker/SKILL.md
+++ b/skills/submission-checker/SKILL.md
@@ -19,10 +19,10 @@ liefern, weil ich gegen falsches FH-Regelwerk prüfen würde."
 
 ## Keine Fabrikation
 
-Erfundene Formalia-Bestätigungen sind für die FH Leibniz ein Plagiatsbefund und
-führen zu einer Abgabe nicht-abgabefähiger Arbeit. Arbeite ausschließlich mit Daten aus
-`literature_state.md` oder direkt geladenen PDFs. Fehlen Daten: frag den User,
-rate nicht.
+Erfundene Formalia-Bestätigungen produzieren eine nicht-abgabefähige Arbeit,
+die bei Einreichung zurückgewiesen wird. Arbeite ausschließlich mit der
+Arbeits-PDF und den FH-Zuordnungen in `academic_context.md`. Fehlen Daten:
+frag den User, rate nicht.
 
 ## FH-Leibniz-Formalia-Check
 

--- a/skills/submission-checker/SKILL.md
+++ b/skills/submission-checker/SKILL.md
@@ -7,6 +7,13 @@ description: Dieser Skill wird genutzt, wenn der User vor der Abgabe seiner akad
 
 Prüft, ob eine akademische Arbeit alle formalen Abgabeanforderungen erfüllt: Seitenzahl, Formatierung, Quellenzahl, Pflichtabschnitte (Deckblatt, Inhaltsverzeichnis, Eidesstattliche Erklärung, Anhang) und hochschulspezifische Regeln.
 
+## Keine Fabrikation
+
+Erfundene Formalia-Bestätigungen sind für die FH Leibniz ein Plagiatsbefund und
+führen zu einer Abgabe nicht-abgabefähiger Arbeit. Arbeite ausschließlich mit Daten aus
+`literature_state.md` oder direkt geladenen PDFs. Fehlen Daten: frag den User,
+rate nicht.
+
 ## Aktivierung dieses Skills
 
 - Der User fragt, ob seine Arbeit abgabefertig ist

--- a/skills/submission-checker/SKILL.md
+++ b/skills/submission-checker/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Submission Checker
-description: Dieser Skill wird genutzt, wenn der User vor der Abgabe seiner akademischen Arbeit formale Anforderungen prüfen möchte. Triggers on "formale Pruefung", "Abgabe-Check", "Formatierung pruefen", "abgabefertig", "submission check", "formal requirements", "Deckblatt pruefen", "Eidesstattliche Erklaerung", "Seitenraender", "Formatvorlage", oder wenn der User sich auf die finale Abgabe vorbereitet.
+description: Dieser Skill wird genutzt, wenn der User vor der Abgabe seiner akademischen Arbeit formale Anforderungen prüfen möchte. Triggers on "formale Prüfung / formale Pruefung", "Abgabe-Check", "Formatierung prüfen / Formatierung pruefen", "abgabefertig", "submission check", "formal requirements", "Deckblatt prüfen / Deckblatt pruefen", "Eidesstattliche Erklärung / Eidesstattliche Erklaerung", "Seitenränder / Seitenraender", "Formatvorlage", oder wenn der User sich auf die finale Abgabe vorbereitet.
 ---
 
 # Abgabe-Prüfer

--- a/skills/submission-checker/SKILL.md
+++ b/skills/submission-checker/SKILL.md
@@ -14,6 +14,21 @@ führen zu einer Abgabe nicht-abgabefähiger Arbeit. Arbeite ausschließlich mit
 `literature_state.md` oder direkt geladenen PDFs. Fehlen Daten: frag den User,
 rate nicht.
 
+## FH-Leibniz-Formalia-Check
+
+Prüfe folgende Formalia. Jeder Punkt ist PASS/FAIL:
+
+1. **Seitenränder** — 2,5 cm rundum (oben/unten/links/rechts)
+2. **Schriftart** — Times New Roman 12 pt ODER Arial 11 pt
+3. **Zeilenabstand** — 1,5-fach
+4. **Eidesstattliche Erklärung** — vollständiger Wortlaut laut FH-Vorlage, unterschrieben
+5. **Deckblatt** — alle Pflicht-Felder: Titel, Name, Matrikelnummer, Studiengang, Supervisor, Abgabedatum
+6. **Literaturverzeichnis** — nach FH-vorgegebenem Zitationsstil durchgehend einheitlich
+7. **Seitenzählung** — Einleitung beginnt mit Seite 1 (arabisch), Verzeichnisse römisch
+8. **Inhaltsverzeichnis** — automatisiert (nicht manuell), Seitenangaben korrekt
+
+Ausgabe: Tabelle Kriterium + PASS/FAIL + bei FAIL: konkrete Korrektur-Anweisung.
+
 ## Aktivierung dieses Skills
 
 - Der User fragt, ob seine Arbeit abgabefertig ist

--- a/skills/submission-checker/SKILL.md
+++ b/skills/submission-checker/SKILL.md
@@ -7,6 +7,16 @@ description: Dieser Skill wird genutzt, wenn der User vor der Abgabe seiner akad
 
 Prüft, ob eine akademische Arbeit alle formalen Abgabeanforderungen erfüllt: Seitenzahl, Formatierung, Quellenzahl, Pflichtabschnitte (Deckblatt, Inhaltsverzeichnis, Eidesstattliche Erklärung, Anhang) und hochschulspezifische Regeln.
 
+## Vorbedingungen
+
+Bevor du startest: Prüfe, ob `academic_context.md` und `literature_state.md`
+vorhanden und aktuell sind. Fehlt Kontext → triggere den `academic-context`-
+Skill und warte auf dessen Abschluss.
+
+Lehnt der User den Trigger ab → brich diesen Skill ab und erkläre:
+"Ohne FH-Zuordnung in `academic_context.md` kann ich keinen Formalia-Check
+liefern, weil ich gegen falsches FH-Regelwerk prüfen würde."
+
 ## Keine Fabrikation
 
 Erfundene Formalia-Bestätigungen sind für die FH Leibniz ein Plagiatsbefund und

--- a/skills/title-generator/SKILL.md
+++ b/skills/title-generator/SKILL.md
@@ -7,6 +7,16 @@ description: Dieser Skill wird genutzt, wenn der User Titelvorschläge für sein
 
 Analysiert eine fertige oder nahezu fertige akademische Arbeit und erzeugt 5-7 Titelvarianten mit Begründung. Liefert eine Mischung aus akademisch, kreativ und deskriptiv, abgestimmt auf Disziplin und Arbeitstyp.
 
+## Vorbedingungen
+
+Bevor du startest: Prüfe, ob `academic_context.md` und `literature_state.md`
+vorhanden und aktuell sind. Fehlt Kontext → triggere den `academic-context`-
+Skill und warte auf dessen Abschluss.
+
+Lehnt der User den Trigger ab → brich diesen Skill ab und erkläre:
+"Ohne Forschungsfrage und Kernergebnisse kann ich keine Titel-Vorschläge
+liefern, weil ich leere Titel-Hülsen ohne Verankerung liefern würde."
+
 ## Keine Fabrikation
 
 Erfundene in den Titel eingebaute Claims sind für die FH Leibniz ein Plagiatsbefund und

--- a/skills/title-generator/SKILL.md
+++ b/skills/title-generator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Title Generator
-description: Dieser Skill wird genutzt, wenn der User Titelvorschläge für seine akademische Arbeit braucht. Triggers on "Titel suchen", "Titelvorschlaege", "Arbeitstitel", "title suggestions", "Titel finden", "paper title", "Ueberschrift", oder wenn der User mit dem Schreiben fertig ist und einen finalen Titel braucht.
+description: Dieser Skill wird genutzt, wenn der User Titelvorschläge für seine akademische Arbeit braucht. Triggers on "Titel suchen", "Titelvorschläge / Titelvorschlaege", "Arbeitstitel", "title suggestions", "Titel finden", "paper title", "Überschrift / Ueberschrift", oder wenn der User mit dem Schreiben fertig ist und einen finalen Titel braucht.
 ---
 
 # Titel-Generator

--- a/skills/title-generator/SKILL.md
+++ b/skills/title-generator/SKILL.md
@@ -1,130 +1,130 @@
 ---
 name: Title Generator
-description: This skill should be used when the user needs title suggestions for their academic paper. Triggers on "Titel suchen", "Titelvorschlaege", "Arbeitstitel", "title suggestions", "Titel finden", "paper title", "Ueberschrift", or when the user has finished writing and needs a final title.
+description: Dieser Skill wird genutzt, wenn der User Titelvorschläge für seine akademische Arbeit braucht. Triggers on "Titel suchen", "Titelvorschlaege", "Arbeitstitel", "title suggestions", "Titel finden", "paper title", "Ueberschrift", oder wenn der User mit dem Schreiben fertig ist und einen finalen Titel braucht.
 ---
 
-# Title Generator
+# Titel-Generator
 
-Analyze a finished or near-finished academic paper and generate 5-7 title options with rationale. Provide a mix of academic, creative, and descriptive variants tailored to the discipline and work type.
+Analysiert eine fertige oder nahezu fertige akademische Arbeit und erzeugt 5-7 Titelvarianten mit Begründung. Liefert eine Mischung aus akademisch, kreativ und deskriptiv, abgestimmt auf Disziplin und Arbeitstyp.
 
-## When This Skill Activates
+## Aktivierung dieses Skills
 
-- The user asks for title suggestions or wants to change their working title
-- The user has completed a draft and needs a final title
-- The user is brainstorming thesis titles during the planning phase
+- Der User fragt nach Titelvorschlägen oder möchte seinen Arbeitstitel ändern
+- Der User hat einen Entwurf fertig und braucht einen finalen Titel
+- Der User sammelt in der Planungsphase Thesis-Titel-Ideen
 
-## Memory Files
+## Memory-Dateien
 
-- Read `academic_context.md` for work type, discipline, research question, methodology, language, and university requirements
-- Read `writing_state.md` for completed chapters and key arguments identified during writing
+- Lies `academic_context.md` für Arbeitstyp, Disziplin, Forschungsfrage, Methodik, Sprache und Hochschulanforderungen
+- Lies `writing_state.md` für abgeschlossene Kapitel und während des Schreibens identifizierte Kernargumente
 
-## Analysis Phase
+## Analyse-Phase
 
-Before generating titles, analyze the paper along these dimensions:
+Vor der Titelgenerierung die Arbeit entlang dieser Dimensionen analysieren:
 
-### 1. Content Structure
+### 1. Inhaltliche Struktur
 
-- Identify the central argument or thesis statement
-- Extract the main theoretical framework or model
-- Note the scope (single case study, comparative, industry-wide)
-- Identify the dependent and independent variables or key concepts
+- Zentrale These oder Kernargument identifizieren
+- Haupttheorie oder Analyserahmen extrahieren
+- Scope notieren (Einzelfall, Vergleich, branchenweit)
+- Abhängige und unabhängige Variablen bzw. Schlüsselkonzepte bestimmen
 
-### 2. Key Arguments
+### 2. Kernaussagen
 
-- Extract the 3-5 strongest claims made in the paper
-- Identify the most novel contribution or finding
-- Note any unexpected results or contrarian positions
+- Die 3-5 stärksten Claims der Arbeit extrahieren
+- Den originellsten Beitrag oder Befund identifizieren
+- Unerwartete Ergebnisse oder Gegenpositionen notieren
 
-### 3. Methodology Signature
+### 3. Methodik-Signatur
 
-- Identify the research approach (qualitative, quantitative, mixed, literature review)
-- Note specific methods that distinguish the work (e.g., Delphi method, SLR, grounded theory)
-- Check if the methodology itself is noteworthy enough for the title
+- Forschungsansatz identifizieren (qualitativ, quantitativ, Mixed, Literaturreview)
+- Methoden notieren, die die Arbeit auszeichnen (z. B. Delphi, SLR, Grounded Theory)
+- Prüfen, ob die Methodik selbst titelwürdig ist
 
-### 4. Keywords and Terminology
+### 4. Keywords und Terminologie
 
-- Extract domain-specific keywords from the paper
-- Identify the most frequently used technical terms
-- Note any coined terms or framework names
+- Domänenspezifische Keywords aus der Arbeit extrahieren
+- Häufigste Fachbegriffe identifizieren
+- Selbst geprägte Begriffe oder Framework-Namen notieren
 
-## Title Generation
+## Titel-Generierung
 
-Generate exactly 5-7 title options across these categories:
+Genau 5-7 Titelvarianten über diese Kategorien erzeugen:
 
-### Category A: Classic Academic (2 titles)
+### Kategorie A: Klassisch-Akademisch (2 Titel)
 
-Structure: `[Topic]: [Subtitle with scope/method]`
+Struktur: `[Thema]: [Untertitel mit Scope/Methode]`
 
-Characteristics:
-- Formal, descriptive, unambiguous
-- Contains the core topic and methodology or scope
-- Typical for German Abschlussarbeiten
-- Example pattern: "Digitale Transformation im Mittelstand: Eine qualitative Analyse der Erfolgsfaktoren"
+Eigenschaften:
+- Formal, deskriptiv, eindeutig
+- Enthält Kernthema und Methodik oder Scope
+- Typisch für deutsche Abschlussarbeiten
+- Beispielmuster: "Digitale Transformation im Mittelstand: Eine qualitative Analyse der Erfolgsfaktoren"
 
-### Category B: Question-Based (1-2 titles)
+### Kategorie B: Fragenbasiert (1-2 Titel)
 
-Structure: Title formulated as the research question or a provocative question.
+Struktur: Titel als Forschungsfrage oder provokante Frage.
 
-Characteristics:
-- Engages the reader immediately
-- Reflects the research question from `academic_context.md`
-- Appropriate for exploratory or argumentative work
+Eigenschaften:
+- Spricht den Leser direkt an
+- Spiegelt die Forschungsfrage aus `academic_context.md`
+- Passend für explorative oder argumentative Arbeiten
 
-### Category C: Conceptual / Creative (1-2 titles)
+### Kategorie C: Konzeptuell / Kreativ (1-2 Titel)
 
-Structure: Short, memorable phrase with academic subtitle.
+Struktur: Kurze, einprägsame Phrase mit akademischem Untertitel.
 
-Characteristics:
-- Uses a metaphor, paradox, or striking phrase
-- Always paired with a clarifying subtitle
-- More common in social sciences and humanities
-- Must remain professionally appropriate
+Eigenschaften:
+- Nutzt Metapher, Paradox oder prägnante Formulierung
+- Immer mit klärendem Untertitel
+- Häufiger in Sozial- und Geisteswissenschaften
+- Muss professionell bleiben
 
-### Category D: Result-Oriented (1 title)
+### Kategorie D: Ergebnisorientiert (1 Titel)
 
-Structure: Title that hints at or states the main finding.
+Struktur: Titel, der das zentrale Ergebnis andeutet oder benennt.
 
-Characteristics:
-- Previews the conclusion
-- Appropriate when the finding is strong and clear
-- Less common in German academic tradition but increasingly accepted
+Eigenschaften:
+- Kündigt die Schlussfolgerung an
+- Passend, wenn der Befund klar und stark ist
+- In deutscher Tradition weniger üblich, aber zunehmend akzeptiert
 
-## Output Format
+## Output-Format
 
-Present each title with:
+Jeder Titel mit:
 
 ```
-## Titelvorschlaege
+## Titelvorschläge
 
-### 1. [Title] — Kategorie: Klassisch-Akademisch
-**Rationale:** [Why this title works -- what it emphasizes, how it positions the work]
-**Staerke:** [Key advantage]
-**Einschraenkung:** [Potential drawback or limitation]
+### 1. [Titel] — Kategorie: Klassisch-Akademisch
+**Rationale:** [Warum dieser Titel trägt -- was er betont, wie er die Arbeit positioniert]
+**Stärke:** [Wichtigster Vorteil]
+**Einschränkung:** [Möglicher Nachteil oder Grenze]
 
-### 2. [Title] — Kategorie: ...
+### 2. [Titel] — Kategorie: ...
 ...
 
 ---
 
-**Empfehlung:** [Which title best fits the work type and university context, with brief justification]
+**Empfehlung:** [Welcher Titel am besten zu Arbeitstyp und Hochschule passt, mit kurzer Begründung]
 ```
 
-## Title Quality Criteria
+## Qualitätskriterien für Titel
 
-Verify each generated title against:
+Jeder generierte Titel ist zu prüfen auf:
 
-- **Accuracy** -- Does the title faithfully represent the paper's content?
-- **Specificity** -- Is the scope clear (not too broad, not too narrow)?
-- **Searchability** -- Does it contain keywords that aid discoverability?
-- **Length** -- Aim for 8-15 words (including subtitle); flag if exceeding 20
-- **Convention** -- Does it match typical title patterns for the work type and discipline?
-- **Language** -- Match the paper's language; if German paper, generate German titles (optionally add one English variant)
+- **Korrektheit** -- Gibt der Titel den Inhalt der Arbeit korrekt wieder?
+- **Spezifität** -- Ist der Scope klar (nicht zu breit, nicht zu eng)?
+- **Auffindbarkeit** -- Enthält er Keywords, die die Auffindbarkeit unterstützen?
+- **Länge** -- Ziel 8-15 Wörter (inkl. Untertitel); flag bei über 20
+- **Konvention** -- Passt er zu typischen Titelmustern für Arbeitstyp und Disziplin?
+- **Sprache** -- Sprache der Arbeit einhalten; bei deutschen Arbeiten deutsche Titel (optional eine englische Variante ergänzen)
 
-## Important Rules
+## Wichtige Regeln
 
-- Read the actual paper content before generating titles -- never generate titles from the outline alone if text is available
-- Respect the language specified in `academic_context.md`
-- Never suggest clickbait or sensationalist phrasing
-- Avoid titles that overstate the findings
-- Include the recommendation with reasoning tied to the specific university and work type
-- If no paper text is available yet, generate preliminary titles from the outline and research question, and mark them as provisional
+- Den tatsächlichen Arbeitstext vor der Titelgenerierung lesen -- nie nur aus der Gliederung erzeugen, wenn Text da ist
+- Die in `academic_context.md` angegebene Sprache respektieren
+- Niemals Clickbait oder sensationalistische Formulierungen vorschlagen
+- Titel vermeiden, die die Befunde überhöhen
+- Empfehlung mit Begründung an Hochschule und Arbeitstyp binden
+- Liegt noch kein Text vor, vorläufige Titel aus Gliederung und Forschungsfrage erzeugen und als vorläufig markieren

--- a/skills/title-generator/SKILL.md
+++ b/skills/title-generator/SKILL.md
@@ -14,6 +14,41 @@ führen zu einer vor der Korrektur angreifbaren Arbeit. Arbeite ausschließlich 
 `literature_state.md` oder direkt geladenen PDFs. Fehlen Daten: frag den User,
 rate nicht.
 
+## Few-Shot-Beispiele (Titelstile)
+
+### Stil: Deskriptiv
+
+**Schlecht** (Grund: zu allgemein, kein Kontext):
+
+> "Eine Untersuchung zu KI in der Lehre"
+
+**Gut** (Grund: Gegenstand + Methode + Kontext):
+
+> "Einsatz generativer KI in FH-Seminaren: Quantitative Analyse von
+> Prüfungsleistungen im Studienjahr 2024"
+
+### Stil: These
+
+**Schlecht** (Grund: These ohne Bezug zum Scope):
+
+> "KI ist die Zukunft"
+
+**Gut** (Grund: überprüfbare These + Domäne + Qualifikator):
+
+> "Generative KI verbessert Prüfungsleistungen: Evidenz aus einer
+> FH-Stichprobe 2024"
+
+### Stil: Frage
+
+**Schlecht** (Grund: rhetorisch, nicht beantwortet):
+
+> "Sollten Studierende KI nutzen?"
+
+**Gut** (Grund: direkte Forschungsfrage als Titel, empirisch beantwortbar):
+
+> "Wie beeinflusst regelmäßige KI-Nutzung die Prüfungsnoten in BWL- und
+> Informatik-Studiengängen? Eine Erhebung an der FH Leibniz 2024"
+
 ## Aktivierung dieses Skills
 
 - Der User fragt nach Titelvorschlägen oder möchte seinen Arbeitstitel ändern

--- a/skills/title-generator/SKILL.md
+++ b/skills/title-generator/SKILL.md
@@ -7,6 +7,13 @@ description: Dieser Skill wird genutzt, wenn der User Titelvorschläge für sein
 
 Analysiert eine fertige oder nahezu fertige akademische Arbeit und erzeugt 5-7 Titelvarianten mit Begründung. Liefert eine Mischung aus akademisch, kreativ und deskriptiv, abgestimmt auf Disziplin und Arbeitstyp.
 
+## Keine Fabrikation
+
+Erfundene in den Titel eingebaute Claims sind für die FH Leibniz ein Plagiatsbefund und
+führen zu einer vor der Korrektur angreifbaren Arbeit. Arbeite ausschließlich mit Daten aus
+`literature_state.md` oder direkt geladenen PDFs. Fehlen Daten: frag den User,
+rate nicht.
+
 ## Aktivierung dieses Skills
 
 - Der User fragt nach Titelvorschlägen oder möchte seinen Arbeitstitel ändern

--- a/skills/title-generator/SKILL.md
+++ b/skills/title-generator/SKILL.md
@@ -19,10 +19,11 @@ liefern, weil ich leere Titel-Hülsen ohne Verankerung liefern würde."
 
 ## Keine Fabrikation
 
-Erfundene in den Titel eingebaute Claims sind für die FH Leibniz ein Plagiatsbefund und
-führen zu einer vor der Korrektur angreifbaren Arbeit. Arbeite ausschließlich mit Daten aus
-`literature_state.md` oder direkt geladenen PDFs. Fehlen Daten: frag den User,
-rate nicht.
+In den Titel eingebaute Claims ohne Textbeleg machen die Arbeit vor der
+Korrektur angreifbar und riskieren Nachfragen im Kolloquium. Arbeite
+ausschließlich mit `writing_state.md` (fertiger Arbeitstext) und
+`academic_context.md` (Forschungsfrage, Kernergebnisse). Fehlen Daten: frag
+den User, rate nicht.
 
 ## Few-Shot-Beispiele (Titelstile)
 

--- a/tests/test_skills_manifest.py
+++ b/tests/test_skills_manifest.py
@@ -1,0 +1,65 @@
+"""Smoke-Test fuer Skill-Manifest-Struktur nach E3-Prompt-Quality-Refactor.
+
+Prueft jede skills/*/SKILL.md auf:
+- valides YAML-Frontmatter mit name + description
+- '## Vorbedingungen'-Sektion (ausser academic-context)
+- '## Keine Fabrikation'-Sektion (alle 13)
+- >= 1 Umlaut-Paar ('X.../X...'-Muster mit Umlaut vor dem Slash) in description
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+SKILLS_DIR = Path(__file__).parent.parent / "skills"
+ALL_SKILLS = sorted(SKILLS_DIR.glob("*/SKILL.md"))
+SKILLS_WITH_PRECONDITION = [p for p in ALL_SKILLS if p.parent.name != "academic-context"]
+
+
+def _frontmatter(path: Path) -> dict:
+    text = path.read_text()
+    m = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
+    if not m:
+        return {}
+    fm: dict = {}
+    current_key: str | None = None
+    for line in m.group(1).splitlines():
+        if re.match(r"^[a-zA-Z_-]+:\s*", line):
+            key, _, val = line.partition(":")
+            current_key = key.strip()
+            fm[current_key] = val.strip()
+        elif current_key and line.startswith("  "):
+            fm[current_key] += " " + line.strip()
+    return fm
+
+
+@pytest.mark.parametrize("skill_path", ALL_SKILLS, ids=lambda p: p.parent.name)
+def test_frontmatter_valid(skill_path: Path) -> None:
+    fm = _frontmatter(skill_path)
+    assert fm.get("name"), f"{skill_path}: name fehlt"
+    assert fm.get("description"), f"{skill_path}: description fehlt"
+
+
+@pytest.mark.parametrize("skill_path", ALL_SKILLS, ids=lambda p: p.parent.name)
+def test_no_fabrication_section(skill_path: Path) -> None:
+    assert "\n## Keine Fabrikation\n" in skill_path.read_text(), (
+        f"{skill_path}: '## Keine Fabrikation' fehlt"
+    )
+
+
+@pytest.mark.parametrize("skill_path", SKILLS_WITH_PRECONDITION, ids=lambda p: p.parent.name)
+def test_precondition_section(skill_path: Path) -> None:
+    assert "\n## Vorbedingungen\n" in skill_path.read_text(), (
+        f"{skill_path}: '## Vorbedingungen' fehlt"
+    )
+
+
+@pytest.mark.parametrize("skill_path", ALL_SKILLS, ids=lambda p: p.parent.name)
+def test_umlaut_variants_in_description(skill_path: Path) -> None:
+    fm = _frontmatter(skill_path)
+    desc = fm.get("description", "")
+    pairs = re.findall(r'"[^"]*[äöüß][^"]*\s*/\s*[a-zA-Z][^"]*"', desc)
+    assert len(pairs) >= 1, (
+        f"{skill_path}: 0 Umlaut-Paare in description (gefunden: {desc[:160]}...)"
+    )


### PR DESCRIPTION
## Zusammenfassung

Epic 3 — Prompt-Qualitäts-Refactor. Reine Text/Prompt-Änderungen in 13 Skills, 5 Commands, 3 Agents. Keine Python-, Interface- oder Breaking Changes.

## Enthaltene Blöcke

- **A:** Sprach-Vereinheitlichung auf Deutsch (2 Commits: Skills + Commands/Agents)
- **B:** Anti-Fabrikations-Klauseln mit skill-spezifischer FH-Leibniz-Begründung (+ Follow-up-Fix aus Skill-Review: generisches "Plagiatsbefund" durch skill-passende Konsequenzen ersetzt)
- **C:** Numerische Schwellen in 5 Skills (PASS/FAIL-Checklisten, Scoring-Matrix, Fallback-Rubrik, Coverage-Metriken)
- **D:** Few-Shot-Paare (Gut/Schlecht mit Grund-Annotation) in 4 Skills
- **E:** Memory-Precondition-Checks mit hartem Abbruch in 12 Skills
- **F:** Abgrenzung `literature-gap-analysis` ↔ `source-quality-audit`
- **G:** Umlaut-Varianten (`"X / Xae"`-Form) in allen 13 Skill-Trigger-Descriptions
- **H:** 3 Einzelprobleme (quote-extractor Pre-Execution-Guard, query-generator CS-Disambiguierung, abstract-generator Default-String)

## Verifikation

- `tests/test_skills_manifest.py`: 51/51 Tests grün (Frontmatter, Sektionen, Umlaut-Paare)
- Skill-Reviewer-Run durchgeführt, Critical-Findings adressiert im Follow-up-Commit `60c7b63`

## Commits

11 Implementierungs-Commits (themenorientiert pro Block) + 1 Release-Commit = 12 Commits auf dem Branch seit `4ee2390` (Plan).

Closes #10 #30 #31 #32 #33 #34 #35 #36 #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)