### PR TITLE
refactor: vendor xlsx skill into plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ Alle bemerkenswerten Änderungen an diesem Plugin werden hier dokumentiert.
 
 Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Versionierung nach [Semantic Versioning](https://semver.org/lang/de/).
 
+## [Unreleased] — xlsx-Skill vendoriert
+
+### Changed
+
+- **Excel-Skill plugin-intern vendoriert.** Der `xlsx`-Skill aus `anthropics/skills/document-skills/` liegt jetzt unter `skills/xlsx/` und wird mit dem Plugin ausgeliefert. Keine separate Installation von `document-skills@anthropic-agent-skills` mehr nötig. Updates des Upstream-Skills müssen manuell nachgezogen werden (Trade-off bewusst gewählt).
+- `scripts/requirements.txt`: `openpyxl>=3.1` und `pandas>=2.0` ergänzt (Dependencies des vendored xlsx-Skills).
+- `hooks/hooks.json`: SessionStart-Python-Env-Check prüft zusätzlich `openpyxl`; der separate `document-skills`-Plugin-Check entfällt.
+- `commands/excel.md`, `commands/setup.md`, `scripts/setup.sh`, `README.md`: alle `document-skills`-Install-Hinweise und Cache-Pfad-Checks entfernt.
+- `tests/test_skills_manifest.py`: vendorierte Skills (aktuell nur `xlsx`) vom projektspezifischen Manifest-Test (Vorbedingungen/Keine-Fabrikation/Umlaut-Paare) ausgeschlossen — Upstream-Skills folgen eigenen Conventions.
+
 ## [5.4.0] — 2026-04-24
 
 Finale Review-Runde gegen anthropics/skills Cookbook (Commit `5128e186`).

--- a/README.md
+++ b/README.md
@@ -114,25 +114,15 @@ Dieser Command:
 
 1. Legt `~/.academic-research/` als Daten-Verzeichnis an (Sessions, PDFs).
 2. Erzeugt ein isoliertes Python-venv unter `~/.academic-research/venv/`.
-3. Installiert Python-Pakete (`httpx`, `PyPDF2`, `pyyaml`, `anthropic`).
+3. Installiert Python-Pakete (`httpx`, `PyPDF2`, `pyyaml`, `anthropic`, `openpyxl`, `pandas`).
 4. Installiert `browser-use`-CLI automatisch via `uv tool install browser-use` oder `pipx install browser-use`.
-5. Prüft, ob der `browser-use`-Claude-Skill und das `document-skills`-Plugin vorhanden sind, und warnt wenn nicht.
+5. Prüft, ob der `browser-use`-Claude-Skill vorhanden ist, und warnt wenn nicht.
 6. Trägt Permissions in `~/.claude/settings.local.json` ein.
 7. **Wenn der aktuelle Ordner leer ist:** fragt, ob eine Facharbeit-Struktur angelegt werden soll (*„Hier einen Facharbeit-Arbeitsordner initialisieren?"* → `y`). Legt dann `academic_context.md`, `CLAUDE.md`, `.gitignore`, `kapitel/`, `literatur/`, `pdfs/` an.
 
 Das Setup ist **idempotent** — du kannst es beliebig oft aufrufen, ohne etwas zu beschädigen.
 
-### Schritt 4 — document-skills installieren (für Excel-Export)
-
-Nur wenn du `/academic-research:excel` nutzen willst:
-
-```
-/plugin install document-skills@anthropic-agent-skills
-```
-
-Ohne dieses Plugin bleiben alle anderen Features funktionsfähig — nur der Excel-Export braucht es.
-
-### Schritt 5 — browser-use Skill (optional, für Google Scholar & Co.)
+### Schritt 4 — browser-use Skill (optional, für Google Scholar & Co.)
 
 Der `browser-use`-Claude-Skill liegt unter `~/.claude/skills/browser-use/`. Falls er fehlt, warnt das Setup. Er ermöglicht Suchen über Google Scholar, Springer, OECD, RePEc, OPAC, EBSCO und ProQuest. Anthropic distribuiert den Skill separat — eine Google-Suche nach *„claude browser-use skill"* führt zu den aktuellen Installationshinweisen.
 
@@ -169,7 +159,7 @@ Das stellt sicher, dass neue Dependencies (z. B. `anthropic>=0.40`) nachgezogen 
 v5.0.0 hat drei Dinge umgestellt:
 
 1. **Browser-Automation**: Playwright-MCP → `browser-use`-CLI.
-2. **Excel-Generierung**: eigene Python-Pipeline → externes `document-skills`-Plugin.
+2. **Excel-Generierung**: eigene Python-Pipeline → `xlsx`-Skill (ab v5.5 plugin-intern vendoriert, davor externes `document-skills`-Plugin).
 3. **Drei Python-Skripte gelöscht**: Logik ist jetzt in Skills/Agents inline.
 
 v5.3.0 hat zusätzlich den Kontext umgestellt:
@@ -188,13 +178,10 @@ v5.3.0 hat zusätzlich den Kontext umgestellt:
 # 3. Venv neu bauen (wegen openpyxl, das nicht mehr gebraucht wird)
 rm -rf ~/.academic-research/venv
 
-# 4. Setup neu laufen lassen — installiert browser-use, neue Deps
+# 4. Setup neu laufen lassen — installiert browser-use, neue Deps (inkl. openpyxl/pandas für den vendorierten xlsx-Skill)
 /academic-research:setup
 
-# 5. document-skills installieren (für Excel)
-/plugin install document-skills@anthropic-agent-skills
-
-# 6. Im Facharbeit-Ordner: Kontext aus Memory in Projekt migrieren
+# 5. Im Facharbeit-Ordner: Kontext aus Memory in Projekt migrieren
 cd ~/Pfad/zur/Arbeit
 /academic-research:setup
 # → fragt: "Bestehenden Kontext in Claude-Memory gefunden. Kopieren?" → y
@@ -220,7 +207,6 @@ Danach:
 /plugin marketplace add jamski105/academic-research
 /plugin install academic-research@academic-research
 /academic-research:setup
-/plugin install document-skills@anthropic-agent-skills
 ```
 
 ## Alte Dateien löschen
@@ -232,7 +218,7 @@ Wenn du von v3 oder v4 kommst (oder einfach aufräumen willst), sind das die Ste
 ```bash
 # macOS / Linux
 rm -rf ~/.claude/plugins/cache/academic-research      # falls vom /plugin uninstall nicht entfernt
-rm -rf ~/.claude/plugins/cache/anthropic-agent-skills/document-skills  # nur wenn du document-skills NICHT mehr willst
+rm -rf ~/.claude/plugins/cache/anthropic-agent-skills/document-skills  # optional: nur wenn du das alte externe document-skills-Plugin komplett loswerden willst (wird von academic-research v5.5+ nicht mehr benötigt)
 ```
 
 ### 2. Alte Python-Venv (aus v3/v4)
@@ -538,7 +524,7 @@ Nutzt die 5D-Scoring-Engine (siehe unten) und weist Cluster zu. Kann auf die let
 
 ### `/academic-research:excel`
 
-Professionelle Excel-Datei aus gescorten Papers generieren. **Benötigt das `document-skills`-Plugin.**
+Professionelle Excel-Datei aus gescorten Papers generieren. Nutzt den plugin-intern vendorierten `xlsx`-Skill — keine externe Plugin-Installation nötig.
 
 **Syntax:** `/academic-research:excel [--papers papers.json] [--output name.xlsx] [--context]`
 
@@ -704,7 +690,7 @@ Die Commands `/search` und `/history` erwarten die Python-Venv unter `~/.academi
 | Excel leer | Zuerst `/academic-research:search` ausführen |
 | Semantic Scholar 429-Fehler | `SS_API_KEY` Umgebungsvariable setzen |
 | Skill triggert nicht automatisch | Keyword aus Trigger-Liste verwenden (siehe Skill-Tabelle) oder Skill explizit ansprechen (*„Nutze den advisor-Skill …"*) |
-| `/academic-research:excel` scheitert mit *„document-skills nicht gefunden"* | `/plugin install document-skills@anthropic-agent-skills` |
+| `/academic-research:excel` meldet fehlendes `openpyxl` oder `pandas` | `~/.academic-research/venv/bin/pip install -r ${CLAUDE_PLUGIN_ROOT}/scripts/requirements.txt` oder `/academic-research:setup` erneut laufen lassen |
 | Kontext wird nicht geladen | `ls academic_context.md` — fehlt die Datei, `/academic-research:setup` in diesem Ordner laufen lassen |
 | Plugin soll in Code-Projekten nicht mehr laden | In `.claude/settings.local.json` des Code-Projekts: `{"enabledPlugins": {"academic-research@academic-research": false}}` |
 
@@ -743,7 +729,7 @@ Kein CI-Trigger — Evals laufen lokal vor jedem Release; Reports werden unter `
 
 **v5.0.0** (Breaking) — Architektur-Bereinigung:
 - Browser-Automation auf `browser-use`-CLI umgestellt.
-- Excel-Generierung an `document-skills:xlsx`-Plugin delegiert.
+- Excel-Generierung an den `xlsx`-Skill delegiert (ab v5.5 plugin-intern vendoriert, davor externes `document-skills`-Plugin).
 - Drei redundante Python-Skripte (`citations.py`, `style_analysis.py`, `ranking.py`) gelöscht.
 
 **v5.0.1** — `/academic-research:setup` wurde One-Click-Installer (Auto-Install via `uv`/`pipx`).

--- a/commands/excel.md
+++ b/commands/excel.md
@@ -1,5 +1,5 @@
 ---
-description: Generate or update a literature Excel spreadsheet via the document-skills:xlsx skill
+description: Generate or update a literature Excel spreadsheet via the vendored xlsx skill
 disable-model-invocation: true
 allowed-tools: Read, Write
 argument-hint: [--papers papers.json] [--output literature.xlsx] [--context]
@@ -7,7 +7,7 @@ argument-hint: [--papers papers.json] [--output literature.xlsx] [--context]
 
 # Literatur-Excel-Generator
 
-Erstellt ein formatiertes Excel-Workbook aus gescorten Papers. Die eigentliche Excel-Generierung übernimmt der extern installierte `document-skills:xlsx`-Skill (siehe README-Prerequisites).
+Erstellt ein formatiertes Excel-Workbook aus gescorten Papers. Die eigentliche Excel-Generierung übernimmt der plugin-intern vendorierte `xlsx`-Skill unter `${CLAUDE_PLUGIN_ROOT}/skills/xlsx/` — keine externe Plugin-Installation nötig.
 
 ## Verwendung
 
@@ -17,13 +17,7 @@ Erstellt ein formatiertes Excel-Workbook aus gescorten Papers. Die eigentliche E
 
 ## Voraussetzung
 
-`document-skills:xlsx` muss installiert sein:
-
-```
-/plugin install document-skills@anthropic-agent-skills
-```
-
-Wenn nicht installiert: SessionStart-Hook warnt beim Start; dieser Command bricht klar ab, wenn der Skill beim Aufruf fehlt.
+Der `xlsx`-Skill ist im Plugin eingebunden (`skills/xlsx/`) und steht ohne weitere Installation zur Verfügung. Das Setup benötigt `python3` mit `openpyxl` — wird über `/academic-research:setup` mit installiert.
 
 ## Erwartete Sheets
 
@@ -43,17 +37,7 @@ if [ -z "$PAPERS" ]; then
 fi
 ```
 
-### Schritt 2: Verfügbarkeit des xlsx-Skills prüfen
-
-```bash
-if [ ! -d "$HOME/.claude/plugins/cache/anthropic-agent-skills/document-skills" ]; then
-  echo "❌ document-skills:xlsx nicht installiert."
-  echo "   Install: /plugin install document-skills@anthropic-agent-skills"
-  exit 1
-fi
-```
-
-### Schritt 3: Input strukturieren
+### Schritt 2: Input strukturieren
 
 Lies die Paper-Daten aus `$PAPERS` (JSON-Array mit Feldern `title`, `authors`, `year`, `doi`, `total_score`, `cluster`, `relevance_score`, `recency_score`, `quality_score`, `authority_score`, `access_score`, `venue`, `source_module`).
 
@@ -61,11 +45,11 @@ Wenn `--context` gesetzt:
 - Lies `./academic_context.md` aus dem Projekt-Ordner; extrahiere die `Gliederung`
 - Berechne pro Paper die zugeordneten Kapitel (Keyword-Match zwischen `title`/`abstract` und Kapitelüberschriften)
 
-### Schritt 4: xlsx-Skill aktivieren
+### Schritt 3: xlsx-Skill aktivieren
 
-Rufe den `document-skills:xlsx`-Skill mit klarer Input/Output-Spezifikation auf:
+Der vendorierte `xlsx`-Skill liegt unter `${CLAUDE_PLUGIN_ROOT}/skills/xlsx/SKILL.md`. Wende ihn auf die strukturierten Paper-Daten an.
 
-**Input:** Strukturierte Paper-Daten (siehe Schritt 3) plus Sheet-Spezifikation (welche Sheets, welche Spalten, welche Farbcodierung).
+**Input:** Strukturierte Paper-Daten (siehe Schritt 2) plus Sheet-Spezifikation (welche Sheets, welche Spalten, welche Farbcodierung).
 
 **Output:** `$OUTPUT` (Default: `~/.academic-research/sessions/$LATEST/literature.xlsx`).
 
@@ -76,6 +60,6 @@ Rufe den `document-skills:xlsx`-Skill mit klarer Input/Output-Spezifikation auf:
 - **Kapitel-Zuordnung** (nur bei `--context`): Mapping Kapitel → Papers.
 - **Datenblatt**: Alle Rohdatenfelder in flachem Tabellenformat.
 
-### Schritt 5: Ergebnis präsentieren
+### Schritt 4: Ergebnis präsentieren
 
 Ausgabepfad und Zusammenfassung anzeigen (Anzahl Papers, Cluster-Verteilung, Dateigröße).

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -1,5 +1,5 @@
 ---
-description: Set up the academic research plugin (Python env, browser-use CLI, document-skills check, permissions)
+description: Set up the academic research plugin (Python env, browser-use CLI, permissions)
 disable-model-invocation: true
 allowed-tools: Bash(bash *), Bash(python3 *)
 ---
@@ -14,15 +14,14 @@ Vollständiges Setup über das zentrale Installationsskript. Ein Aufruf, alle Ab
 bash ${CLAUDE_PLUGIN_ROOT}/scripts/setup.sh
 ```
 
-Das Skript übernimmt in sieben Schritten:
+Das Skript übernimmt in sechs Schritten:
 
 1. Legt `~/.academic-research/{sessions,pdfs,venv}` an.
-2. Erstellt die Python-venv und installiert `httpx`, `PyPDF2`, `pyyaml` (aus `scripts/requirements.txt`).
+2. Erstellt die Python-venv und installiert `httpx`, `PyPDF2`, `pyyaml`, `openpyxl` (aus `scripts/requirements.txt`).
 3. Prüft, ob `browser-use` CLI vorhanden ist. Falls nicht: installiert automatisch via `uv tool install` oder `pipx install`, sofern eines der beiden Tools vorhanden ist. Führt anschließend `browser-use doctor` aus.
 4. Prüft, ob der globale `browser-use` Claude-Skill unter `~/.claude/skills/browser-use/` liegt.
-5. Prüft, ob das `document-skills` Plugin im Plugin-Cache vorhanden ist. Falls nicht: zeigt den exakten `/plugin install`-Befehl an — dieser Schritt ist **nicht automatisierbar**, da Plugins in Claude Code keine anderen Plugins auto-installieren dürfen.
-6. Schreibt die Claude-Code-Permissions über `scripts/configure_permissions.py`.
-7. **Projekt-Bootstrap (Auto-Detect).** Wenn das aktuelle Verzeichnis ein leerer Ordner ist, fragt `/setup` `"Hier einen Facharbeit-Arbeitsordner initialisieren?"`. Bei `y` werden `academic_context.md` (Stub), `CLAUDE.md`, `.gitignore`, sowie `kapitel/`, `literatur/`, `pdfs/` angelegt. In einem bestehenden Facharbeit-Ordner (mit `academic_context.md`) werden nur fehlende Artefakte nachgezogen — idempotent, keine Rückfrage. In Code-Repos (erkannt an `package.json`, `pyproject.toml`, …) oder nicht-leeren fremden Verzeichnissen: keine Aktion. Findet der Bootstrap zusätzlich bestehenden Kontext in Claude-Memory, bietet er an, ihn einmalig ins Projekt zu kopieren; die Memory-Dateien bleiben als Backup liegen.
+5. Schreibt die Claude-Code-Permissions über `scripts/configure_permissions.py`.
+6. **Projekt-Bootstrap (Auto-Detect).** Wenn das aktuelle Verzeichnis ein leerer Ordner ist, fragt `/setup` `"Hier einen Facharbeit-Arbeitsordner initialisieren?"`. Bei `y` werden `academic_context.md` (Stub), `CLAUDE.md`, `.gitignore`, sowie `kapitel/`, `literatur/`, `pdfs/` angelegt. In einem bestehenden Facharbeit-Ordner (mit `academic_context.md`) werden nur fehlende Artefakte nachgezogen — idempotent, keine Rückfrage. In Code-Repos (erkannt an `package.json`, `pyproject.toml`, …) oder nicht-leeren fremden Verzeichnissen: keine Aktion. Findet der Bootstrap zusätzlich bestehenden Kontext in Claude-Memory, bietet er an, ihn einmalig ins Projekt zu kopieren; die Memory-Dateien bleiben als Backup liegen.
 
 ## Interpretation der Ausgabe
 
@@ -31,7 +30,6 @@ Das Skript übernimmt in sieben Schritten:
 | ✅ Python environment: ready | venv + requirements.txt erfolgreich installiert |
 | ✅ browser-use CLI: ready | CLI vorhanden und `browser-use doctor` meldet keinen Fehler |
 | ✅ browser-use Claude-Skill: vorhanden | Skill unter `~/.claude/skills/browser-use/` |
-| ✅ document-skills Plugin: vorhanden | Plugin-Cache-Pfad existiert |
 | ⚠️ … | siehe Hinweistext direkt unter dem Marker |
 | ✅ Facharbeit-Arbeitsordner initialisiert | Projekt-Struktur wurde im aktuellen Verzeichnis angelegt |
 
@@ -39,7 +37,6 @@ Das Skript übernimmt in sieben Schritten:
 
 - **Ohne `browser-use` CLI:** API-basierte Suchmodule (CrossRef, OpenAlex, Semantic Scholar, BASE, EconBiz, EconStor, arXiv) laufen weiter. Browser-basierte Suchmodule (Scholar, Springer, OECD, RePEc, OPAC, EBSCOhost, ProQuest) werden übersprungen.
 - **Ohne `browser-use` Claude-Skill:** Claude fällt bei Browser-Aufrufen auf direkte CLI-Kommandos zurück (funktional identisch, nur ohne den Skill-Wrapper mit seinen Best-Practice-Hinweisen).
-- **Ohne `document-skills` Plugin:** `/academic-research:excel` bricht mit klarer Fehlermeldung und Install-Befehl ab.
 
 ## Erneutes Ausführen
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,13 +6,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'VENV=~/.academic-research/venv; if [ ! -d \"$VENV\" ]; then echo \"⚠️ academic-research: Python venv not found. Run /academic-research:setup\"; exit 0; fi; $VENV/bin/python -c \"import httpx, PyPDF2, yaml\" 2>/dev/null && echo \"✅ academic-research: Python environment ready\" || echo \"⚠️ academic-research: Missing dependencies. Run: $VENV/bin/pip install -r ${CLAUDE_PLUGIN_ROOT}/scripts/requirements.txt\"'",
+            "command": "bash -c 'VENV=~/.academic-research/venv; if [ ! -d \"$VENV\" ]; then echo \"⚠️ academic-research: Python venv not found. Run /academic-research:setup\"; exit 0; fi; $VENV/bin/python -c \"import httpx, PyPDF2, yaml, openpyxl\" 2>/dev/null && echo \"✅ academic-research: Python environment ready\" || echo \"⚠️ academic-research: Missing dependencies. Run: $VENV/bin/pip install -r ${CLAUDE_PLUGIN_ROOT}/scripts/requirements.txt\"'",
             "timeout": 10
-          },
-          {
-            "type": "command",
-            "command": "bash -c '[ -d \"$HOME/.claude/plugins/cache/anthropic-agent-skills/document-skills\" ] || echo \"⚠️  academic-research: document-skills nicht installiert — /academic-research:excel benötigt: /plugin install document-skills@anthropic-agent-skills\"'",
-            "timeout": 5
           }
         ]
       }

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -2,3 +2,5 @@ anthropic>=0.40
 httpx>=0.25.0
 PyPDF2>=3.0.0
 pyyaml>=6.0
+openpyxl>=3.1
+pandas>=2.0

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -6,8 +6,7 @@
 #   2. Python-Pakete aus requirements.txt
 #   3. browser-use CLI (via uv oder pipx)
 #   4. Check: globaler browser-use Claude-Skill
-#   5. Check: document-skills Plugin (Install-Befehl bei Fehlen)
-#   6. Claude-Code-Permissions via configure_permissions.py
+#   5. Claude-Code-Permissions via configure_permissions.py
 
 set -e
 
@@ -87,22 +86,7 @@ fi
 echo ""
 
 # ---------------------------------------------------------------------------
-# 5. document-skills Plugin (für /academic-research:excel)
-# ---------------------------------------------------------------------------
-
-if [ -d "$HOME/.claude/plugins/cache/anthropic-agent-skills/document-skills" ]; then
-  echo "✅ document-skills Plugin: vorhanden"
-else
-  echo "⚠️  document-skills Plugin fehlt — /academic-research:excel wird ohne es abbrechen."
-  echo "   In Claude Code ausführen:"
-  echo "     /plugin install document-skills@anthropic-agent-skills"
-  echo "   (Plugin-zu-Plugin-Auto-Install wird von Claude Code nicht unterstützt.)"
-fi
-
-echo ""
-
-# ---------------------------------------------------------------------------
-# 6. Claude-Code-Permissions
+# 5. Claude-Code-Permissions
 # ---------------------------------------------------------------------------
 
 python3 "$SCRIPT_DIR/configure_permissions.py"

--- a/skills/xlsx/LICENSE.txt
+++ b/skills/xlsx/LICENSE.txt
@@ -1,0 +1,30 @@
+© 2025 Anthropic, PBC. All rights reserved.
+
+LICENSE: Use of these materials (including all code, prompts, assets, files,
+and other components of this Skill) is governed by your agreement with
+Anthropic regarding use of Anthropic's services. If no separate agreement
+exists, use is governed by Anthropic's Consumer Terms of Service or
+Commercial Terms of Service, as applicable:
+https://www.anthropic.com/legal/consumer-terms
+https://www.anthropic.com/legal/commercial-terms
+Your applicable agreement is referred to as the "Agreement." "Services" are
+as defined in the Agreement.
+
+ADDITIONAL RESTRICTIONS: Notwithstanding anything in the Agreement to the
+contrary, users may not:
+
+- Extract these materials from the Services or retain copies of these
+  materials outside the Services
+- Reproduce or copy these materials, except for temporary copies created
+  automatically during authorized use of the Services
+- Create derivative works based on these materials
+- Distribute, sublicense, or transfer these materials to any third party
+- Make, offer to sell, sell, or import any inventions embodied in these
+  materials
+- Reverse engineer, decompile, or disassemble these materials
+
+The receipt, viewing, or possession of these materials does not convey or
+imply any license or right beyond those expressly granted above.
+
+Anthropic retains all right, title, and interest in these materials,
+including all copyrights, patents, and other intellectual property rights.

--- a/skills/xlsx/SKILL.md
+++ b/skills/xlsx/SKILL.md
@@ -1,0 +1,292 @@
+---
+name: xlsx
+description: "Use this skill any time a spreadsheet file is the primary input or output. This means any task where the user wants to: open, read, edit, or fix an existing .xlsx, .xlsm, .csv, or .tsv file (e.g., adding columns, computing formulas, formatting, charting, cleaning messy data); create a new spreadsheet from scratch or from other data sources; or convert between tabular file formats. Trigger especially when the user references a spreadsheet file by name or path — even casually (like \"the xlsx in my downloads\") — and wants something done to it or produced from it. Also trigger for cleaning or restructuring messy tabular data files (malformed rows, misplaced headers, junk data) into proper spreadsheets. The deliverable must be a spreadsheet file. Do NOT trigger when the primary deliverable is a Word document, HTML report, standalone Python script, database pipeline, or Google Sheets API integration, even if tabular data is involved."
+license: Proprietary. LICENSE.txt has complete terms
+---
+
+# Requirements for Outputs
+
+## All Excel files
+
+### Professional Font
+- Use a consistent, professional font (e.g., Arial, Times New Roman) for all deliverables unless otherwise instructed by the user
+
+### Zero Formula Errors
+- Every Excel model MUST be delivered with ZERO formula errors (#REF!, #DIV/0!, #VALUE!, #N/A, #NAME?)
+
+### Preserve Existing Templates (when updating templates)
+- Study and EXACTLY match existing format, style, and conventions when modifying files
+- Never impose standardized formatting on files with established patterns
+- Existing template conventions ALWAYS override these guidelines
+
+## Financial models
+
+### Color Coding Standards
+Unless otherwise stated by the user or existing template
+
+#### Industry-Standard Color Conventions
+- **Blue text (RGB: 0,0,255)**: Hardcoded inputs, and numbers users will change for scenarios
+- **Black text (RGB: 0,0,0)**: ALL formulas and calculations
+- **Green text (RGB: 0,128,0)**: Links pulling from other worksheets within same workbook
+- **Red text (RGB: 255,0,0)**: External links to other files
+- **Yellow background (RGB: 255,255,0)**: Key assumptions needing attention or cells that need to be updated
+
+### Number Formatting Standards
+
+#### Required Format Rules
+- **Years**: Format as text strings (e.g., "2024" not "2,024")
+- **Currency**: Use $#,##0 format; ALWAYS specify units in headers ("Revenue ($mm)")
+- **Zeros**: Use number formatting to make all zeros "-", including percentages (e.g., "$#,##0;($#,##0);-")
+- **Percentages**: Default to 0.0% format (one decimal)
+- **Multiples**: Format as 0.0x for valuation multiples (EV/EBITDA, P/E)
+- **Negative numbers**: Use parentheses (123) not minus -123
+
+### Formula Construction Rules
+
+#### Assumptions Placement
+- Place ALL assumptions (growth rates, margins, multiples, etc.) in separate assumption cells
+- Use cell references instead of hardcoded values in formulas
+- Example: Use =B5*(1+$B$6) instead of =B5*1.05
+
+#### Formula Error Prevention
+- Verify all cell references are correct
+- Check for off-by-one errors in ranges
+- Ensure consistent formulas across all projection periods
+- Test with edge cases (zero values, negative numbers)
+- Verify no unintended circular references
+
+#### Documentation Requirements for Hardcodes
+- Comment or in cells beside (if end of table). Format: "Source: [System/Document], [Date], [Specific Reference], [URL if applicable]"
+- Examples:
+  - "Source: Company 10-K, FY2024, Page 45, Revenue Note, [SEC EDGAR URL]"
+  - "Source: Company 10-Q, Q2 2025, Exhibit 99.1, [SEC EDGAR URL]"
+  - "Source: Bloomberg Terminal, 8/15/2025, AAPL US Equity"
+  - "Source: FactSet, 8/20/2025, Consensus Estimates Screen"
+
+# XLSX creation, editing, and analysis
+
+## Overview
+
+A user may ask you to create, edit, or analyze the contents of an .xlsx file. You have different tools and workflows available for different tasks.
+
+## Important Requirements
+
+**LibreOffice Required for Formula Recalculation**: You can assume LibreOffice is installed for recalculating formula values using the `scripts/recalc.py` script. The script automatically configures LibreOffice on first run, including in sandboxed environments where Unix sockets are restricted (handled by `scripts/office/soffice.py`)
+
+## Reading and analyzing data
+
+### Data analysis with pandas
+For data analysis, visualization, and basic operations, use **pandas** which provides powerful data manipulation capabilities:
+
+```python
+import pandas as pd
+
+# Read Excel
+df = pd.read_excel('file.xlsx')  # Default: first sheet
+all_sheets = pd.read_excel('file.xlsx', sheet_name=None)  # All sheets as dict
+
+# Analyze
+df.head()      # Preview data
+df.info()      # Column info
+df.describe()  # Statistics
+
+# Write Excel
+df.to_excel('output.xlsx', index=False)
+```
+
+## Excel File Workflows
+
+## CRITICAL: Use Formulas, Not Hardcoded Values
+
+**Always use Excel formulas instead of calculating values in Python and hardcoding them.** This ensures the spreadsheet remains dynamic and updateable.
+
+### ❌ WRONG - Hardcoding Calculated Values
+```python
+# Bad: Calculating in Python and hardcoding result
+total = df['Sales'].sum()
+sheet['B10'] = total  # Hardcodes 5000
+
+# Bad: Computing growth rate in Python
+growth = (df.iloc[-1]['Revenue'] - df.iloc[0]['Revenue']) / df.iloc[0]['Revenue']
+sheet['C5'] = growth  # Hardcodes 0.15
+
+# Bad: Python calculation for average
+avg = sum(values) / len(values)
+sheet['D20'] = avg  # Hardcodes 42.5
+```
+
+### ✅ CORRECT - Using Excel Formulas
+```python
+# Good: Let Excel calculate the sum
+sheet['B10'] = '=SUM(B2:B9)'
+
+# Good: Growth rate as Excel formula
+sheet['C5'] = '=(C4-C2)/C2'
+
+# Good: Average using Excel function
+sheet['D20'] = '=AVERAGE(D2:D19)'
+```
+
+This applies to ALL calculations - totals, percentages, ratios, differences, etc. The spreadsheet should be able to recalculate when source data changes.
+
+## Common Workflow
+1. **Choose tool**: pandas for data, openpyxl for formulas/formatting
+2. **Create/Load**: Create new workbook or load existing file
+3. **Modify**: Add/edit data, formulas, and formatting
+4. **Save**: Write to file
+5. **Recalculate formulas (MANDATORY IF USING FORMULAS)**: Use the scripts/recalc.py script
+   ```bash
+   python scripts/recalc.py output.xlsx
+   ```
+6. **Verify and fix any errors**: 
+   - The script returns JSON with error details
+   - If `status` is `errors_found`, check `error_summary` for specific error types and locations
+   - Fix the identified errors and recalculate again
+   - Common errors to fix:
+     - `#REF!`: Invalid cell references
+     - `#DIV/0!`: Division by zero
+     - `#VALUE!`: Wrong data type in formula
+     - `#NAME?`: Unrecognized formula name
+
+### Creating new Excel files
+
+```python
+# Using openpyxl for formulas and formatting
+from openpyxl import Workbook
+from openpyxl.styles import Font, PatternFill, Alignment
+
+wb = Workbook()
+sheet = wb.active
+
+# Add data
+sheet['A1'] = 'Hello'
+sheet['B1'] = 'World'
+sheet.append(['Row', 'of', 'data'])
+
+# Add formula
+sheet['B2'] = '=SUM(A1:A10)'
+
+# Formatting
+sheet['A1'].font = Font(bold=True, color='FF0000')
+sheet['A1'].fill = PatternFill('solid', start_color='FFFF00')
+sheet['A1'].alignment = Alignment(horizontal='center')
+
+# Column width
+sheet.column_dimensions['A'].width = 20
+
+wb.save('output.xlsx')
+```
+
+### Editing existing Excel files
+
+```python
+# Using openpyxl to preserve formulas and formatting
+from openpyxl import load_workbook
+
+# Load existing file
+wb = load_workbook('existing.xlsx')
+sheet = wb.active  # or wb['SheetName'] for specific sheet
+
+# Working with multiple sheets
+for sheet_name in wb.sheetnames:
+    sheet = wb[sheet_name]
+    print(f"Sheet: {sheet_name}")
+
+# Modify cells
+sheet['A1'] = 'New Value'
+sheet.insert_rows(2)  # Insert row at position 2
+sheet.delete_cols(3)  # Delete column 3
+
+# Add new sheet
+new_sheet = wb.create_sheet('NewSheet')
+new_sheet['A1'] = 'Data'
+
+wb.save('modified.xlsx')
+```
+
+## Recalculating formulas
+
+Excel files created or modified by openpyxl contain formulas as strings but not calculated values. Use the provided `scripts/recalc.py` script to recalculate formulas:
+
+```bash
+python scripts/recalc.py <excel_file> [timeout_seconds]
+```
+
+Example:
+```bash
+python scripts/recalc.py output.xlsx 30
+```
+
+The script:
+- Automatically sets up LibreOffice macro on first run
+- Recalculates all formulas in all sheets
+- Scans ALL cells for Excel errors (#REF!, #DIV/0!, etc.)
+- Returns JSON with detailed error locations and counts
+- Works on both Linux and macOS
+
+## Formula Verification Checklist
+
+Quick checks to ensure formulas work correctly:
+
+### Essential Verification
+- [ ] **Test 2-3 sample references**: Verify they pull correct values before building full model
+- [ ] **Column mapping**: Confirm Excel columns match (e.g., column 64 = BL, not BK)
+- [ ] **Row offset**: Remember Excel rows are 1-indexed (DataFrame row 5 = Excel row 6)
+
+### Common Pitfalls
+- [ ] **NaN handling**: Check for null values with `pd.notna()`
+- [ ] **Far-right columns**: FY data often in columns 50+ 
+- [ ] **Multiple matches**: Search all occurrences, not just first
+- [ ] **Division by zero**: Check denominators before using `/` in formulas (#DIV/0!)
+- [ ] **Wrong references**: Verify all cell references point to intended cells (#REF!)
+- [ ] **Cross-sheet references**: Use correct format (Sheet1!A1) for linking sheets
+
+### Formula Testing Strategy
+- [ ] **Start small**: Test formulas on 2-3 cells before applying broadly
+- [ ] **Verify dependencies**: Check all cells referenced in formulas exist
+- [ ] **Test edge cases**: Include zero, negative, and very large values
+
+### Interpreting scripts/recalc.py Output
+The script returns JSON with error details:
+```json
+{
+  "status": "success",           // or "errors_found"
+  "total_errors": 0,              // Total error count
+  "total_formulas": 42,           // Number of formulas in file
+  "error_summary": {              // Only present if errors found
+    "#REF!": {
+      "count": 2,
+      "locations": ["Sheet1!B5", "Sheet1!C10"]
+    }
+  }
+}
+```
+
+## Best Practices
+
+### Library Selection
+- **pandas**: Best for data analysis, bulk operations, and simple data export
+- **openpyxl**: Best for complex formatting, formulas, and Excel-specific features
+
+### Working with openpyxl
+- Cell indices are 1-based (row=1, column=1 refers to cell A1)
+- Use `data_only=True` to read calculated values: `load_workbook('file.xlsx', data_only=True)`
+- **Warning**: If opened with `data_only=True` and saved, formulas are replaced with values and permanently lost
+- For large files: Use `read_only=True` for reading or `write_only=True` for writing
+- Formulas are preserved but not evaluated - use scripts/recalc.py to update values
+
+### Working with pandas
+- Specify data types to avoid inference issues: `pd.read_excel('file.xlsx', dtype={'id': str})`
+- For large files, read specific columns: `pd.read_excel('file.xlsx', usecols=['A', 'C', 'E'])`
+- Handle dates properly: `pd.read_excel('file.xlsx', parse_dates=['date_column'])`
+
+## Code Style Guidelines
+**IMPORTANT**: When generating Python code for Excel operations:
+- Write minimal, concise Python code without unnecessary comments
+- Avoid verbose variable names and redundant operations
+- Avoid unnecessary print statements
+
+**For Excel files themselves**:
+- Add comments to cells with complex formulas or important assumptions
+- Document data sources for hardcoded values
+- Include notes for key calculations and model sections

--- a/skills/xlsx/scripts/office/helpers/merge_runs.py
+++ b/skills/xlsx/scripts/office/helpers/merge_runs.py
@@ -1,0 +1,199 @@
+"""Merge adjacent runs with identical formatting in DOCX.
+
+Merges adjacent <w:r> elements that have identical <w:rPr> properties.
+Works on runs in paragraphs and inside tracked changes (<w:ins>, <w:del>).
+
+Also:
+- Removes rsid attributes from runs (revision metadata that doesn't affect rendering)
+- Removes proofErr elements (spell/grammar markers that block merging)
+"""
+
+from pathlib import Path
+
+import defusedxml.minidom
+
+
+def merge_runs(input_dir: str) -> tuple[int, str]:
+    doc_xml = Path(input_dir) / "word" / "document.xml"
+
+    if not doc_xml.exists():
+        return 0, f"Error: {doc_xml} not found"
+
+    try:
+        dom = defusedxml.minidom.parseString(doc_xml.read_text(encoding="utf-8"))
+        root = dom.documentElement
+
+        _remove_elements(root, "proofErr")
+        _strip_run_rsid_attrs(root)
+
+        containers = {run.parentNode for run in _find_elements(root, "r")}
+
+        merge_count = 0
+        for container in containers:
+            merge_count += _merge_runs_in(container)
+
+        doc_xml.write_bytes(dom.toxml(encoding="UTF-8"))
+        return merge_count, f"Merged {merge_count} runs"
+
+    except Exception as e:
+        return 0, f"Error: {e}"
+
+
+
+
+def _find_elements(root, tag: str) -> list:
+    results = []
+
+    def traverse(node):
+        if node.nodeType == node.ELEMENT_NODE:
+            name = node.localName or node.tagName
+            if name == tag or name.endswith(f":{tag}"):
+                results.append(node)
+            for child in node.childNodes:
+                traverse(child)
+
+    traverse(root)
+    return results
+
+
+def _get_child(parent, tag: str):
+    for child in parent.childNodes:
+        if child.nodeType == child.ELEMENT_NODE:
+            name = child.localName or child.tagName
+            if name == tag or name.endswith(f":{tag}"):
+                return child
+    return None
+
+
+def _get_children(parent, tag: str) -> list:
+    results = []
+    for child in parent.childNodes:
+        if child.nodeType == child.ELEMENT_NODE:
+            name = child.localName or child.tagName
+            if name == tag or name.endswith(f":{tag}"):
+                results.append(child)
+    return results
+
+
+def _is_adjacent(elem1, elem2) -> bool:
+    node = elem1.nextSibling
+    while node:
+        if node == elem2:
+            return True
+        if node.nodeType == node.ELEMENT_NODE:
+            return False
+        if node.nodeType == node.TEXT_NODE and node.data.strip():
+            return False
+        node = node.nextSibling
+    return False
+
+
+
+
+def _remove_elements(root, tag: str):
+    for elem in _find_elements(root, tag):
+        if elem.parentNode:
+            elem.parentNode.removeChild(elem)
+
+
+def _strip_run_rsid_attrs(root):
+    for run in _find_elements(root, "r"):
+        for attr in list(run.attributes.values()):
+            if "rsid" in attr.name.lower():
+                run.removeAttribute(attr.name)
+
+
+
+
+def _merge_runs_in(container) -> int:
+    merge_count = 0
+    run = _first_child_run(container)
+
+    while run:
+        while True:
+            next_elem = _next_element_sibling(run)
+            if next_elem and _is_run(next_elem) and _can_merge(run, next_elem):
+                _merge_run_content(run, next_elem)
+                container.removeChild(next_elem)
+                merge_count += 1
+            else:
+                break
+
+        _consolidate_text(run)
+        run = _next_sibling_run(run)
+
+    return merge_count
+
+
+def _first_child_run(container):
+    for child in container.childNodes:
+        if child.nodeType == child.ELEMENT_NODE and _is_run(child):
+            return child
+    return None
+
+
+def _next_element_sibling(node):
+    sibling = node.nextSibling
+    while sibling:
+        if sibling.nodeType == sibling.ELEMENT_NODE:
+            return sibling
+        sibling = sibling.nextSibling
+    return None
+
+
+def _next_sibling_run(node):
+    sibling = node.nextSibling
+    while sibling:
+        if sibling.nodeType == sibling.ELEMENT_NODE:
+            if _is_run(sibling):
+                return sibling
+        sibling = sibling.nextSibling
+    return None
+
+
+def _is_run(node) -> bool:
+    name = node.localName or node.tagName
+    return name == "r" or name.endswith(":r")
+
+
+def _can_merge(run1, run2) -> bool:
+    rpr1 = _get_child(run1, "rPr")
+    rpr2 = _get_child(run2, "rPr")
+
+    if (rpr1 is None) != (rpr2 is None):
+        return False
+    if rpr1 is None:
+        return True
+    return rpr1.toxml() == rpr2.toxml()  
+
+
+def _merge_run_content(target, source):
+    for child in list(source.childNodes):
+        if child.nodeType == child.ELEMENT_NODE:
+            name = child.localName or child.tagName
+            if name != "rPr" and not name.endswith(":rPr"):
+                target.appendChild(child)
+
+
+def _consolidate_text(run):
+    t_elements = _get_children(run, "t")
+
+    for i in range(len(t_elements) - 1, 0, -1):
+        curr, prev = t_elements[i], t_elements[i - 1]
+
+        if _is_adjacent(prev, curr):
+            prev_text = prev.firstChild.data if prev.firstChild else ""
+            curr_text = curr.firstChild.data if curr.firstChild else ""
+            merged = prev_text + curr_text
+
+            if prev.firstChild:
+                prev.firstChild.data = merged
+            else:
+                prev.appendChild(run.ownerDocument.createTextNode(merged))
+
+            if merged.startswith(" ") or merged.endswith(" "):
+                prev.setAttribute("xml:space", "preserve")
+            elif prev.hasAttribute("xml:space"):
+                prev.removeAttribute("xml:space")
+
+            run.removeChild(curr)

--- a/skills/xlsx/scripts/office/helpers/simplify_redlines.py
+++ b/skills/xlsx/scripts/office/helpers/simplify_redlines.py
@@ -1,0 +1,197 @@
+"""Simplify tracked changes by merging adjacent w:ins or w:del elements.
+
+Merges adjacent <w:ins> elements from the same author into a single element.
+Same for <w:del> elements. This makes heavily-redlined documents easier to
+work with by reducing the number of tracked change wrappers.
+
+Rules:
+- Only merges w:ins with w:ins, w:del with w:del (same element type)
+- Only merges if same author (ignores timestamp differences)
+- Only merges if truly adjacent (only whitespace between them)
+"""
+
+import xml.etree.ElementTree as ET
+import zipfile
+from pathlib import Path
+
+import defusedxml.minidom
+
+WORD_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+
+
+def simplify_redlines(input_dir: str) -> tuple[int, str]:
+    doc_xml = Path(input_dir) / "word" / "document.xml"
+
+    if not doc_xml.exists():
+        return 0, f"Error: {doc_xml} not found"
+
+    try:
+        dom = defusedxml.minidom.parseString(doc_xml.read_text(encoding="utf-8"))
+        root = dom.documentElement
+
+        merge_count = 0
+
+        containers = _find_elements(root, "p") + _find_elements(root, "tc")
+
+        for container in containers:
+            merge_count += _merge_tracked_changes_in(container, "ins")
+            merge_count += _merge_tracked_changes_in(container, "del")
+
+        doc_xml.write_bytes(dom.toxml(encoding="UTF-8"))
+        return merge_count, f"Simplified {merge_count} tracked changes"
+
+    except Exception as e:
+        return 0, f"Error: {e}"
+
+
+def _merge_tracked_changes_in(container, tag: str) -> int:
+    merge_count = 0
+
+    tracked = [
+        child
+        for child in container.childNodes
+        if child.nodeType == child.ELEMENT_NODE and _is_element(child, tag)
+    ]
+
+    if len(tracked) < 2:
+        return 0
+
+    i = 0
+    while i < len(tracked) - 1:
+        curr = tracked[i]
+        next_elem = tracked[i + 1]
+
+        if _can_merge_tracked(curr, next_elem):
+            _merge_tracked_content(curr, next_elem)
+            container.removeChild(next_elem)
+            tracked.pop(i + 1)
+            merge_count += 1
+        else:
+            i += 1
+
+    return merge_count
+
+
+def _is_element(node, tag: str) -> bool:
+    name = node.localName or node.tagName
+    return name == tag or name.endswith(f":{tag}")
+
+
+def _get_author(elem) -> str:
+    author = elem.getAttribute("w:author")
+    if not author:
+        for attr in elem.attributes.values():
+            if attr.localName == "author" or attr.name.endswith(":author"):
+                return attr.value
+    return author
+
+
+def _can_merge_tracked(elem1, elem2) -> bool:
+    if _get_author(elem1) != _get_author(elem2):
+        return False
+
+    node = elem1.nextSibling
+    while node and node != elem2:
+        if node.nodeType == node.ELEMENT_NODE:
+            return False
+        if node.nodeType == node.TEXT_NODE and node.data.strip():
+            return False
+        node = node.nextSibling
+
+    return True
+
+
+def _merge_tracked_content(target, source):
+    while source.firstChild:
+        child = source.firstChild
+        source.removeChild(child)
+        target.appendChild(child)
+
+
+def _find_elements(root, tag: str) -> list:
+    results = []
+
+    def traverse(node):
+        if node.nodeType == node.ELEMENT_NODE:
+            name = node.localName or node.tagName
+            if name == tag or name.endswith(f":{tag}"):
+                results.append(node)
+            for child in node.childNodes:
+                traverse(child)
+
+    traverse(root)
+    return results
+
+
+def get_tracked_change_authors(doc_xml_path: Path) -> dict[str, int]:
+    if not doc_xml_path.exists():
+        return {}
+
+    try:
+        tree = ET.parse(doc_xml_path)
+        root = tree.getroot()
+    except ET.ParseError:
+        return {}
+
+    namespaces = {"w": WORD_NS}
+    author_attr = f"{{{WORD_NS}}}author"
+
+    authors: dict[str, int] = {}
+    for tag in ["ins", "del"]:
+        for elem in root.findall(f".//w:{tag}", namespaces):
+            author = elem.get(author_attr)
+            if author:
+                authors[author] = authors.get(author, 0) + 1
+
+    return authors
+
+
+def _get_authors_from_docx(docx_path: Path) -> dict[str, int]:
+    try:
+        with zipfile.ZipFile(docx_path, "r") as zf:
+            if "word/document.xml" not in zf.namelist():
+                return {}
+            with zf.open("word/document.xml") as f:
+                tree = ET.parse(f)
+                root = tree.getroot()
+
+                namespaces = {"w": WORD_NS}
+                author_attr = f"{{{WORD_NS}}}author"
+
+                authors: dict[str, int] = {}
+                for tag in ["ins", "del"]:
+                    for elem in root.findall(f".//w:{tag}", namespaces):
+                        author = elem.get(author_attr)
+                        if author:
+                            authors[author] = authors.get(author, 0) + 1
+                return authors
+    except (zipfile.BadZipFile, ET.ParseError):
+        return {}
+
+
+def infer_author(modified_dir: Path, original_docx: Path, default: str = "Claude") -> str:
+    modified_xml = modified_dir / "word" / "document.xml"
+    modified_authors = get_tracked_change_authors(modified_xml)
+
+    if not modified_authors:
+        return default
+
+    original_authors = _get_authors_from_docx(original_docx)
+
+    new_changes: dict[str, int] = {}
+    for author, count in modified_authors.items():
+        original_count = original_authors.get(author, 0)
+        diff = count - original_count
+        if diff > 0:
+            new_changes[author] = diff
+
+    if not new_changes:
+        return default
+
+    if len(new_changes) == 1:
+        return next(iter(new_changes))
+
+    raise ValueError(
+        f"Multiple authors added new changes: {new_changes}. "
+        "Cannot infer which author to validate."
+    )

--- a/skills/xlsx/scripts/office/pack.py
+++ b/skills/xlsx/scripts/office/pack.py
@@ -1,0 +1,159 @@
+"""Pack a directory into a DOCX, PPTX, or XLSX file.
+
+Validates with auto-repair, condenses XML formatting, and creates the Office file.
+
+Usage:
+    python pack.py <input_directory> <output_file> [--original <file>] [--validate true|false]
+
+Examples:
+    python pack.py unpacked/ output.docx --original input.docx
+    python pack.py unpacked/ output.pptx --validate false
+"""
+
+import argparse
+import sys
+import shutil
+import tempfile
+import zipfile
+from pathlib import Path
+
+import defusedxml.minidom
+
+from validators import DOCXSchemaValidator, PPTXSchemaValidator, RedliningValidator
+
+def pack(
+    input_directory: str,
+    output_file: str,
+    original_file: str | None = None,
+    validate: bool = True,
+    infer_author_func=None,
+) -> tuple[None, str]:
+    input_dir = Path(input_directory)
+    output_path = Path(output_file)
+    suffix = output_path.suffix.lower()
+
+    if not input_dir.is_dir():
+        return None, f"Error: {input_dir} is not a directory"
+
+    if suffix not in {".docx", ".pptx", ".xlsx"}:
+        return None, f"Error: {output_file} must be a .docx, .pptx, or .xlsx file"
+
+    if validate and original_file:
+        original_path = Path(original_file)
+        if original_path.exists():
+            success, output = _run_validation(
+                input_dir, original_path, suffix, infer_author_func
+            )
+            if output:
+                print(output)
+            if not success:
+                return None, f"Error: Validation failed for {input_dir}"
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_content_dir = Path(temp_dir) / "content"
+        shutil.copytree(input_dir, temp_content_dir)
+
+        for pattern in ["*.xml", "*.rels"]:
+            for xml_file in temp_content_dir.rglob(pattern):
+                _condense_xml(xml_file)
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            for f in temp_content_dir.rglob("*"):
+                if f.is_file():
+                    zf.write(f, f.relative_to(temp_content_dir))
+
+    return None, f"Successfully packed {input_dir} to {output_file}"
+
+
+def _run_validation(
+    unpacked_dir: Path,
+    original_file: Path,
+    suffix: str,
+    infer_author_func=None,
+) -> tuple[bool, str | None]:
+    output_lines = []
+    validators = []
+
+    if suffix == ".docx":
+        author = "Claude"
+        if infer_author_func:
+            try:
+                author = infer_author_func(unpacked_dir, original_file)
+            except ValueError as e:
+                print(f"Warning: {e} Using default author 'Claude'.", file=sys.stderr)
+
+        validators = [
+            DOCXSchemaValidator(unpacked_dir, original_file),
+            RedliningValidator(unpacked_dir, original_file, author=author),
+        ]
+    elif suffix == ".pptx":
+        validators = [PPTXSchemaValidator(unpacked_dir, original_file)]
+
+    if not validators:
+        return True, None
+
+    total_repairs = sum(v.repair() for v in validators)
+    if total_repairs:
+        output_lines.append(f"Auto-repaired {total_repairs} issue(s)")
+
+    success = all(v.validate() for v in validators)
+
+    if success:
+        output_lines.append("All validations PASSED!")
+
+    return success, "\n".join(output_lines) if output_lines else None
+
+
+def _condense_xml(xml_file: Path) -> None:
+    try:
+        with open(xml_file, encoding="utf-8") as f:
+            dom = defusedxml.minidom.parse(f)
+
+        for element in dom.getElementsByTagName("*"):
+            if element.tagName.endswith(":t"):
+                continue
+
+            for child in list(element.childNodes):
+                if (
+                    child.nodeType == child.TEXT_NODE
+                    and child.nodeValue
+                    and child.nodeValue.strip() == ""
+                ) or child.nodeType == child.COMMENT_NODE:
+                    element.removeChild(child)
+
+        xml_file.write_bytes(dom.toxml(encoding="UTF-8"))
+    except Exception as e:
+        print(f"ERROR: Failed to parse {xml_file.name}: {e}", file=sys.stderr)
+        raise
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Pack a directory into a DOCX, PPTX, or XLSX file"
+    )
+    parser.add_argument("input_directory", help="Unpacked Office document directory")
+    parser.add_argument("output_file", help="Output Office file (.docx/.pptx/.xlsx)")
+    parser.add_argument(
+        "--original",
+        help="Original file for validation comparison",
+    )
+    parser.add_argument(
+        "--validate",
+        type=lambda x: x.lower() == "true",
+        default=True,
+        metavar="true|false",
+        help="Run validation with auto-repair (default: true)",
+    )
+    args = parser.parse_args()
+
+    _, message = pack(
+        args.input_directory,
+        args.output_file,
+        original_file=args.original,
+        validate=args.validate,
+    )
+    print(message)
+
+    if "Error" in message:
+        sys.exit(1)

--- a/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-chart.xsd
+++ b/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-chart.xsd
@@ -1,0 +1,1499 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+  xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+  xmlns="http://schemas.openxmlformats.org/drawingml/2006/chart"
+  xmlns:cdr="http://schemas.openxmlformats.org/drawingml/2006/chartDrawing"
+  xmlns:s="http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"
+  targetNamespace="http://schemas.openxmlformats.org/drawingml/2006/chart"
+  elementFormDefault="qualified" attributeFormDefault="unqualified" blockDefault="#all">
+  <xsd:import namespace="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+    schemaLocation="shared-relationshipReference.xsd"/>
+  <xsd:import namespace="http://schemas.openxmlformats.org/drawingml/2006/main"
+    schemaLocation="dml-main.xsd"/>
+  <xsd:import namespace="http://schemas.openxmlformats.org/drawingml/2006/chartDrawing"
+    schemaLocation="dml-chartDrawing.xsd"/>
+  <xsd:import namespace="http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"
+    schemaLocation="shared-commonSimpleTypes.xsd"/>
+  <xsd:complexType name="CT_Boolean">
+    <xsd:attribute name="val" type="xsd:boolean" use="optional" default="true"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Double">
+    <xsd:attribute name="val" type="xsd:double" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_UnsignedInt">
+    <xsd:attribute name="val" type="xsd:unsignedInt" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_RelId">
+    <xsd:attribute ref="r:id" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Extension">
+    <xsd:sequence>
+      <xsd:any processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="uri" type="xsd:token"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ExtensionList">
+    <xsd:sequence>
+      <xsd:element name="ext" type="CT_Extension" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_NumVal">
+    <xsd:sequence>
+      <xsd:element name="v" type="s:ST_Xstring" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="idx" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="formatCode" type="s:ST_Xstring" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_NumData">
+    <xsd:sequence>
+      <xsd:element name="formatCode" type="s:ST_Xstring" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="ptCount" type="CT_UnsignedInt" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="pt" type="CT_NumVal" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_NumRef">
+    <xsd:sequence>
+      <xsd:element name="f" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="numCache" type="CT_NumData" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_NumDataSource">
+    <xsd:sequence>
+      <xsd:choice minOccurs="1" maxOccurs="1">
+        <xsd:element name="numRef" type="CT_NumRef" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="numLit" type="CT_NumData" minOccurs="1" maxOccurs="1"/>
+      </xsd:choice>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_StrVal">
+    <xsd:sequence>
+      <xsd:element name="v" type="s:ST_Xstring" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="idx" type="xsd:unsignedInt" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_StrData">
+    <xsd:sequence>
+      <xsd:element name="ptCount" type="CT_UnsignedInt" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="pt" type="CT_StrVal" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_StrRef">
+    <xsd:sequence>
+      <xsd:element name="f" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="strCache" type="CT_StrData" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Tx">
+    <xsd:sequence>
+      <xsd:choice minOccurs="1" maxOccurs="1">
+        <xsd:element name="strRef" type="CT_StrRef" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="rich" type="a:CT_TextBody" minOccurs="1" maxOccurs="1"/>
+      </xsd:choice>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TextLanguageID">
+    <xsd:attribute name="val" type="s:ST_Lang" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Lvl">
+    <xsd:sequence>
+      <xsd:element name="pt" type="CT_StrVal" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_MultiLvlStrData">
+    <xsd:sequence>
+      <xsd:element name="ptCount" type="CT_UnsignedInt" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="lvl" type="CT_Lvl" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_MultiLvlStrRef">
+    <xsd:sequence>
+      <xsd:element name="f" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="multiLvlStrCache" type="CT_MultiLvlStrData" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_AxDataSource">
+    <xsd:sequence>
+      <xsd:choice minOccurs="1" maxOccurs="1">
+        <xsd:element name="multiLvlStrRef" type="CT_MultiLvlStrRef" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="numRef" type="CT_NumRef" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="numLit" type="CT_NumData" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="strRef" type="CT_StrRef" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="strLit" type="CT_StrData" minOccurs="1" maxOccurs="1"/>
+      </xsd:choice>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SerTx">
+    <xsd:sequence>
+      <xsd:choice minOccurs="1" maxOccurs="1">
+        <xsd:element name="strRef" type="CT_StrRef" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="v" type="s:ST_Xstring" minOccurs="1" maxOccurs="1"/>
+      </xsd:choice>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_LayoutTarget">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="inner"/>
+      <xsd:enumeration value="outer"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_LayoutTarget">
+    <xsd:attribute name="val" type="ST_LayoutTarget" default="outer"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_LayoutMode">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="edge"/>
+      <xsd:enumeration value="factor"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_LayoutMode">
+    <xsd:attribute name="val" type="ST_LayoutMode" default="factor"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ManualLayout">
+    <xsd:sequence>
+      <xsd:element name="layoutTarget" type="CT_LayoutTarget" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="xMode" type="CT_LayoutMode" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="yMode" type="CT_LayoutMode" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="wMode" type="CT_LayoutMode" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="hMode" type="CT_LayoutMode" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="x" type="CT_Double" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="y" type="CT_Double" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="w" type="CT_Double" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="h" type="CT_Double" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Layout">
+    <xsd:sequence>
+      <xsd:element name="manualLayout" type="CT_ManualLayout" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Title">
+    <xsd:sequence>
+      <xsd:element name="tx" type="CT_Tx" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="layout" type="CT_Layout" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="overlay" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="spPr" type="a:CT_ShapeProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="txPr" type="a:CT_TextBody" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_RotX">
+    <xsd:restriction base="xsd:byte">
+      <xsd:minInclusive value="-90"/>
+      <xsd:maxInclusive value="90"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_RotX">
+    <xsd:attribute name="val" type="ST_RotX" default="0"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_HPercent">
+    <xsd:union memberTypes="ST_HPercentWithSymbol ST_HPercentUShort"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_HPercentWithSymbol">
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="0*(([5-9])|([1-9][0-9])|([1-4][0-9][0-9])|500)%"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_HPercentUShort">
+    <xsd:restriction base="xsd:unsignedShort">
+      <xsd:minInclusive value="5"/>
+      <xsd:maxInclusive value="500"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_HPercent">
+    <xsd:attribute name="val" type="ST_HPercent" default="100%"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_RotY">
+    <xsd:restriction base="xsd:unsignedShort">
+      <xsd:minInclusive value="0"/>
+      <xsd:maxInclusive value="360"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_RotY">
+    <xsd:attribute name="val" type="ST_RotY" default="0"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_DepthPercent">
+    <xsd:union memberTypes="ST_DepthPercentWithSymbol ST_DepthPercentUShort"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_DepthPercentWithSymbol">
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="0*(([2-9][0-9])|([1-9][0-9][0-9])|(1[0-9][0-9][0-9])|2000)%"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_DepthPercentUShort">
+    <xsd:restriction base="xsd:unsignedShort">
+      <xsd:minInclusive value="20"/>
+      <xsd:maxInclusive value="2000"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_DepthPercent">
+    <xsd:attribute name="val" type="ST_DepthPercent" default="100%"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_Perspective">
+    <xsd:restriction base="xsd:unsignedByte">
+      <xsd:minInclusive value="0"/>
+      <xsd:maxInclusive value="240"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Perspective">
+    <xsd:attribute name="val" type="ST_Perspective" default="30"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_View3D">
+    <xsd:sequence>
+      <xsd:element name="rotX" type="CT_RotX" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="hPercent" type="CT_HPercent" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="rotY" type="CT_RotY" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="depthPercent" type="CT_DepthPercent" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="rAngAx" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="perspective" type="CT_Perspective" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Surface">
+    <xsd:sequence>
+      <xsd:element name="thickness" type="CT_Thickness" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="spPr" type="a:CT_ShapeProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="pictureOptions" type="CT_PictureOptions" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_Thickness">
+    <xsd:union memberTypes="ST_ThicknessPercent xsd:unsignedInt"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_ThicknessPercent">
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="([0-9]+)%"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Thickness">
+    <xsd:attribute name="val" type="ST_Thickness" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DTable">
+    <xsd:sequence>
+      <xsd:element name="showHorzBorder" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="showVertBorder" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="showOutline" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="showKeys" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="spPr" type="a:CT_ShapeProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="txPr" type="a:CT_TextBody" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_GapAmount">
+    <xsd:union memberTypes="ST_GapAmountPercent ST_GapAmountUShort"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_GapAmountPercent">
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="0*(([0-9])|([1-9][0-9])|([1-4][0-9][0-9])|500)%"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_GapAmountUShort">
+    <xsd:restriction base="xsd:unsignedShort">
+      <xsd:minInclusive value="0"/>
+      <xsd:maxInclusive value="500"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_GapAmount">
+    <xsd:attribute name="val" type="ST_GapAmount" default="150%"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_Overlap">
+    <xsd:union memberTypes="ST_OverlapPercent ST_OverlapByte"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_OverlapPercent">
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="(-?0*(([0-9])|([1-9][0-9])|100))%"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_OverlapByte">
+    <xsd:restriction base="xsd:byte">
+      <xsd:minInclusive value="-100"/>
+      <xsd:maxInclusive value="100"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Overlap">
+    <xsd:attribute name="val" type="ST_Overlap" default="0%"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_BubbleScale">
+    <xsd:union memberTypes="ST_BubbleScalePercent ST_BubbleScaleUInt"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_BubbleScalePercent">
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="0*(([0-9])|([1-9][0-9])|([1-2][0-9][0-9])|300)%"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_BubbleScaleUInt">
+    <xsd:restriction base="xsd:unsignedInt">
+      <xsd:minInclusive value="0"/>
+      <xsd:maxInclusive value="300"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_BubbleScale">
+    <xsd:attribute name="val" type="ST_BubbleScale" default="100%"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_SizeRepresents">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="area"/>
+      <xsd:enumeration value="w"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_SizeRepresents">
+    <xsd:attribute name="val" type="ST_SizeRepresents" default="area"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_FirstSliceAng">
+    <xsd:restriction base="xsd:unsignedShort">
+      <xsd:minInclusive value="0"/>
+      <xsd:maxInclusive value="360"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_FirstSliceAng">
+    <xsd:attribute name="val" type="ST_FirstSliceAng" default="0"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_HoleSize">
+    <xsd:union memberTypes="ST_HoleSizePercent ST_HoleSizeUByte"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_HoleSizePercent">
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="0*([1-9]|([1-8][0-9])|90)%"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_HoleSizeUByte">
+    <xsd:restriction base="xsd:unsignedByte">
+      <xsd:minInclusive value="1"/>
+      <xsd:maxInclusive value="90"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_HoleSize">
+    <xsd:attribute name="val" type="ST_HoleSize" default="10%"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_SplitType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="auto"/>
+      <xsd:enumeration value="cust"/>
+      <xsd:enumeration value="percent"/>
+      <xsd:enumeration value="pos"/>
+      <xsd:enumeration value="val"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_SplitType">
+    <xsd:attribute name="val" type="ST_SplitType" default="auto"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CustSplit">
+    <xsd:sequence>
+      <xsd:element name="secondPiePt" type="CT_UnsignedInt" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_SecondPieSize">
+    <xsd:union memberTypes="ST_SecondPieSizePercent ST_SecondPieSizeUShort"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_SecondPieSizePercent">
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="0*(([5-9])|([1-9][0-9])|(1[0-9][0-9])|200)%"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_SecondPieSizeUShort">
+    <xsd:restriction base="xsd:unsignedShort">
+      <xsd:minInclusive value="5"/>
+      <xsd:maxInclusive value="200"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_SecondPieSize">
+    <xsd:attribute name="val" type="ST_SecondPieSize" default="75%"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_NumFmt">
+    <xsd:attribute name="formatCode" type="s:ST_Xstring" use="required"/>
+    <xsd:attribute name="sourceLinked" type="xsd:boolean"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_LblAlgn">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="ctr"/>
+      <xsd:enumeration value="l"/>
+      <xsd:enumeration value="r"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_LblAlgn">
+    <xsd:attribute name="val" type="ST_LblAlgn" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_DLblPos">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="bestFit"/>
+      <xsd:enumeration value="b"/>
+      <xsd:enumeration value="ctr"/>
+      <xsd:enumeration value="inBase"/>
+      <xsd:enumeration value="inEnd"/>
+      <xsd:enumeration value="l"/>
+      <xsd:enumeration value="outEnd"/>
+      <xsd:enumeration value="r"/>
+      <xsd:enumeration value="t"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_DLblPos">
+    <xsd:attribute name="val" type="ST_DLblPos" use="required"/>
+  </xsd:complexType>
+  <xsd:group name="EG_DLblShared">
+    <xsd:sequence>
+      <xsd:element name="numFmt" type="CT_NumFmt" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="spPr" type="a:CT_ShapeProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="txPr" type="a:CT_TextBody" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="dLblPos" type="CT_DLblPos" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="showLegendKey" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="showVal" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="showCatName" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="showSerName" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="showPercent" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="showBubbleSize" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="separator" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:group>
+  <xsd:group name="Group_DLbl">
+    <xsd:sequence>
+      <xsd:element name="layout" type="CT_Layout" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tx" type="CT_Tx" minOccurs="0" maxOccurs="1"/>
+      <xsd:group ref="EG_DLblShared" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:group>
+  <xsd:complexType name="CT_DLbl">
+    <xsd:sequence>
+      <xsd:element name="idx" type="CT_UnsignedInt" minOccurs="1" maxOccurs="1"/>
+      <xsd:choice>
+        <xsd:element name="delete" type="CT_Boolean" minOccurs="1" maxOccurs="1"/>
+        <xsd:group ref="Group_DLbl" minOccurs="1" maxOccurs="1"/>
+      </xsd:choice>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:group name="Group_DLbls">
+    <xsd:sequence>
+      <xsd:group ref="EG_DLblShared" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="showLeaderLines" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="leaderLines" type="CT_ChartLines" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:group>
+  <xsd:complexType name="CT_DLbls">
+    <xsd:sequence>
+      <xsd:element name="dLbl" type="CT_DLbl" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:choice>
+        <xsd:element name="delete" type="CT_Boolean" minOccurs="1" maxOccurs="1"/>
+        <xsd:group ref="Group_DLbls" minOccurs="1" maxOccurs="1"/>
+      </xsd:choice>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_MarkerStyle">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="circle"/>
+      <xsd:enumeration value="dash"/>
+      <xsd:enumeration value="diamond"/>
+      <xsd:enumeration value="dot"/>
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="picture"/>
+      <xsd:enumeration value="plus"/>
+      <xsd:enumeration value="square"/>
+      <xsd:enumeration value="star"/>
+      <xsd:enumeration value="triangle"/>
+      <xsd:enumeration value="x"/>
+      <xsd:enumeration value="auto"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_MarkerStyle">
+    <xsd:attribute name="val" type="ST_MarkerStyle" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_MarkerSize">
+    <xsd:restriction base="xsd:unsignedByte">
+      <xsd:minInclusive value="2"/>
+      <xsd:maxInclusive value="72"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_MarkerSize">
+    <xsd:attribute name="val" type="ST_MarkerSize" default="5"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Marker">
+    <xsd:sequence>
+      <xsd:element name="symbol" type="CT_MarkerStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="size" type="CT_MarkerSize" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="spPr" type="a:CT_ShapeProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DPt">
+    <xsd:sequence>
+      <xsd:element name="idx" type="CT_UnsignedInt" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="invertIfNegative" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="marker" type="CT_Marker" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="bubble3D" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="explosion" type="CT_UnsignedInt" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="spPr" type="a:CT_ShapeProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="pictureOptions" type="CT_PictureOptions" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TrendlineType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="exp"/>
+      <xsd:enumeration value="linear"/>
+      <xsd:enumeration value="log"/>
+      <xsd:enumeration value="movingAvg"/>
+      <xsd:enumeration value="poly"/>
+      <xsd:enumeration value="power"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TrendlineType">
+    <xsd:attribute name="val" type="ST_TrendlineType" default="linear"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_Order">
+    <xsd:restriction base="xsd:unsignedByte">
+      <xsd:minInclusive value="2"/>
+      <xsd:maxInclusive value="6"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Order">
+    <xsd:attribute name="val" type="ST_Order" default="2"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_Period">
+    <xsd:restriction base="xsd:unsignedInt">
+      <xsd:minInclusive value="2"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Period">
+    <xsd:attribute name="val" type="ST_Period" default="2"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TrendlineLbl">
+    <xsd:sequence>
+      <xsd:element name="layout" type="CT_Layout" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tx" type="CT_Tx" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="numFmt" type="CT_NumFmt" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="spPr" type="a:CT_ShapeProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="txPr" type="a:CT_TextBody" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Trendline">
+    <xsd:sequence>
+      <xsd:element name="name" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="spPr" type="a:CT_ShapeProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="trendlineType" type="CT_TrendlineType" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="order" type="CT_Order" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="period" type="CT_Period" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="forward" type="CT_Double" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="backward" type="CT_Double" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="intercept" type="CT_Double" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="dispRSqr" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="dispEq" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="trendlineLbl" type="CT_TrendlineLbl" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_ErrDir">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="x"/>
+      <xsd:enumeration value="y"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_ErrDir">
+    <xsd:attribute name="val" type="ST_ErrDir" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_ErrBarType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="both"/>
+      <xsd:enumeration value="minus"/>
+      <xsd:enumeration value="plus"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_ErrBarType">
+    <xsd:attribute name="val" type="ST_ErrBarType" default="both"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_ErrValType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="cust"/>
+      <xsd:enumeration value="fixedVal"/>
+      <xsd:enumeration value="percentage"/>
+      <xsd:enumeration value="stdDev"/>
+      <xsd:enumeration value="stdErr"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_ErrValType">
+    <xsd:attribute name="val" type="ST_ErrValType" default="fixedVal"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ErrBars">
+    <xsd:sequence>
+      <xsd:element name="errDir" type="CT_ErrDir" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="errBarType" type="CT_ErrBarType" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="errValType" type="CT_ErrValType" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="noEndCap" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="plus" type="CT_NumDataSource" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="minus" type="CT_NumDataSource" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="val" type="CT_Double" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="spPr" type="a:CT_ShapeProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_UpDownBar">
+    <xsd:sequence>
+      <xsd:element name="spPr" type="a:CT_ShapeProperties" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_UpDownBars">
+    <xsd:sequence>
+      <xsd:element name="gapWidth" type="CT_GapAmount" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="upBars" type="CT_UpDownBar" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="downBars" type="CT_UpDownBar" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:group name="EG_SerShared">
+    <xsd:sequence>
+      <xsd:element name="idx" type="CT_UnsignedInt" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="order" type="CT_UnsignedInt" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="tx" type="CT_SerTx" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="spPr" type="a:CT_ShapeProperties" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:group>
+  <xsd:complexType name="CT_LineSer">
+    <xsd:sequence>
+      <xsd:group ref="EG_SerShared" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="marker" type="CT_Marker" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="dPt" type="CT_DPt" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="dLbls" type="CT_DLbls" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="trendline" type="CT_Trendline" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="errBars" type="CT_ErrBars" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="cat" type="CT_AxDataSource" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="val" type="CT_NumDataSource" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="smooth" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ScatterSer">
+    <xsd:sequence>
+      <xsd:group ref="EG_SerShared" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="marker" type="CT_Marker" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="dPt" type="CT_DPt" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="dLbls" type="CT_DLbls" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="trendline" type="CT_Trendline" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="errBars" type="CT_ErrBars" minOccurs="0" maxOccurs="2"/>
+      <xsd:element name="xVal" type="CT_AxDataSource" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="yVal" type="CT_NumDataSource" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="smooth" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_RadarSer">
+    <xsd:sequence>
+      <xsd:group ref="EG_SerShared" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="marker" type="CT_Marker" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="dPt" type="CT_DPt" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="dLbls" type="CT_DLbls" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="cat" type="CT_AxDataSource" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="val" type="CT_NumDataSource" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_BarSer">
+    <xsd:sequence>
+      <xsd:group ref="EG_SerShared" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="invertIfNegative" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="pictureOptions" type="CT_PictureOptions" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="dPt" type="CT_DPt" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="dLbls" type="CT_DLbls" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="trendline" type="CT_Trendline" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="errBars" type="CT_ErrBars" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="cat" type="CT_AxDataSource" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="val" type="CT_NumDataSource" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="shape" type="CT_Shape" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_AreaSer">
+    <xsd:sequence>
+      <xsd:group ref="EG_SerShared" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="pictureOptions" type="CT_PictureOptions" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="dPt" type="CT_DPt" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="dLbls" type="CT_DLbls" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="trendline" type="CT_Trendline" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="errBars" type="CT_ErrBars" minOccurs="0" maxOccurs="2"/>
+      <xsd:element name="cat" type="CT_AxDataSource" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="val" type="CT_NumDataSource" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PieSer">
+    <xsd:sequence>
+      <xsd:group ref="EG_SerShared" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="explosion" type="CT_UnsignedInt" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="dPt" type="CT_DPt" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="dLbls" type="CT_DLbls" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="cat" type="CT_AxDataSource" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="val" type="CT_NumDataSource" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_BubbleSer">
+    <xsd:sequence>
+      <xsd:group ref="EG_SerShared" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="invertIfNegative" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="dPt" type="CT_DPt" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="dLbls" type="CT_DLbls" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="trendline" type="CT_Trendline" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="errBars" type="CT_ErrBars" minOccurs="0" maxOccurs="2"/>
+      <xsd:element name="xVal" type="CT_AxDataSource" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="yVal" type="CT_NumDataSource" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="bubbleSize" type="CT_NumDataSource" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="bubble3D" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SurfaceSer">
+    <xsd:sequence>
+      <xsd:group ref="EG_SerShared" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="cat" type="CT_AxDataSource" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="val" type="CT_NumDataSource" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_Grouping">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="percentStacked"/>
+      <xsd:enumeration value="standard"/>
+      <xsd:enumeration value="stacked"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Grouping">
+    <xsd:attribute name="val" type="ST_Grouping" default="standard"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ChartLines">
+    <xsd:sequence>
+      <xsd:element name="spPr" type="a:CT_ShapeProperties" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:group name="EG_LineChartShared">
+    <xsd:sequence>
+      <xsd:element name="grouping" type="CT_Grouping" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="varyColors" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="ser" type="CT_LineSer" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="dLbls" type="CT_DLbls" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="dropLines" type="CT_ChartLines" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:group>
+  <xsd:complexType name="CT_LineChart">
+    <xsd:sequence>
+      <xsd:group ref="EG_LineChartShared" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="hiLowLines" type="CT_ChartLines" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="upDownBars" type="CT_UpDownBars" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="marker" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="smooth" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="axId" type="CT_UnsignedInt" minOccurs="2" maxOccurs="2"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Line3DChart">
+    <xsd:sequence>
+      <xsd:group ref="EG_LineChartShared" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="gapDepth" type="CT_GapAmount" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="axId" type="CT_UnsignedInt" minOccurs="3" maxOccurs="3"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_StockChart">
+    <xsd:sequence>
+      <xsd:element name="ser" type="CT_LineSer" minOccurs="3" maxOccurs="4"/>
+      <xsd:element name="dLbls" type="CT_DLbls" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="dropLines" type="CT_ChartLines" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="hiLowLines" type="CT_ChartLines" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="upDownBars" type="CT_UpDownBars" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="axId" type="CT_UnsignedInt" minOccurs="2" maxOccurs="2"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_ScatterStyle">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="line"/>
+      <xsd:enumeration value="lineMarker"/>
+      <xsd:enumeration value="marker"/>
+      <xsd:enumeration value="smooth"/>
+      <xsd:enumeration value="smoothMarker"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_ScatterStyle">
+    <xsd:attribute name="val" type="ST_ScatterStyle" default="marker"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ScatterChart">
+    <xsd:sequence>
+      <xsd:element name="scatterStyle" type="CT_ScatterStyle" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="varyColors" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="ser" type="CT_ScatterSer" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="dLbls" type="CT_DLbls" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="axId" type="CT_UnsignedInt" minOccurs="2" maxOccurs="2"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_RadarStyle">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="standard"/>
+      <xsd:enumeration value="marker"/>
+      <xsd:enumeration value="filled"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_RadarStyle">
+    <xsd:attribute name="val" type="ST_RadarStyle" default="standard"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_RadarChart">
+    <xsd:sequence>
+      <xsd:element name="radarStyle" type="CT_RadarStyle" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="varyColors" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="ser" type="CT_RadarSer" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="dLbls" type="CT_DLbls" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="axId" type="CT_UnsignedInt" minOccurs="2" maxOccurs="2"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_BarGrouping">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="percentStacked"/>
+      <xsd:enumeration value="clustered"/>
+      <xsd:enumeration value="standard"/>
+      <xsd:enumeration value="stacked"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_BarGrouping">
+    <xsd:attribute name="val" type="ST_BarGrouping" default="clustered"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_BarDir">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="bar"/>
+      <xsd:enumeration value="col"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_BarDir">
+    <xsd:attribute name="val" type="ST_BarDir" default="col"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_Shape">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="cone"/>
+      <xsd:enumeration value="coneToMax"/>
+      <xsd:enumeration value="box"/>
+      <xsd:enumeration value="cylinder"/>
+      <xsd:enumeration value="pyramid"/>
+      <xsd:enumeration value="pyramidToMax"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Shape">
+    <xsd:attribute name="val" type="ST_Shape" default="box"/>
+  </xsd:complexType>
+  <xsd:group name="EG_BarChartShared">
+    <xsd:sequence>
+      <xsd:element name="barDir" type="CT_BarDir" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="grouping" type="CT_BarGrouping" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="varyColors" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="ser" type="CT_BarSer" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="dLbls" type="CT_DLbls" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:group>
+  <xsd:complexType name="CT_BarChart">
+    <xsd:sequence>
+      <xsd:group ref="EG_BarChartShared" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="gapWidth" type="CT_GapAmount" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="overlap" type="CT_Overlap" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="serLines" type="CT_ChartLines" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="axId" type="CT_UnsignedInt" minOccurs="2" maxOccurs="2"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Bar3DChart">
+    <xsd:sequence>
+      <xsd:group ref="EG_BarChartShared" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="gapWidth" type="CT_GapAmount" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="gapDepth" type="CT_GapAmount" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="shape" type="CT_Shape" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="axId" type="CT_UnsignedInt" minOccurs="2" maxOccurs="3"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:group name="EG_AreaChartShared">
+    <xsd:sequence>
+      <xsd:element name="grouping" type="CT_Grouping" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="varyColors" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="ser" type="CT_AreaSer" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="dLbls" type="CT_DLbls" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="dropLines" type="CT_ChartLines" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:group>
+  <xsd:complexType name="CT_AreaChart">
+    <xsd:sequence>
+      <xsd:group ref="EG_AreaChartShared" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="axId" type="CT_UnsignedInt" minOccurs="2" maxOccurs="2"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Area3DChart">
+    <xsd:sequence>
+      <xsd:group ref="EG_AreaChartShared" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="gapDepth" type="CT_GapAmount" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="axId" type="CT_UnsignedInt" minOccurs="2" maxOccurs="3"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:group name="EG_PieChartShared">
+    <xsd:sequence>
+      <xsd:element name="varyColors" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="ser" type="CT_PieSer" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="dLbls" type="CT_DLbls" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:group>
+  <xsd:complexType name="CT_PieChart">
+    <xsd:sequence>
+      <xsd:group ref="EG_PieChartShared" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="firstSliceAng" type="CT_FirstSliceAng" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Pie3DChart">
+    <xsd:sequence>
+      <xsd:group ref="EG_PieChartShared" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DoughnutChart">
+    <xsd:sequence>
+      <xsd:group ref="EG_PieChartShared" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="firstSliceAng" type="CT_FirstSliceAng" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="holeSize" type="CT_HoleSize" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_OfPieType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="pie"/>
+      <xsd:enumeration value="bar"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_OfPieType">
+    <xsd:attribute name="val" type="ST_OfPieType" default="pie"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_OfPieChart">
+    <xsd:sequence>
+      <xsd:element name="ofPieType" type="CT_OfPieType" minOccurs="1" maxOccurs="1"/>
+      <xsd:group ref="EG_PieChartShared" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="gapWidth" type="CT_GapAmount" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="splitType" type="CT_SplitType" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="splitPos" type="CT_Double" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="custSplit" type="CT_CustSplit" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="secondPieSize" type="CT_SecondPieSize" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="serLines" type="CT_ChartLines" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_BubbleChart">
+    <xsd:sequence>
+      <xsd:element name="varyColors" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="ser" type="CT_BubbleSer" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="dLbls" type="CT_DLbls" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="bubble3D" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="bubbleScale" type="CT_BubbleScale" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="showNegBubbles" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="sizeRepresents" type="CT_SizeRepresents" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="axId" type="CT_UnsignedInt" minOccurs="2" maxOccurs="2"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_BandFmt">
+    <xsd:sequence>
+      <xsd:element name="idx" type="CT_UnsignedInt" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="spPr" type="a:CT_ShapeProperties" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_BandFmts">
+    <xsd:sequence>
+      <xsd:element name="bandFmt" type="CT_BandFmt" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:group name="EG_SurfaceChartShared">
+    <xsd:sequence>
+      <xsd:element name="wireframe" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="ser" type="CT_SurfaceSer" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="bandFmts" type="CT_BandFmts" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:group>
+  <xsd:complexType name="CT_SurfaceChart">
+    <xsd:sequence>
+      <xsd:group ref="EG_SurfaceChartShared" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="axId" type="CT_UnsignedInt" minOccurs="2" maxOccurs="3"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Surface3DChart">
+    <xsd:sequence>
+      <xsd:group ref="EG_SurfaceChartShared" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="axId" type="CT_UnsignedInt" minOccurs="3" maxOccurs="3"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_AxPos">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="b"/>
+      <xsd:enumeration value="l"/>
+      <xsd:enumeration value="r"/>
+      <xsd:enumeration value="t"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_AxPos">
+    <xsd:attribute name="val" type="ST_AxPos" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_Crosses">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="autoZero"/>
+      <xsd:enumeration value="max"/>
+      <xsd:enumeration value="min"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Crosses">
+    <xsd:attribute name="val" type="ST_Crosses" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_CrossBetween">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="between"/>
+      <xsd:enumeration value="midCat"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_CrossBetween">
+    <xsd:attribute name="val" type="ST_CrossBetween" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TickMark">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="cross"/>
+      <xsd:enumeration value="in"/>
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="out"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TickMark">
+    <xsd:attribute name="val" type="ST_TickMark" default="cross"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TickLblPos">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="high"/>
+      <xsd:enumeration value="low"/>
+      <xsd:enumeration value="nextTo"/>
+      <xsd:enumeration value="none"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TickLblPos">
+    <xsd:attribute name="val" type="ST_TickLblPos" default="nextTo"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_Skip">
+    <xsd:restriction base="xsd:unsignedInt">
+      <xsd:minInclusive value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Skip">
+    <xsd:attribute name="val" type="ST_Skip" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TimeUnit">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="days"/>
+      <xsd:enumeration value="months"/>
+      <xsd:enumeration value="years"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TimeUnit">
+    <xsd:attribute name="val" type="ST_TimeUnit" default="days"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_AxisUnit">
+    <xsd:restriction base="xsd:double">
+      <xsd:minExclusive value="0"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_AxisUnit">
+    <xsd:attribute name="val" type="ST_AxisUnit" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_BuiltInUnit">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="hundreds"/>
+      <xsd:enumeration value="thousands"/>
+      <xsd:enumeration value="tenThousands"/>
+      <xsd:enumeration value="hundredThousands"/>
+      <xsd:enumeration value="millions"/>
+      <xsd:enumeration value="tenMillions"/>
+      <xsd:enumeration value="hundredMillions"/>
+      <xsd:enumeration value="billions"/>
+      <xsd:enumeration value="trillions"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_BuiltInUnit">
+    <xsd:attribute name="val" type="ST_BuiltInUnit" default="thousands"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_PictureFormat">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="stretch"/>
+      <xsd:enumeration value="stack"/>
+      <xsd:enumeration value="stackScale"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_PictureFormat">
+    <xsd:attribute name="val" type="ST_PictureFormat" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_PictureStackUnit">
+    <xsd:restriction base="xsd:double">
+      <xsd:minExclusive value="0"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_PictureStackUnit">
+    <xsd:attribute name="val" type="ST_PictureStackUnit" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PictureOptions">
+    <xsd:sequence>
+      <xsd:element name="applyToFront" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="applyToSides" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="applyToEnd" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="pictureFormat" type="CT_PictureFormat" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="pictureStackUnit" type="CT_PictureStackUnit" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DispUnitsLbl">
+    <xsd:sequence>
+      <xsd:element name="layout" type="CT_Layout" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tx" type="CT_Tx" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="spPr" type="a:CT_ShapeProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="txPr" type="a:CT_TextBody" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DispUnits">
+    <xsd:sequence>
+      <xsd:choice>
+        <xsd:element name="custUnit" type="CT_Double" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="builtInUnit" type="CT_BuiltInUnit" minOccurs="1" maxOccurs="1"/>
+      </xsd:choice>
+      <xsd:element name="dispUnitsLbl" type="CT_DispUnitsLbl" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_Orientation">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="maxMin"/>
+      <xsd:enumeration value="minMax"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Orientation">
+    <xsd:attribute name="val" type="ST_Orientation" default="minMax"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_LogBase">
+    <xsd:restriction base="xsd:double">
+      <xsd:minInclusive value="2"/>
+      <xsd:maxInclusive value="1000"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_LogBase">
+    <xsd:attribute name="val" type="ST_LogBase" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Scaling">
+    <xsd:sequence>
+      <xsd:element name="logBase" type="CT_LogBase" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="orientation" type="CT_Orientation" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="max" type="CT_Double" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="min" type="CT_Double" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_LblOffset">
+    <xsd:union memberTypes="ST_LblOffsetPercent ST_LblOffsetUShort"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_LblOffsetPercent">
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="0*(([0-9])|([1-9][0-9])|([1-9][0-9][0-9])|1000)%"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_LblOffsetUShort">
+    <xsd:restriction base="xsd:unsignedShort">
+      <xsd:minInclusive value="0"/>
+      <xsd:maxInclusive value="1000"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_LblOffset">
+    <xsd:attribute name="val" type="ST_LblOffset" default="100%"/>
+  </xsd:complexType>
+  <xsd:group name="EG_AxShared">
+    <xsd:sequence>
+      <xsd:element name="axId" type="CT_UnsignedInt" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="scaling" type="CT_Scaling" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="delete" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="axPos" type="CT_AxPos" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="majorGridlines" type="CT_ChartLines" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="minorGridlines" type="CT_ChartLines" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="title" type="CT_Title" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="numFmt" type="CT_NumFmt" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="majorTickMark" type="CT_TickMark" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="minorTickMark" type="CT_TickMark" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tickLblPos" type="CT_TickLblPos" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="spPr" type="a:CT_ShapeProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="txPr" type="a:CT_TextBody" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="crossAx" type="CT_UnsignedInt" minOccurs="1" maxOccurs="1"/>
+      <xsd:choice minOccurs="0" maxOccurs="1">
+        <xsd:element name="crosses" type="CT_Crosses" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="crossesAt" type="CT_Double" minOccurs="1" maxOccurs="1"/>
+      </xsd:choice>
+    </xsd:sequence>
+  </xsd:group>
+  <xsd:complexType name="CT_CatAx">
+    <xsd:sequence>
+      <xsd:group ref="EG_AxShared" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="auto" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="lblAlgn" type="CT_LblAlgn" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="lblOffset" type="CT_LblOffset" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tickLblSkip" type="CT_Skip" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tickMarkSkip" type="CT_Skip" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="noMultiLvlLbl" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DateAx">
+    <xsd:sequence>
+      <xsd:group ref="EG_AxShared" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="auto" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="lblOffset" type="CT_LblOffset" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="baseTimeUnit" type="CT_TimeUnit" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="majorUnit" type="CT_AxisUnit" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="majorTimeUnit" type="CT_TimeUnit" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="minorUnit" type="CT_AxisUnit" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="minorTimeUnit" type="CT_TimeUnit" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SerAx">
+    <xsd:sequence>
+      <xsd:group ref="EG_AxShared" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="tickLblSkip" type="CT_Skip" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tickMarkSkip" type="CT_Skip" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ValAx">
+    <xsd:sequence>
+      <xsd:group ref="EG_AxShared" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="crossBetween" type="CT_CrossBetween" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="majorUnit" type="CT_AxisUnit" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="minorUnit" type="CT_AxisUnit" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="dispUnits" type="CT_DispUnits" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PlotArea">
+    <xsd:sequence>
+      <xsd:element name="layout" type="CT_Layout" minOccurs="0" maxOccurs="1"/>
+      <xsd:choice minOccurs="1" maxOccurs="unbounded">
+        <xsd:element name="areaChart" type="CT_AreaChart" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="area3DChart" type="CT_Area3DChart" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="lineChart" type="CT_LineChart" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="line3DChart" type="CT_Line3DChart" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="stockChart" type="CT_StockChart" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="radarChart" type="CT_RadarChart" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="scatterChart" type="CT_ScatterChart" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="pieChart" type="CT_PieChart" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="pie3DChart" type="CT_Pie3DChart" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="doughnutChart" type="CT_DoughnutChart" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="barChart" type="CT_BarChart" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="bar3DChart" type="CT_Bar3DChart" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="ofPieChart" type="CT_OfPieChart" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="surfaceChart" type="CT_SurfaceChart" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="surface3DChart" type="CT_Surface3DChart" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="bubbleChart" type="CT_BubbleChart" minOccurs="1" maxOccurs="1"/>
+      </xsd:choice>
+      <xsd:choice minOccurs="0" maxOccurs="unbounded">
+        <xsd:element name="valAx" type="CT_ValAx" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="catAx" type="CT_CatAx" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="dateAx" type="CT_DateAx" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="serAx" type="CT_SerAx" minOccurs="1" maxOccurs="1"/>
+      </xsd:choice>
+      <xsd:element name="dTable" type="CT_DTable" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="spPr" type="a:CT_ShapeProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PivotFmt">
+    <xsd:sequence>
+      <xsd:element name="idx" type="CT_UnsignedInt" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="spPr" type="a:CT_ShapeProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="txPr" type="a:CT_TextBody" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="marker" type="CT_Marker" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="dLbl" type="CT_DLbl" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PivotFmts">
+    <xsd:sequence>
+      <xsd:element name="pivotFmt" type="CT_PivotFmt" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_LegendPos">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="b"/>
+      <xsd:enumeration value="tr"/>
+      <xsd:enumeration value="l"/>
+      <xsd:enumeration value="r"/>
+      <xsd:enumeration value="t"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_LegendPos">
+    <xsd:attribute name="val" type="ST_LegendPos" default="r"/>
+  </xsd:complexType>
+  <xsd:group name="EG_LegendEntryData">
+    <xsd:sequence>
+      <xsd:element name="txPr" type="a:CT_TextBody" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:group>
+  <xsd:complexType name="CT_LegendEntry">
+    <xsd:sequence>
+      <xsd:element name="idx" type="CT_UnsignedInt" minOccurs="1" maxOccurs="1"/>
+      <xsd:choice>
+        <xsd:element name="delete" type="CT_Boolean" minOccurs="1" maxOccurs="1"/>
+        <xsd:group ref="EG_LegendEntryData" minOccurs="1" maxOccurs="1"/>
+      </xsd:choice>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Legend">
+    <xsd:sequence>
+      <xsd:element name="legendPos" type="CT_LegendPos" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="legendEntry" type="CT_LegendEntry" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="layout" type="CT_Layout" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="overlay" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="spPr" type="a:CT_ShapeProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="txPr" type="a:CT_TextBody" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_DispBlanksAs">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="span"/>
+      <xsd:enumeration value="gap"/>
+      <xsd:enumeration value="zero"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_DispBlanksAs">
+    <xsd:attribute name="val" type="ST_DispBlanksAs" default="zero"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Chart">
+    <xsd:sequence>
+      <xsd:element name="title" type="CT_Title" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="autoTitleDeleted" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="pivotFmts" type="CT_PivotFmts" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="view3D" type="CT_View3D" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="floor" type="CT_Surface" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="sideWall" type="CT_Surface" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="backWall" type="CT_Surface" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="plotArea" type="CT_PlotArea" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="legend" type="CT_Legend" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="plotVisOnly" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="dispBlanksAs" type="CT_DispBlanksAs" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="showDLblsOverMax" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_Style">
+    <xsd:restriction base="xsd:unsignedByte">
+      <xsd:minInclusive value="1"/>
+      <xsd:maxInclusive value="48"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Style">
+    <xsd:attribute name="val" type="ST_Style" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PivotSource">
+    <xsd:sequence>
+      <xsd:element name="name" type="s:ST_Xstring" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="fmtId" type="CT_UnsignedInt" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Protection">
+    <xsd:sequence>
+      <xsd:element name="chartObject" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="data" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="formatting" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="selection" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="userInterface" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_HeaderFooter">
+    <xsd:sequence>
+      <xsd:element name="oddHeader" type="s:ST_Xstring" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="oddFooter" type="s:ST_Xstring" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="evenHeader" type="s:ST_Xstring" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="evenFooter" type="s:ST_Xstring" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="firstHeader" type="s:ST_Xstring" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="firstFooter" type="s:ST_Xstring" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="alignWithMargins" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="differentOddEven" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="differentFirst" type="xsd:boolean" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PageMargins">
+    <xsd:attribute name="l" type="xsd:double" use="required"/>
+    <xsd:attribute name="r" type="xsd:double" use="required"/>
+    <xsd:attribute name="t" type="xsd:double" use="required"/>
+    <xsd:attribute name="b" type="xsd:double" use="required"/>
+    <xsd:attribute name="header" type="xsd:double" use="required"/>
+    <xsd:attribute name="footer" type="xsd:double" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_PageSetupOrientation">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="default"/>
+      <xsd:enumeration value="portrait"/>
+      <xsd:enumeration value="landscape"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_ExternalData">
+    <xsd:sequence>
+      <xsd:element name="autoUpdate" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute ref="r:id" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PageSetup">
+    <xsd:attribute name="paperSize" type="xsd:unsignedInt" use="optional" default="1"/>
+    <xsd:attribute name="paperHeight" type="s:ST_PositiveUniversalMeasure" use="optional"/>
+    <xsd:attribute name="paperWidth" type="s:ST_PositiveUniversalMeasure" use="optional"/>
+    <xsd:attribute name="firstPageNumber" type="xsd:unsignedInt" use="optional" default="1"/>
+    <xsd:attribute name="orientation" type="ST_PageSetupOrientation" use="optional"
+      default="default"/>
+    <xsd:attribute name="blackAndWhite" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="draft" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="useFirstPageNumber" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="horizontalDpi" type="xsd:int" use="optional" default="600"/>
+    <xsd:attribute name="verticalDpi" type="xsd:int" use="optional" default="600"/>
+    <xsd:attribute name="copies" type="xsd:unsignedInt" use="optional" default="1"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PrintSettings">
+    <xsd:sequence>
+      <xsd:element name="headerFooter" type="CT_HeaderFooter" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="pageMargins" type="CT_PageMargins" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="pageSetup" type="CT_PageSetup" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="legacyDrawingHF" type="CT_RelId" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ChartSpace">
+    <xsd:sequence>
+      <xsd:element name="date1904" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="lang" type="CT_TextLanguageID" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="roundedCorners" type="CT_Boolean" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="style" type="CT_Style" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="clrMapOvr" type="a:CT_ColorMapping" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="pivotSource" type="CT_PivotSource" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="protection" type="CT_Protection" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="chart" type="CT_Chart" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="spPr" type="a:CT_ShapeProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="txPr" type="a:CT_TextBody" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="externalData" type="CT_ExternalData" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="printSettings" type="CT_PrintSettings" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="userShapes" type="CT_RelId" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="chartSpace" type="CT_ChartSpace"/>
+  <xsd:element name="userShapes" type="cdr:CT_Drawing"/>
+  <xsd:element name="chart" type="CT_RelId"/>
+</xsd:schema>

--- a/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-chartDrawing.xsd
+++ b/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-chartDrawing.xsd
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+  xmlns="http://schemas.openxmlformats.org/drawingml/2006/chartDrawing"
+  targetNamespace="http://schemas.openxmlformats.org/drawingml/2006/chartDrawing"
+  elementFormDefault="qualified">
+  <xsd:import namespace="http://schemas.openxmlformats.org/drawingml/2006/main"
+    schemaLocation="dml-main.xsd"/>
+  <xsd:complexType name="CT_ShapeNonVisual">
+    <xsd:sequence>
+      <xsd:element name="cNvPr" type="a:CT_NonVisualDrawingProps" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="cNvSpPr" type="a:CT_NonVisualDrawingShapeProps" minOccurs="1" maxOccurs="1"
+      />
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Shape">
+    <xsd:sequence>
+      <xsd:element name="nvSpPr" type="CT_ShapeNonVisual" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="spPr" type="a:CT_ShapeProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="style" type="a:CT_ShapeStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="txBody" type="a:CT_TextBody" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="macro" type="xsd:string" use="optional"/>
+    <xsd:attribute name="textlink" type="xsd:string" use="optional"/>
+    <xsd:attribute name="fLocksText" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="fPublished" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ConnectorNonVisual">
+    <xsd:sequence>
+      <xsd:element name="cNvPr" type="a:CT_NonVisualDrawingProps" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="cNvCxnSpPr" type="a:CT_NonVisualConnectorProperties" minOccurs="1"
+        maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Connector">
+    <xsd:sequence>
+      <xsd:element name="nvCxnSpPr" type="CT_ConnectorNonVisual" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="spPr" type="a:CT_ShapeProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="style" type="a:CT_ShapeStyle" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="macro" type="xsd:string" use="optional"/>
+    <xsd:attribute name="fPublished" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PictureNonVisual">
+    <xsd:sequence>
+      <xsd:element name="cNvPr" type="a:CT_NonVisualDrawingProps" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="cNvPicPr" type="a:CT_NonVisualPictureProperties" minOccurs="1"
+        maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Picture">
+    <xsd:sequence>
+      <xsd:element name="nvPicPr" type="CT_PictureNonVisual" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="blipFill" type="a:CT_BlipFillProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="spPr" type="a:CT_ShapeProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="style" type="a:CT_ShapeStyle" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="macro" type="xsd:string" use="optional" default=""/>
+    <xsd:attribute name="fPublished" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GraphicFrameNonVisual">
+    <xsd:sequence>
+      <xsd:element name="cNvPr" type="a:CT_NonVisualDrawingProps" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="cNvGraphicFramePr" type="a:CT_NonVisualGraphicFrameProperties"
+        minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GraphicFrame">
+    <xsd:sequence>
+      <xsd:element name="nvGraphicFramePr" type="CT_GraphicFrameNonVisual" minOccurs="1"
+        maxOccurs="1"/>
+      <xsd:element name="xfrm" type="a:CT_Transform2D" minOccurs="1" maxOccurs="1"/>
+      <xsd:element ref="a:graphic" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="macro" type="xsd:string" use="optional"/>
+    <xsd:attribute name="fPublished" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GroupShapeNonVisual">
+    <xsd:sequence>
+      <xsd:element name="cNvPr" type="a:CT_NonVisualDrawingProps" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="cNvGrpSpPr" type="a:CT_NonVisualGroupDrawingShapeProps" minOccurs="1"
+        maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GroupShape">
+    <xsd:sequence>
+      <xsd:element name="nvGrpSpPr" type="CT_GroupShapeNonVisual" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="grpSpPr" type="a:CT_GroupShapeProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:choice minOccurs="0" maxOccurs="unbounded">
+        <xsd:element name="sp" type="CT_Shape"/>
+        <xsd:element name="grpSp" type="CT_GroupShape"/>
+        <xsd:element name="graphicFrame" type="CT_GraphicFrame"/>
+        <xsd:element name="cxnSp" type="CT_Connector"/>
+        <xsd:element name="pic" type="CT_Picture"/>
+      </xsd:choice>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:group name="EG_ObjectChoices">
+    <xsd:sequence>
+      <xsd:choice minOccurs="1" maxOccurs="1">
+        <xsd:element name="sp" type="CT_Shape"/>
+        <xsd:element name="grpSp" type="CT_GroupShape"/>
+        <xsd:element name="graphicFrame" type="CT_GraphicFrame"/>
+        <xsd:element name="cxnSp" type="CT_Connector"/>
+        <xsd:element name="pic" type="CT_Picture"/>
+      </xsd:choice>
+    </xsd:sequence>
+  </xsd:group>
+  <xsd:simpleType name="ST_MarkerCoordinate">
+    <xsd:restriction base="xsd:double">
+      <xsd:minInclusive value="0.0"/>
+      <xsd:maxInclusive value="1.0"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Marker">
+    <xsd:sequence>
+      <xsd:element name="x" type="ST_MarkerCoordinate" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="y" type="ST_MarkerCoordinate" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_RelSizeAnchor">
+    <xsd:sequence>
+      <xsd:element name="from" type="CT_Marker"/>
+      <xsd:element name="to" type="CT_Marker"/>
+      <xsd:group ref="EG_ObjectChoices"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_AbsSizeAnchor">
+    <xsd:sequence>
+      <xsd:element name="from" type="CT_Marker"/>
+      <xsd:element name="ext" type="a:CT_PositiveSize2D"/>
+      <xsd:group ref="EG_ObjectChoices"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:group name="EG_Anchor">
+    <xsd:choice>
+      <xsd:element name="relSizeAnchor" type="CT_RelSizeAnchor"/>
+      <xsd:element name="absSizeAnchor" type="CT_AbsSizeAnchor"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:complexType name="CT_Drawing">
+    <xsd:sequence>
+      <xsd:group ref="EG_Anchor" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+</xsd:schema>

--- a/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-diagram.xsd
+++ b/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-diagram.xsd
@@ -1,0 +1,1085 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://schemas.openxmlformats.org/drawingml/2006/diagram"
+  xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+  xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+  xmlns:s="http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"
+  targetNamespace="http://schemas.openxmlformats.org/drawingml/2006/diagram"
+  elementFormDefault="qualified" attributeFormDefault="unqualified">
+  <xsd:import namespace="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+    schemaLocation="shared-relationshipReference.xsd"/>
+  <xsd:import namespace="http://schemas.openxmlformats.org/drawingml/2006/main"
+    schemaLocation="dml-main.xsd"/>
+  <xsd:import namespace="http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"
+    schemaLocation="shared-commonSimpleTypes.xsd"/>
+  <xsd:complexType name="CT_CTName">
+    <xsd:attribute name="lang" type="xsd:string" use="optional" default=""/>
+    <xsd:attribute name="val" type="xsd:string" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CTDescription">
+    <xsd:attribute name="lang" type="xsd:string" use="optional" default=""/>
+    <xsd:attribute name="val" type="xsd:string" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CTCategory">
+    <xsd:attribute name="type" type="xsd:anyURI" use="required"/>
+    <xsd:attribute name="pri" type="xsd:unsignedInt" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CTCategories">
+    <xsd:sequence minOccurs="0" maxOccurs="unbounded">
+      <xsd:element name="cat" type="CT_CTCategory" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_ClrAppMethod">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="span"/>
+      <xsd:enumeration value="cycle"/>
+      <xsd:enumeration value="repeat"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_HueDir">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="cw"/>
+      <xsd:enumeration value="ccw"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Colors">
+    <xsd:sequence>
+      <xsd:group ref="a:EG_ColorChoice" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="meth" type="ST_ClrAppMethod" use="optional" default="span"/>
+    <xsd:attribute name="hueDir" type="ST_HueDir" use="optional" default="cw"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CTStyleLabel">
+    <xsd:sequence>
+      <xsd:element name="fillClrLst" type="CT_Colors" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="linClrLst" type="CT_Colors" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="effectClrLst" type="CT_Colors" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="txLinClrLst" type="CT_Colors" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="txFillClrLst" type="CT_Colors" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="txEffectClrLst" type="CT_Colors" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="a:CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ColorTransform">
+    <xsd:sequence>
+      <xsd:element name="title" type="CT_CTName" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="desc" type="CT_CTDescription" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="catLst" type="CT_CTCategories" minOccurs="0"/>
+      <xsd:element name="styleLbl" type="CT_CTStyleLabel" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="extLst" type="a:CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="uniqueId" type="xsd:string" use="optional" default=""/>
+    <xsd:attribute name="minVer" type="xsd:string" use="optional"/>
+  </xsd:complexType>
+  <xsd:element name="colorsDef" type="CT_ColorTransform"/>
+  <xsd:complexType name="CT_ColorTransformHeader">
+    <xsd:sequence>
+      <xsd:element name="title" type="CT_CTName" minOccurs="1" maxOccurs="unbounded"/>
+      <xsd:element name="desc" type="CT_CTDescription" minOccurs="1" maxOccurs="unbounded"/>
+      <xsd:element name="catLst" type="CT_CTCategories" minOccurs="0"/>
+      <xsd:element name="extLst" type="a:CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="uniqueId" type="xsd:string" use="required"/>
+    <xsd:attribute name="minVer" type="xsd:string" use="optional"/>
+    <xsd:attribute name="resId" type="xsd:int" use="optional" default="0"/>
+  </xsd:complexType>
+  <xsd:element name="colorsDefHdr" type="CT_ColorTransformHeader"/>
+  <xsd:complexType name="CT_ColorTransformHeaderLst">
+    <xsd:sequence>
+      <xsd:element name="colorsDefHdr" type="CT_ColorTransformHeader" minOccurs="0"
+        maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="colorsDefHdrLst" type="CT_ColorTransformHeaderLst"/>
+  <xsd:simpleType name="ST_PtType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="node"/>
+      <xsd:enumeration value="asst"/>
+      <xsd:enumeration value="doc"/>
+      <xsd:enumeration value="pres"/>
+      <xsd:enumeration value="parTrans"/>
+      <xsd:enumeration value="sibTrans"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Pt">
+    <xsd:sequence>
+      <xsd:element name="prSet" type="CT_ElemPropSet" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="spPr" type="a:CT_ShapeProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="t" type="a:CT_TextBody" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="a:CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="modelId" type="ST_ModelId" use="required"/>
+    <xsd:attribute name="type" type="ST_PtType" use="optional" default="node"/>
+    <xsd:attribute name="cxnId" type="ST_ModelId" use="optional" default="0"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PtList">
+    <xsd:sequence>
+      <xsd:element name="pt" type="CT_Pt" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_CxnType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="parOf"/>
+      <xsd:enumeration value="presOf"/>
+      <xsd:enumeration value="presParOf"/>
+      <xsd:enumeration value="unknownRelationship"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Cxn">
+    <xsd:sequence>
+      <xsd:element name="extLst" type="a:CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="modelId" type="ST_ModelId" use="required"/>
+    <xsd:attribute name="type" type="ST_CxnType" use="optional" default="parOf"/>
+    <xsd:attribute name="srcId" type="ST_ModelId" use="required"/>
+    <xsd:attribute name="destId" type="ST_ModelId" use="required"/>
+    <xsd:attribute name="srcOrd" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="destOrd" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="parTransId" type="ST_ModelId" use="optional" default="0"/>
+    <xsd:attribute name="sibTransId" type="ST_ModelId" use="optional" default="0"/>
+    <xsd:attribute name="presId" type="xsd:string" use="optional" default=""/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CxnList">
+    <xsd:sequence>
+      <xsd:element name="cxn" type="CT_Cxn" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DataModel">
+    <xsd:sequence>
+      <xsd:element name="ptLst" type="CT_PtList"/>
+      <xsd:element name="cxnLst" type="CT_CxnList" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="bg" type="a:CT_BackgroundFormatting" minOccurs="0"/>
+      <xsd:element name="whole" type="a:CT_WholeE2oFormatting" minOccurs="0"/>
+      <xsd:element name="extLst" type="a:CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="dataModel" type="CT_DataModel"/>
+  <xsd:attributeGroup name="AG_IteratorAttributes">
+    <xsd:attribute name="axis" type="ST_AxisTypes" use="optional" default="none"/>
+    <xsd:attribute name="ptType" type="ST_ElementTypes" use="optional" default="all"/>
+    <xsd:attribute name="hideLastTrans" type="ST_Booleans" use="optional" default="true"/>
+    <xsd:attribute name="st" type="ST_Ints" use="optional" default="1"/>
+    <xsd:attribute name="cnt" type="ST_UnsignedInts" use="optional" default="0"/>
+    <xsd:attribute name="step" type="ST_Ints" use="optional" default="1"/>
+  </xsd:attributeGroup>
+  <xsd:attributeGroup name="AG_ConstraintAttributes">
+    <xsd:attribute name="type" type="ST_ConstraintType" use="required"/>
+    <xsd:attribute name="for" type="ST_ConstraintRelationship" use="optional" default="self"/>
+    <xsd:attribute name="forName" type="xsd:string" use="optional" default=""/>
+    <xsd:attribute name="ptType" type="ST_ElementType" use="optional" default="all"/>
+  </xsd:attributeGroup>
+  <xsd:attributeGroup name="AG_ConstraintRefAttributes">
+    <xsd:attribute name="refType" type="ST_ConstraintType" use="optional" default="none"/>
+    <xsd:attribute name="refFor" type="ST_ConstraintRelationship" use="optional" default="self"/>
+    <xsd:attribute name="refForName" type="xsd:string" use="optional" default=""/>
+    <xsd:attribute name="refPtType" type="ST_ElementType" use="optional" default="all"/>
+  </xsd:attributeGroup>
+  <xsd:complexType name="CT_Constraint">
+    <xsd:sequence>
+      <xsd:element name="extLst" type="a:CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attributeGroup ref="AG_ConstraintAttributes"/>
+    <xsd:attributeGroup ref="AG_ConstraintRefAttributes"/>
+    <xsd:attribute name="op" type="ST_BoolOperator" use="optional" default="none"/>
+    <xsd:attribute name="val" type="xsd:double" use="optional" default="0"/>
+    <xsd:attribute name="fact" type="xsd:double" use="optional" default="1"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Constraints">
+    <xsd:sequence>
+      <xsd:element name="constr" type="CT_Constraint" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_NumericRule">
+    <xsd:sequence>
+      <xsd:element name="extLst" type="a:CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attributeGroup ref="AG_ConstraintAttributes"/>
+    <xsd:attribute name="val" type="xsd:double" use="optional" default="NaN"/>
+    <xsd:attribute name="fact" type="xsd:double" use="optional" default="NaN"/>
+    <xsd:attribute name="max" type="xsd:double" use="optional" default="NaN"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Rules">
+    <xsd:sequence>
+      <xsd:element name="rule" type="CT_NumericRule" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PresentationOf">
+    <xsd:sequence>
+      <xsd:element name="extLst" type="a:CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attributeGroup ref="AG_IteratorAttributes"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_LayoutShapeType" final="restriction">
+    <xsd:union memberTypes="a:ST_ShapeType ST_OutputShapeType"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_Index1">
+    <xsd:restriction base="xsd:unsignedInt">
+      <xsd:minInclusive value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Adj">
+    <xsd:attribute name="idx" type="ST_Index1" use="required"/>
+    <xsd:attribute name="val" type="xsd:double" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_AdjLst">
+    <xsd:sequence>
+      <xsd:element name="adj" type="CT_Adj" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Shape">
+    <xsd:sequence>
+      <xsd:element name="adjLst" type="CT_AdjLst" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="a:CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="rot" type="xsd:double" use="optional" default="0"/>
+    <xsd:attribute name="type" type="ST_LayoutShapeType" use="optional" default="none"/>
+    <xsd:attribute ref="r:blip" use="optional"/>
+    <xsd:attribute name="zOrderOff" type="xsd:int" use="optional" default="0"/>
+    <xsd:attribute name="hideGeom" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="lkTxEntry" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="blipPhldr" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Parameter">
+    <xsd:attribute name="type" type="ST_ParameterId" use="required"/>
+    <xsd:attribute name="val" type="ST_ParameterVal" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Algorithm">
+    <xsd:sequence>
+      <xsd:element name="param" type="CT_Parameter" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="extLst" type="a:CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="type" type="ST_AlgorithmType" use="required"/>
+    <xsd:attribute name="rev" type="xsd:unsignedInt" use="optional" default="0"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_LayoutNode">
+    <xsd:choice minOccurs="0" maxOccurs="unbounded">
+      <xsd:element name="alg" type="CT_Algorithm" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="shape" type="CT_Shape" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="presOf" type="CT_PresentationOf" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="constrLst" type="CT_Constraints" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="ruleLst" type="CT_Rules" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="varLst" type="CT_LayoutVariablePropertySet" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="forEach" type="CT_ForEach"/>
+      <xsd:element name="layoutNode" type="CT_LayoutNode"/>
+      <xsd:element name="choose" type="CT_Choose"/>
+      <xsd:element name="extLst" type="a:CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:choice>
+    <xsd:attribute name="name" type="xsd:string" use="optional" default=""/>
+    <xsd:attribute name="styleLbl" type="xsd:string" use="optional" default=""/>
+    <xsd:attribute name="chOrder" type="ST_ChildOrderType" use="optional" default="b"/>
+    <xsd:attribute name="moveWith" type="xsd:string" use="optional" default=""/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ForEach">
+    <xsd:choice minOccurs="0" maxOccurs="unbounded">
+      <xsd:element name="alg" type="CT_Algorithm" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="shape" type="CT_Shape" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="presOf" type="CT_PresentationOf" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="constrLst" type="CT_Constraints" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="ruleLst" type="CT_Rules" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="forEach" type="CT_ForEach"/>
+      <xsd:element name="layoutNode" type="CT_LayoutNode"/>
+      <xsd:element name="choose" type="CT_Choose"/>
+      <xsd:element name="extLst" type="a:CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:choice>
+    <xsd:attribute name="name" type="xsd:string" use="optional" default=""/>
+    <xsd:attribute name="ref" type="xsd:string" use="optional" default=""/>
+    <xsd:attributeGroup ref="AG_IteratorAttributes"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_When">
+    <xsd:choice minOccurs="0" maxOccurs="unbounded">
+      <xsd:element name="alg" type="CT_Algorithm" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="shape" type="CT_Shape" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="presOf" type="CT_PresentationOf" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="constrLst" type="CT_Constraints" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="ruleLst" type="CT_Rules" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="forEach" type="CT_ForEach"/>
+      <xsd:element name="layoutNode" type="CT_LayoutNode"/>
+      <xsd:element name="choose" type="CT_Choose"/>
+      <xsd:element name="extLst" type="a:CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:choice>
+    <xsd:attribute name="name" type="xsd:string" use="optional" default=""/>
+    <xsd:attributeGroup ref="AG_IteratorAttributes"/>
+    <xsd:attribute name="func" type="ST_FunctionType" use="required"/>
+    <xsd:attribute name="arg" type="ST_FunctionArgument" use="optional" default="none"/>
+    <xsd:attribute name="op" type="ST_FunctionOperator" use="required"/>
+    <xsd:attribute name="val" type="ST_FunctionValue" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Otherwise">
+    <xsd:choice minOccurs="0" maxOccurs="unbounded">
+      <xsd:element name="alg" type="CT_Algorithm" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="shape" type="CT_Shape" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="presOf" type="CT_PresentationOf" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="constrLst" type="CT_Constraints" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="ruleLst" type="CT_Rules" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="forEach" type="CT_ForEach"/>
+      <xsd:element name="layoutNode" type="CT_LayoutNode"/>
+      <xsd:element name="choose" type="CT_Choose"/>
+      <xsd:element name="extLst" type="a:CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:choice>
+    <xsd:attribute name="name" type="xsd:string" use="optional" default=""/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Choose">
+    <xsd:sequence>
+      <xsd:element name="if" type="CT_When" maxOccurs="unbounded"/>
+      <xsd:element name="else" type="CT_Otherwise" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="optional" default=""/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SampleData">
+    <xsd:sequence>
+      <xsd:element name="dataModel" type="CT_DataModel" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="useDef" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Category">
+    <xsd:attribute name="type" type="xsd:anyURI" use="required"/>
+    <xsd:attribute name="pri" type="xsd:unsignedInt" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Categories">
+    <xsd:sequence>
+      <xsd:element name="cat" type="CT_Category" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Name">
+    <xsd:attribute name="lang" type="xsd:string" use="optional" default=""/>
+    <xsd:attribute name="val" type="xsd:string" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Description">
+    <xsd:attribute name="lang" type="xsd:string" use="optional" default=""/>
+    <xsd:attribute name="val" type="xsd:string" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DiagramDefinition">
+    <xsd:sequence>
+      <xsd:element name="title" type="CT_Name" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="desc" type="CT_Description" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="catLst" type="CT_Categories" minOccurs="0"/>
+      <xsd:element name="sampData" type="CT_SampleData" minOccurs="0"/>
+      <xsd:element name="styleData" type="CT_SampleData" minOccurs="0"/>
+      <xsd:element name="clrData" type="CT_SampleData" minOccurs="0"/>
+      <xsd:element name="layoutNode" type="CT_LayoutNode"/>
+      <xsd:element name="extLst" type="a:CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="uniqueId" type="xsd:string" use="optional" default=""/>
+    <xsd:attribute name="minVer" type="xsd:string" use="optional"/>
+    <xsd:attribute name="defStyle" type="xsd:string" use="optional" default=""/>
+  </xsd:complexType>
+  <xsd:element name="layoutDef" type="CT_DiagramDefinition"/>
+  <xsd:complexType name="CT_DiagramDefinitionHeader">
+    <xsd:sequence>
+      <xsd:element name="title" type="CT_Name" minOccurs="1" maxOccurs="unbounded"/>
+      <xsd:element name="desc" type="CT_Description" minOccurs="1" maxOccurs="unbounded"/>
+      <xsd:element name="catLst" type="CT_Categories" minOccurs="0"/>
+      <xsd:element name="extLst" type="a:CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="uniqueId" type="xsd:string" use="required"/>
+    <xsd:attribute name="minVer" type="xsd:string" use="optional"/>
+    <xsd:attribute name="defStyle" type="xsd:string" use="optional" default=""/>
+    <xsd:attribute name="resId" type="xsd:int" use="optional" default="0"/>
+  </xsd:complexType>
+  <xsd:element name="layoutDefHdr" type="CT_DiagramDefinitionHeader"/>
+  <xsd:complexType name="CT_DiagramDefinitionHeaderLst">
+    <xsd:sequence>
+      <xsd:element name="layoutDefHdr" type="CT_DiagramDefinitionHeader" minOccurs="0"
+        maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="layoutDefHdrLst" type="CT_DiagramDefinitionHeaderLst"/>
+  <xsd:complexType name="CT_RelIds">
+    <xsd:attribute ref="r:dm" use="required"/>
+    <xsd:attribute ref="r:lo" use="required"/>
+    <xsd:attribute ref="r:qs" use="required"/>
+    <xsd:attribute ref="r:cs" use="required"/>
+  </xsd:complexType>
+  <xsd:element name="relIds" type="CT_RelIds"/>
+  <xsd:simpleType name="ST_ParameterVal">
+    <xsd:union
+      memberTypes="ST_DiagramHorizontalAlignment ST_VerticalAlignment ST_ChildDirection ST_ChildAlignment ST_SecondaryChildAlignment ST_LinearDirection ST_SecondaryLinearDirection ST_StartingElement ST_BendPoint ST_ConnectorRouting ST_ArrowheadStyle ST_ConnectorDimension ST_RotationPath ST_CenterShapeMapping ST_NodeHorizontalAlignment ST_NodeVerticalAlignment ST_FallbackDimension ST_TextDirection ST_PyramidAccentPosition ST_PyramidAccentTextMargin ST_TextBlockDirection ST_TextAnchorHorizontal ST_TextAnchorVertical ST_DiagramTextAlignment ST_AutoTextRotation ST_GrowDirection ST_FlowDirection ST_ContinueDirection ST_Breakpoint ST_Offset ST_HierarchyAlignment xsd:int xsd:double xsd:boolean xsd:string ST_ConnectorPoint"
+    />
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_ModelId">
+    <xsd:union memberTypes="xsd:int s:ST_Guid"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_PrSetCustVal">
+    <xsd:union memberTypes="s:ST_Percentage xsd:int"/>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_ElemPropSet">
+    <xsd:sequence>
+      <xsd:element name="presLayoutVars" type="CT_LayoutVariablePropertySet" minOccurs="0"
+        maxOccurs="1"/>
+      <xsd:element name="style" type="a:CT_ShapeStyle" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="presAssocID" type="ST_ModelId" use="optional"/>
+    <xsd:attribute name="presName" type="xsd:string" use="optional"/>
+    <xsd:attribute name="presStyleLbl" type="xsd:string" use="optional"/>
+    <xsd:attribute name="presStyleIdx" type="xsd:int" use="optional"/>
+    <xsd:attribute name="presStyleCnt" type="xsd:int" use="optional"/>
+    <xsd:attribute name="loTypeId" type="xsd:string" use="optional"/>
+    <xsd:attribute name="loCatId" type="xsd:string" use="optional"/>
+    <xsd:attribute name="qsTypeId" type="xsd:string" use="optional"/>
+    <xsd:attribute name="qsCatId" type="xsd:string" use="optional"/>
+    <xsd:attribute name="csTypeId" type="xsd:string" use="optional"/>
+    <xsd:attribute name="csCatId" type="xsd:string" use="optional"/>
+    <xsd:attribute name="coherent3DOff" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="phldrT" type="xsd:string" use="optional"/>
+    <xsd:attribute name="phldr" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="custAng" type="xsd:int" use="optional"/>
+    <xsd:attribute name="custFlipVert" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="custFlipHor" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="custSzX" type="xsd:int" use="optional"/>
+    <xsd:attribute name="custSzY" type="xsd:int" use="optional"/>
+    <xsd:attribute name="custScaleX" type="ST_PrSetCustVal" use="optional"/>
+    <xsd:attribute name="custScaleY" type="ST_PrSetCustVal" use="optional"/>
+    <xsd:attribute name="custT" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="custLinFactX" type="ST_PrSetCustVal" use="optional"/>
+    <xsd:attribute name="custLinFactY" type="ST_PrSetCustVal" use="optional"/>
+    <xsd:attribute name="custLinFactNeighborX" type="ST_PrSetCustVal" use="optional"/>
+    <xsd:attribute name="custLinFactNeighborY" type="ST_PrSetCustVal" use="optional"/>
+    <xsd:attribute name="custRadScaleRad" type="ST_PrSetCustVal" use="optional"/>
+    <xsd:attribute name="custRadScaleInc" type="ST_PrSetCustVal" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_Direction" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="norm"/>
+      <xsd:enumeration value="rev"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_HierBranchStyle" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="l"/>
+      <xsd:enumeration value="r"/>
+      <xsd:enumeration value="hang"/>
+      <xsd:enumeration value="std"/>
+      <xsd:enumeration value="init"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_AnimOneStr" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="one"/>
+      <xsd:enumeration value="branch"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_AnimLvlStr" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="lvl"/>
+      <xsd:enumeration value="ctr"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_OrgChart">
+    <xsd:attribute name="val" type="xsd:boolean" default="false" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_NodeCount">
+    <xsd:restriction base="xsd:int">
+      <xsd:minInclusive value="-1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_ChildMax">
+    <xsd:attribute name="val" type="ST_NodeCount" default="-1" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ChildPref">
+    <xsd:attribute name="val" type="ST_NodeCount" default="-1" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_BulletEnabled">
+    <xsd:attribute name="val" type="xsd:boolean" default="false" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Direction">
+    <xsd:attribute name="val" type="ST_Direction" default="norm" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_HierBranchStyle">
+    <xsd:attribute name="val" type="ST_HierBranchStyle" default="std" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_AnimOne">
+    <xsd:attribute name="val" type="ST_AnimOneStr" default="one" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_AnimLvl">
+    <xsd:attribute name="val" type="ST_AnimLvlStr" default="none" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_ResizeHandlesStr" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="exact"/>
+      <xsd:enumeration value="rel"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_ResizeHandles">
+    <xsd:attribute name="val" type="ST_ResizeHandlesStr" default="rel" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_LayoutVariablePropertySet">
+    <xsd:sequence>
+      <xsd:element name="orgChart" type="CT_OrgChart" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="chMax" type="CT_ChildMax" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="chPref" type="CT_ChildPref" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="bulletEnabled" type="CT_BulletEnabled" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="dir" type="CT_Direction" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="hierBranch" type="CT_HierBranchStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="animOne" type="CT_AnimOne" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="animLvl" type="CT_AnimLvl" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="resizeHandles" type="CT_ResizeHandles" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SDName">
+    <xsd:attribute name="lang" type="xsd:string" use="optional" default=""/>
+    <xsd:attribute name="val" type="xsd:string" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SDDescription">
+    <xsd:attribute name="lang" type="xsd:string" use="optional" default=""/>
+    <xsd:attribute name="val" type="xsd:string" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SDCategory">
+    <xsd:attribute name="type" type="xsd:anyURI" use="required"/>
+    <xsd:attribute name="pri" type="xsd:unsignedInt" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SDCategories">
+    <xsd:sequence minOccurs="0" maxOccurs="unbounded">
+      <xsd:element name="cat" type="CT_SDCategory" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TextProps">
+    <xsd:sequence>
+      <xsd:group ref="a:EG_Text3D" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_StyleLabel">
+    <xsd:sequence>
+      <xsd:element name="scene3d" type="a:CT_Scene3D" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="sp3d" type="a:CT_Shape3D" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="txPr" type="CT_TextProps" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="style" type="a:CT_ShapeStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="a:CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_StyleDefinition">
+    <xsd:sequence>
+      <xsd:element name="title" type="CT_SDName" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="desc" type="CT_SDDescription" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="catLst" type="CT_SDCategories" minOccurs="0"/>
+      <xsd:element name="scene3d" type="a:CT_Scene3D" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="styleLbl" type="CT_StyleLabel" minOccurs="1" maxOccurs="unbounded"/>
+      <xsd:element name="extLst" type="a:CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="uniqueId" type="xsd:string" use="optional" default=""/>
+    <xsd:attribute name="minVer" type="xsd:string" use="optional"/>
+  </xsd:complexType>
+  <xsd:element name="styleDef" type="CT_StyleDefinition"/>
+  <xsd:complexType name="CT_StyleDefinitionHeader">
+    <xsd:sequence>
+      <xsd:element name="title" type="CT_SDName" minOccurs="1" maxOccurs="unbounded"/>
+      <xsd:element name="desc" type="CT_SDDescription" minOccurs="1" maxOccurs="unbounded"/>
+      <xsd:element name="catLst" type="CT_SDCategories" minOccurs="0"/>
+      <xsd:element name="extLst" type="a:CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="uniqueId" type="xsd:string" use="required"/>
+    <xsd:attribute name="minVer" type="xsd:string" use="optional"/>
+    <xsd:attribute name="resId" type="xsd:int" use="optional" default="0"/>
+  </xsd:complexType>
+  <xsd:element name="styleDefHdr" type="CT_StyleDefinitionHeader"/>
+  <xsd:complexType name="CT_StyleDefinitionHeaderLst">
+    <xsd:sequence>
+      <xsd:element name="styleDefHdr" type="CT_StyleDefinitionHeader" minOccurs="0"
+        maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="styleDefHdrLst" type="CT_StyleDefinitionHeaderLst"/>
+  <xsd:simpleType name="ST_AlgorithmType" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="composite"/>
+      <xsd:enumeration value="conn"/>
+      <xsd:enumeration value="cycle"/>
+      <xsd:enumeration value="hierChild"/>
+      <xsd:enumeration value="hierRoot"/>
+      <xsd:enumeration value="pyra"/>
+      <xsd:enumeration value="lin"/>
+      <xsd:enumeration value="sp"/>
+      <xsd:enumeration value="tx"/>
+      <xsd:enumeration value="snake"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_AxisType" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="self"/>
+      <xsd:enumeration value="ch"/>
+      <xsd:enumeration value="des"/>
+      <xsd:enumeration value="desOrSelf"/>
+      <xsd:enumeration value="par"/>
+      <xsd:enumeration value="ancst"/>
+      <xsd:enumeration value="ancstOrSelf"/>
+      <xsd:enumeration value="followSib"/>
+      <xsd:enumeration value="precedSib"/>
+      <xsd:enumeration value="follow"/>
+      <xsd:enumeration value="preced"/>
+      <xsd:enumeration value="root"/>
+      <xsd:enumeration value="none"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_AxisTypes">
+    <xsd:list itemType="ST_AxisType"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_BoolOperator" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="equ"/>
+      <xsd:enumeration value="gte"/>
+      <xsd:enumeration value="lte"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_ChildOrderType" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="b"/>
+      <xsd:enumeration value="t"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_ConstraintType" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="alignOff"/>
+      <xsd:enumeration value="begMarg"/>
+      <xsd:enumeration value="bendDist"/>
+      <xsd:enumeration value="begPad"/>
+      <xsd:enumeration value="b"/>
+      <xsd:enumeration value="bMarg"/>
+      <xsd:enumeration value="bOff"/>
+      <xsd:enumeration value="ctrX"/>
+      <xsd:enumeration value="ctrXOff"/>
+      <xsd:enumeration value="ctrY"/>
+      <xsd:enumeration value="ctrYOff"/>
+      <xsd:enumeration value="connDist"/>
+      <xsd:enumeration value="diam"/>
+      <xsd:enumeration value="endMarg"/>
+      <xsd:enumeration value="endPad"/>
+      <xsd:enumeration value="h"/>
+      <xsd:enumeration value="hArH"/>
+      <xsd:enumeration value="hOff"/>
+      <xsd:enumeration value="l"/>
+      <xsd:enumeration value="lMarg"/>
+      <xsd:enumeration value="lOff"/>
+      <xsd:enumeration value="r"/>
+      <xsd:enumeration value="rMarg"/>
+      <xsd:enumeration value="rOff"/>
+      <xsd:enumeration value="primFontSz"/>
+      <xsd:enumeration value="pyraAcctRatio"/>
+      <xsd:enumeration value="secFontSz"/>
+      <xsd:enumeration value="sibSp"/>
+      <xsd:enumeration value="secSibSp"/>
+      <xsd:enumeration value="sp"/>
+      <xsd:enumeration value="stemThick"/>
+      <xsd:enumeration value="t"/>
+      <xsd:enumeration value="tMarg"/>
+      <xsd:enumeration value="tOff"/>
+      <xsd:enumeration value="userA"/>
+      <xsd:enumeration value="userB"/>
+      <xsd:enumeration value="userC"/>
+      <xsd:enumeration value="userD"/>
+      <xsd:enumeration value="userE"/>
+      <xsd:enumeration value="userF"/>
+      <xsd:enumeration value="userG"/>
+      <xsd:enumeration value="userH"/>
+      <xsd:enumeration value="userI"/>
+      <xsd:enumeration value="userJ"/>
+      <xsd:enumeration value="userK"/>
+      <xsd:enumeration value="userL"/>
+      <xsd:enumeration value="userM"/>
+      <xsd:enumeration value="userN"/>
+      <xsd:enumeration value="userO"/>
+      <xsd:enumeration value="userP"/>
+      <xsd:enumeration value="userQ"/>
+      <xsd:enumeration value="userR"/>
+      <xsd:enumeration value="userS"/>
+      <xsd:enumeration value="userT"/>
+      <xsd:enumeration value="userU"/>
+      <xsd:enumeration value="userV"/>
+      <xsd:enumeration value="userW"/>
+      <xsd:enumeration value="userX"/>
+      <xsd:enumeration value="userY"/>
+      <xsd:enumeration value="userZ"/>
+      <xsd:enumeration value="w"/>
+      <xsd:enumeration value="wArH"/>
+      <xsd:enumeration value="wOff"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_ConstraintRelationship" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="self"/>
+      <xsd:enumeration value="ch"/>
+      <xsd:enumeration value="des"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_ElementType" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="all"/>
+      <xsd:enumeration value="doc"/>
+      <xsd:enumeration value="node"/>
+      <xsd:enumeration value="norm"/>
+      <xsd:enumeration value="nonNorm"/>
+      <xsd:enumeration value="asst"/>
+      <xsd:enumeration value="nonAsst"/>
+      <xsd:enumeration value="parTrans"/>
+      <xsd:enumeration value="pres"/>
+      <xsd:enumeration value="sibTrans"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_ElementTypes">
+    <xsd:list itemType="ST_ElementType"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_ParameterId" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="horzAlign"/>
+      <xsd:enumeration value="vertAlign"/>
+      <xsd:enumeration value="chDir"/>
+      <xsd:enumeration value="chAlign"/>
+      <xsd:enumeration value="secChAlign"/>
+      <xsd:enumeration value="linDir"/>
+      <xsd:enumeration value="secLinDir"/>
+      <xsd:enumeration value="stElem"/>
+      <xsd:enumeration value="bendPt"/>
+      <xsd:enumeration value="connRout"/>
+      <xsd:enumeration value="begSty"/>
+      <xsd:enumeration value="endSty"/>
+      <xsd:enumeration value="dim"/>
+      <xsd:enumeration value="rotPath"/>
+      <xsd:enumeration value="ctrShpMap"/>
+      <xsd:enumeration value="nodeHorzAlign"/>
+      <xsd:enumeration value="nodeVertAlign"/>
+      <xsd:enumeration value="fallback"/>
+      <xsd:enumeration value="txDir"/>
+      <xsd:enumeration value="pyraAcctPos"/>
+      <xsd:enumeration value="pyraAcctTxMar"/>
+      <xsd:enumeration value="txBlDir"/>
+      <xsd:enumeration value="txAnchorHorz"/>
+      <xsd:enumeration value="txAnchorVert"/>
+      <xsd:enumeration value="txAnchorHorzCh"/>
+      <xsd:enumeration value="txAnchorVertCh"/>
+      <xsd:enumeration value="parTxLTRAlign"/>
+      <xsd:enumeration value="parTxRTLAlign"/>
+      <xsd:enumeration value="shpTxLTRAlignCh"/>
+      <xsd:enumeration value="shpTxRTLAlignCh"/>
+      <xsd:enumeration value="autoTxRot"/>
+      <xsd:enumeration value="grDir"/>
+      <xsd:enumeration value="flowDir"/>
+      <xsd:enumeration value="contDir"/>
+      <xsd:enumeration value="bkpt"/>
+      <xsd:enumeration value="off"/>
+      <xsd:enumeration value="hierAlign"/>
+      <xsd:enumeration value="bkPtFixedVal"/>
+      <xsd:enumeration value="stBulletLvl"/>
+      <xsd:enumeration value="stAng"/>
+      <xsd:enumeration value="spanAng"/>
+      <xsd:enumeration value="ar"/>
+      <xsd:enumeration value="lnSpPar"/>
+      <xsd:enumeration value="lnSpAfParP"/>
+      <xsd:enumeration value="lnSpCh"/>
+      <xsd:enumeration value="lnSpAfChP"/>
+      <xsd:enumeration value="rtShortDist"/>
+      <xsd:enumeration value="alignTx"/>
+      <xsd:enumeration value="pyraLvlNode"/>
+      <xsd:enumeration value="pyraAcctBkgdNode"/>
+      <xsd:enumeration value="pyraAcctTxNode"/>
+      <xsd:enumeration value="srcNode"/>
+      <xsd:enumeration value="dstNode"/>
+      <xsd:enumeration value="begPts"/>
+      <xsd:enumeration value="endPts"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_Ints">
+    <xsd:list itemType="xsd:int"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_UnsignedInts">
+    <xsd:list itemType="xsd:unsignedInt"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_Booleans">
+    <xsd:list itemType="xsd:boolean"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_FunctionType" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="cnt"/>
+      <xsd:enumeration value="pos"/>
+      <xsd:enumeration value="revPos"/>
+      <xsd:enumeration value="posEven"/>
+      <xsd:enumeration value="posOdd"/>
+      <xsd:enumeration value="var"/>
+      <xsd:enumeration value="depth"/>
+      <xsd:enumeration value="maxDepth"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_FunctionOperator" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="equ"/>
+      <xsd:enumeration value="neq"/>
+      <xsd:enumeration value="gt"/>
+      <xsd:enumeration value="lt"/>
+      <xsd:enumeration value="gte"/>
+      <xsd:enumeration value="lte"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_DiagramHorizontalAlignment" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="l"/>
+      <xsd:enumeration value="ctr"/>
+      <xsd:enumeration value="r"/>
+      <xsd:enumeration value="none"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_VerticalAlignment" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="t"/>
+      <xsd:enumeration value="mid"/>
+      <xsd:enumeration value="b"/>
+      <xsd:enumeration value="none"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_ChildDirection" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="horz"/>
+      <xsd:enumeration value="vert"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_ChildAlignment" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="t"/>
+      <xsd:enumeration value="b"/>
+      <xsd:enumeration value="l"/>
+      <xsd:enumeration value="r"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_SecondaryChildAlignment" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="t"/>
+      <xsd:enumeration value="b"/>
+      <xsd:enumeration value="l"/>
+      <xsd:enumeration value="r"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_LinearDirection" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="fromL"/>
+      <xsd:enumeration value="fromR"/>
+      <xsd:enumeration value="fromT"/>
+      <xsd:enumeration value="fromB"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_SecondaryLinearDirection" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="fromL"/>
+      <xsd:enumeration value="fromR"/>
+      <xsd:enumeration value="fromT"/>
+      <xsd:enumeration value="fromB"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_StartingElement" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="node"/>
+      <xsd:enumeration value="trans"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_RotationPath" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="alongPath"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_CenterShapeMapping" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="fNode"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_BendPoint" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="beg"/>
+      <xsd:enumeration value="def"/>
+      <xsd:enumeration value="end"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_ConnectorRouting" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="stra"/>
+      <xsd:enumeration value="bend"/>
+      <xsd:enumeration value="curve"/>
+      <xsd:enumeration value="longCurve"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_ArrowheadStyle" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="auto"/>
+      <xsd:enumeration value="arr"/>
+      <xsd:enumeration value="noArr"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_ConnectorDimension" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="1D"/>
+      <xsd:enumeration value="2D"/>
+      <xsd:enumeration value="cust"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_ConnectorPoint" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="auto"/>
+      <xsd:enumeration value="bCtr"/>
+      <xsd:enumeration value="ctr"/>
+      <xsd:enumeration value="midL"/>
+      <xsd:enumeration value="midR"/>
+      <xsd:enumeration value="tCtr"/>
+      <xsd:enumeration value="bL"/>
+      <xsd:enumeration value="bR"/>
+      <xsd:enumeration value="tL"/>
+      <xsd:enumeration value="tR"/>
+      <xsd:enumeration value="radial"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_NodeHorizontalAlignment" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="l"/>
+      <xsd:enumeration value="ctr"/>
+      <xsd:enumeration value="r"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_NodeVerticalAlignment" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="t"/>
+      <xsd:enumeration value="mid"/>
+      <xsd:enumeration value="b"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_FallbackDimension" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="1D"/>
+      <xsd:enumeration value="2D"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TextDirection" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="fromT"/>
+      <xsd:enumeration value="fromB"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_PyramidAccentPosition" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="bef"/>
+      <xsd:enumeration value="aft"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_PyramidAccentTextMargin" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="step"/>
+      <xsd:enumeration value="stack"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TextBlockDirection" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="horz"/>
+      <xsd:enumeration value="vert"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TextAnchorHorizontal" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="ctr"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TextAnchorVertical" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="t"/>
+      <xsd:enumeration value="mid"/>
+      <xsd:enumeration value="b"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_DiagramTextAlignment" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="l"/>
+      <xsd:enumeration value="ctr"/>
+      <xsd:enumeration value="r"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_AutoTextRotation" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="upr"/>
+      <xsd:enumeration value="grav"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_GrowDirection" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="tL"/>
+      <xsd:enumeration value="tR"/>
+      <xsd:enumeration value="bL"/>
+      <xsd:enumeration value="bR"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_FlowDirection" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="row"/>
+      <xsd:enumeration value="col"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_ContinueDirection" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="revDir"/>
+      <xsd:enumeration value="sameDir"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_Breakpoint" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="endCnv"/>
+      <xsd:enumeration value="bal"/>
+      <xsd:enumeration value="fixed"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_Offset" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="ctr"/>
+      <xsd:enumeration value="off"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_HierarchyAlignment" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="tL"/>
+      <xsd:enumeration value="tR"/>
+      <xsd:enumeration value="tCtrCh"/>
+      <xsd:enumeration value="tCtrDes"/>
+      <xsd:enumeration value="bL"/>
+      <xsd:enumeration value="bR"/>
+      <xsd:enumeration value="bCtrCh"/>
+      <xsd:enumeration value="bCtrDes"/>
+      <xsd:enumeration value="lT"/>
+      <xsd:enumeration value="lB"/>
+      <xsd:enumeration value="lCtrCh"/>
+      <xsd:enumeration value="lCtrDes"/>
+      <xsd:enumeration value="rT"/>
+      <xsd:enumeration value="rB"/>
+      <xsd:enumeration value="rCtrCh"/>
+      <xsd:enumeration value="rCtrDes"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_FunctionValue" final="restriction">
+    <xsd:union
+      memberTypes="xsd:int xsd:boolean ST_Direction ST_HierBranchStyle ST_AnimOneStr ST_AnimLvlStr ST_ResizeHandlesStr"
+    />
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_VariableType" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="orgChart"/>
+      <xsd:enumeration value="chMax"/>
+      <xsd:enumeration value="chPref"/>
+      <xsd:enumeration value="bulEnabled"/>
+      <xsd:enumeration value="dir"/>
+      <xsd:enumeration value="hierBranch"/>
+      <xsd:enumeration value="animOne"/>
+      <xsd:enumeration value="animLvl"/>
+      <xsd:enumeration value="resizeHandles"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_FunctionArgument" final="restriction">
+    <xsd:union memberTypes="ST_VariableType"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_OutputShapeType" final="restriction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="conn"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+</xsd:schema>

--- a/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-lockedCanvas.xsd
+++ b/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-lockedCanvas.xsd
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://schemas.openxmlformats.org/drawingml/2006/lockedCanvas"
+  xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+  xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+  elementFormDefault="qualified"
+  targetNamespace="http://schemas.openxmlformats.org/drawingml/2006/lockedCanvas">
+  <xsd:import namespace="http://schemas.openxmlformats.org/drawingml/2006/main"
+    schemaLocation="dml-main.xsd"/>
+  <xsd:element name="lockedCanvas" type="a:CT_GvmlGroupShape"/>
+</xsd:schema>

--- a/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-main.xsd
+++ b/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-main.xsd
@@ -1,0 +1,3081 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+  xmlns:s="http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"
+  xmlns="http://schemas.openxmlformats.org/drawingml/2006/main"
+  targetNamespace="http://schemas.openxmlformats.org/drawingml/2006/main"
+  elementFormDefault="qualified">
+  <xsd:import namespace="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+    schemaLocation="shared-relationshipReference.xsd"/>
+  <xsd:import namespace="http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"
+    schemaLocation="shared-commonSimpleTypes.xsd"/>
+  <xsd:import namespace="http://schemas.openxmlformats.org/drawingml/2006/diagram"
+    schemaLocation="dml-diagram.xsd"/>
+  <xsd:import namespace="http://schemas.openxmlformats.org/drawingml/2006/chart"
+    schemaLocation="dml-chart.xsd"/>
+  <xsd:import namespace="http://schemas.openxmlformats.org/drawingml/2006/picture"
+    schemaLocation="dml-picture.xsd"/>
+  <xsd:import namespace="http://schemas.openxmlformats.org/drawingml/2006/lockedCanvas"
+    schemaLocation="dml-lockedCanvas.xsd"/>
+  <xsd:complexType name="CT_AudioFile">
+    <xsd:sequence>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute ref="r:link" use="required"/>
+    <xsd:attribute name="contentType" type="xsd:string" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_VideoFile">
+    <xsd:sequence>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute ref="r:link" use="required"/>
+    <xsd:attribute name="contentType" type="xsd:string" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_QuickTimeFile">
+    <xsd:sequence>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute ref="r:link" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_AudioCDTime">
+    <xsd:attribute name="track" type="xsd:unsignedByte" use="required"/>
+    <xsd:attribute name="time" type="xsd:unsignedInt" use="optional" default="0"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_AudioCD">
+    <xsd:sequence>
+      <xsd:element name="st" type="CT_AudioCDTime" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="end" type="CT_AudioCDTime" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:group name="EG_Media">
+    <xsd:choice>
+      <xsd:element name="audioCd" type="CT_AudioCD"/>
+      <xsd:element name="wavAudioFile" type="CT_EmbeddedWAVAudioFile"/>
+      <xsd:element name="audioFile" type="CT_AudioFile"/>
+      <xsd:element name="videoFile" type="CT_VideoFile"/>
+      <xsd:element name="quickTimeFile" type="CT_QuickTimeFile"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:element name="videoFile" type="CT_VideoFile"/>
+  <xsd:simpleType name="ST_StyleMatrixColumnIndex">
+    <xsd:restriction base="xsd:unsignedInt"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_FontCollectionIndex">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="major"/>
+      <xsd:enumeration value="minor"/>
+      <xsd:enumeration value="none"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_ColorSchemeIndex">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="dk1"/>
+      <xsd:enumeration value="lt1"/>
+      <xsd:enumeration value="dk2"/>
+      <xsd:enumeration value="lt2"/>
+      <xsd:enumeration value="accent1"/>
+      <xsd:enumeration value="accent2"/>
+      <xsd:enumeration value="accent3"/>
+      <xsd:enumeration value="accent4"/>
+      <xsd:enumeration value="accent5"/>
+      <xsd:enumeration value="accent6"/>
+      <xsd:enumeration value="hlink"/>
+      <xsd:enumeration value="folHlink"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_ColorScheme">
+    <xsd:sequence>
+      <xsd:element name="dk1" type="CT_Color" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="lt1" type="CT_Color" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="dk2" type="CT_Color" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="lt2" type="CT_Color" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="accent1" type="CT_Color" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="accent2" type="CT_Color" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="accent3" type="CT_Color" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="accent4" type="CT_Color" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="accent5" type="CT_Color" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="accent6" type="CT_Color" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="hlink" type="CT_Color" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="folHlink" type="CT_Color" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CustomColor">
+    <xsd:sequence>
+      <xsd:group ref="EG_ColorChoice" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="optional" default=""/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SupplementalFont">
+    <xsd:attribute name="script" type="xsd:string" use="required"/>
+    <xsd:attribute name="typeface" type="ST_TextTypeface" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CustomColorList">
+    <xsd:sequence>
+      <xsd:element name="custClr" type="CT_CustomColor" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_FontCollection">
+    <xsd:sequence>
+      <xsd:element name="latin" type="CT_TextFont" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="ea" type="CT_TextFont" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="cs" type="CT_TextFont" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="font" type="CT_SupplementalFont" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_EffectStyleItem">
+    <xsd:sequence>
+      <xsd:group ref="EG_EffectProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="scene3d" type="CT_Scene3D" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="sp3d" type="CT_Shape3D" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_FontScheme">
+    <xsd:sequence>
+      <xsd:element name="majorFont" type="CT_FontCollection" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="minorFont" type="CT_FontCollection" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_FillStyleList">
+    <xsd:sequence>
+      <xsd:group ref="EG_FillProperties" minOccurs="3" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_LineStyleList">
+    <xsd:sequence>
+      <xsd:element name="ln" type="CT_LineProperties" minOccurs="3" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_EffectStyleList">
+    <xsd:sequence>
+      <xsd:element name="effectStyle" type="CT_EffectStyleItem" minOccurs="3" maxOccurs="unbounded"
+      />
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_BackgroundFillStyleList">
+    <xsd:sequence>
+      <xsd:group ref="EG_FillProperties" minOccurs="3" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_StyleMatrix">
+    <xsd:sequence>
+      <xsd:element name="fillStyleLst" type="CT_FillStyleList" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="lnStyleLst" type="CT_LineStyleList" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="effectStyleLst" type="CT_EffectStyleList" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="bgFillStyleLst" type="CT_BackgroundFillStyleList" minOccurs="1"
+        maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="optional" default=""/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_BaseStyles">
+    <xsd:sequence>
+      <xsd:element name="clrScheme" type="CT_ColorScheme" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="fontScheme" type="CT_FontScheme" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="fmtScheme" type="CT_StyleMatrix" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_OfficeArtExtension">
+    <xsd:sequence>
+      <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="uri" type="xsd:token" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_Coordinate">
+    <xsd:union memberTypes="ST_CoordinateUnqualified s:ST_UniversalMeasure"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_CoordinateUnqualified">
+    <xsd:restriction base="xsd:long">
+      <xsd:minInclusive value="-27273042329600"/>
+      <xsd:maxInclusive value="27273042316900"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_Coordinate32">
+    <xsd:union memberTypes="ST_Coordinate32Unqualified s:ST_UniversalMeasure"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_Coordinate32Unqualified">
+    <xsd:restriction base="xsd:int"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_PositiveCoordinate">
+    <xsd:restriction base="xsd:long">
+      <xsd:minInclusive value="0"/>
+      <xsd:maxInclusive value="27273042316900"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_PositiveCoordinate32">
+    <xsd:restriction base="ST_Coordinate32Unqualified">
+      <xsd:minInclusive value="0"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_Angle">
+    <xsd:restriction base="xsd:int"/>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Angle">
+    <xsd:attribute name="val" type="ST_Angle" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_FixedAngle">
+    <xsd:restriction base="ST_Angle">
+      <xsd:minExclusive value="-5400000"/>
+      <xsd:maxExclusive value="5400000"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_PositiveFixedAngle">
+    <xsd:restriction base="ST_Angle">
+      <xsd:minInclusive value="0"/>
+      <xsd:maxExclusive value="21600000"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_PositiveFixedAngle">
+    <xsd:attribute name="val" type="ST_PositiveFixedAngle" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_Percentage">
+    <xsd:union memberTypes="ST_PercentageDecimal s:ST_Percentage"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_PercentageDecimal">
+    <xsd:restriction base="xsd:int"/>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Percentage">
+    <xsd:attribute name="val" type="ST_Percentage" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_PositivePercentage">
+    <xsd:union memberTypes="ST_PositivePercentageDecimal s:ST_PositivePercentage"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_PositivePercentageDecimal">
+    <xsd:restriction base="ST_PercentageDecimal">
+      <xsd:minInclusive value="0"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_PositivePercentage">
+    <xsd:attribute name="val" type="ST_PositivePercentage" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_FixedPercentage">
+    <xsd:union memberTypes="ST_FixedPercentageDecimal s:ST_FixedPercentage"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_FixedPercentageDecimal">
+    <xsd:restriction base="ST_PercentageDecimal">
+      <xsd:minInclusive value="-100000"/>
+      <xsd:maxInclusive value="100000"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_FixedPercentage">
+    <xsd:attribute name="val" type="ST_FixedPercentage" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_PositiveFixedPercentage">
+    <xsd:union memberTypes="ST_PositiveFixedPercentageDecimal s:ST_PositiveFixedPercentage"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_PositiveFixedPercentageDecimal">
+    <xsd:restriction base="ST_PercentageDecimal">
+      <xsd:minInclusive value="0"/>
+      <xsd:maxInclusive value="100000"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_PositiveFixedPercentage">
+    <xsd:attribute name="val" type="ST_PositiveFixedPercentage" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Ratio">
+    <xsd:attribute name="n" type="xsd:long" use="required"/>
+    <xsd:attribute name="d" type="xsd:long" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Point2D">
+    <xsd:attribute name="x" type="ST_Coordinate" use="required"/>
+    <xsd:attribute name="y" type="ST_Coordinate" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PositiveSize2D">
+    <xsd:attribute name="cx" type="ST_PositiveCoordinate" use="required"/>
+    <xsd:attribute name="cy" type="ST_PositiveCoordinate" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ComplementTransform"/>
+  <xsd:complexType name="CT_InverseTransform"/>
+  <xsd:complexType name="CT_GrayscaleTransform"/>
+  <xsd:complexType name="CT_GammaTransform"/>
+  <xsd:complexType name="CT_InverseGammaTransform"/>
+  <xsd:group name="EG_ColorTransform">
+    <xsd:choice>
+      <xsd:element name="tint" type="CT_PositiveFixedPercentage" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="shade" type="CT_PositiveFixedPercentage" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="comp" type="CT_ComplementTransform" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="inv" type="CT_InverseTransform" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="gray" type="CT_GrayscaleTransform" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="alpha" type="CT_PositiveFixedPercentage" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="alphaOff" type="CT_FixedPercentage" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="alphaMod" type="CT_PositivePercentage" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="hue" type="CT_PositiveFixedAngle" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="hueOff" type="CT_Angle" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="hueMod" type="CT_PositivePercentage" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="sat" type="CT_Percentage" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="satOff" type="CT_Percentage" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="satMod" type="CT_Percentage" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="lum" type="CT_Percentage" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="lumOff" type="CT_Percentage" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="lumMod" type="CT_Percentage" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="red" type="CT_Percentage" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="redOff" type="CT_Percentage" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="redMod" type="CT_Percentage" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="green" type="CT_Percentage" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="greenOff" type="CT_Percentage" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="greenMod" type="CT_Percentage" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="blue" type="CT_Percentage" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="blueOff" type="CT_Percentage" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="blueMod" type="CT_Percentage" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="gamma" type="CT_GammaTransform" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="invGamma" type="CT_InverseGammaTransform" minOccurs="1" maxOccurs="1"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:complexType name="CT_ScRgbColor">
+    <xsd:sequence>
+      <xsd:group ref="EG_ColorTransform" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="r" type="ST_Percentage" use="required"/>
+    <xsd:attribute name="g" type="ST_Percentage" use="required"/>
+    <xsd:attribute name="b" type="ST_Percentage" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SRgbColor">
+    <xsd:sequence>
+      <xsd:group ref="EG_ColorTransform" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="val" type="s:ST_HexColorRGB" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_HslColor">
+    <xsd:sequence>
+      <xsd:group ref="EG_ColorTransform" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="hue" type="ST_PositiveFixedAngle" use="required"/>
+    <xsd:attribute name="sat" type="ST_Percentage" use="required"/>
+    <xsd:attribute name="lum" type="ST_Percentage" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_SystemColorVal">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="scrollBar"/>
+      <xsd:enumeration value="background"/>
+      <xsd:enumeration value="activeCaption"/>
+      <xsd:enumeration value="inactiveCaption"/>
+      <xsd:enumeration value="menu"/>
+      <xsd:enumeration value="window"/>
+      <xsd:enumeration value="windowFrame"/>
+      <xsd:enumeration value="menuText"/>
+      <xsd:enumeration value="windowText"/>
+      <xsd:enumeration value="captionText"/>
+      <xsd:enumeration value="activeBorder"/>
+      <xsd:enumeration value="inactiveBorder"/>
+      <xsd:enumeration value="appWorkspace"/>
+      <xsd:enumeration value="highlight"/>
+      <xsd:enumeration value="highlightText"/>
+      <xsd:enumeration value="btnFace"/>
+      <xsd:enumeration value="btnShadow"/>
+      <xsd:enumeration value="grayText"/>
+      <xsd:enumeration value="btnText"/>
+      <xsd:enumeration value="inactiveCaptionText"/>
+      <xsd:enumeration value="btnHighlight"/>
+      <xsd:enumeration value="3dDkShadow"/>
+      <xsd:enumeration value="3dLight"/>
+      <xsd:enumeration value="infoText"/>
+      <xsd:enumeration value="infoBk"/>
+      <xsd:enumeration value="hotLight"/>
+      <xsd:enumeration value="gradientActiveCaption"/>
+      <xsd:enumeration value="gradientInactiveCaption"/>
+      <xsd:enumeration value="menuHighlight"/>
+      <xsd:enumeration value="menuBar"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_SystemColor">
+    <xsd:sequence>
+      <xsd:group ref="EG_ColorTransform" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="val" type="ST_SystemColorVal" use="required"/>
+    <xsd:attribute name="lastClr" type="s:ST_HexColorRGB" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_SchemeColorVal">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="bg1"/>
+      <xsd:enumeration value="tx1"/>
+      <xsd:enumeration value="bg2"/>
+      <xsd:enumeration value="tx2"/>
+      <xsd:enumeration value="accent1"/>
+      <xsd:enumeration value="accent2"/>
+      <xsd:enumeration value="accent3"/>
+      <xsd:enumeration value="accent4"/>
+      <xsd:enumeration value="accent5"/>
+      <xsd:enumeration value="accent6"/>
+      <xsd:enumeration value="hlink"/>
+      <xsd:enumeration value="folHlink"/>
+      <xsd:enumeration value="phClr"/>
+      <xsd:enumeration value="dk1"/>
+      <xsd:enumeration value="lt1"/>
+      <xsd:enumeration value="dk2"/>
+      <xsd:enumeration value="lt2"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_SchemeColor">
+    <xsd:sequence>
+      <xsd:group ref="EG_ColorTransform" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="val" type="ST_SchemeColorVal" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_PresetColorVal">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="aliceBlue"/>
+      <xsd:enumeration value="antiqueWhite"/>
+      <xsd:enumeration value="aqua"/>
+      <xsd:enumeration value="aquamarine"/>
+      <xsd:enumeration value="azure"/>
+      <xsd:enumeration value="beige"/>
+      <xsd:enumeration value="bisque"/>
+      <xsd:enumeration value="black"/>
+      <xsd:enumeration value="blanchedAlmond"/>
+      <xsd:enumeration value="blue"/>
+      <xsd:enumeration value="blueViolet"/>
+      <xsd:enumeration value="brown"/>
+      <xsd:enumeration value="burlyWood"/>
+      <xsd:enumeration value="cadetBlue"/>
+      <xsd:enumeration value="chartreuse"/>
+      <xsd:enumeration value="chocolate"/>
+      <xsd:enumeration value="coral"/>
+      <xsd:enumeration value="cornflowerBlue"/>
+      <xsd:enumeration value="cornsilk"/>
+      <xsd:enumeration value="crimson"/>
+      <xsd:enumeration value="cyan"/>
+      <xsd:enumeration value="darkBlue"/>
+      <xsd:enumeration value="darkCyan"/>
+      <xsd:enumeration value="darkGoldenrod"/>
+      <xsd:enumeration value="darkGray"/>
+      <xsd:enumeration value="darkGrey"/>
+      <xsd:enumeration value="darkGreen"/>
+      <xsd:enumeration value="darkKhaki"/>
+      <xsd:enumeration value="darkMagenta"/>
+      <xsd:enumeration value="darkOliveGreen"/>
+      <xsd:enumeration value="darkOrange"/>
+      <xsd:enumeration value="darkOrchid"/>
+      <xsd:enumeration value="darkRed"/>
+      <xsd:enumeration value="darkSalmon"/>
+      <xsd:enumeration value="darkSeaGreen"/>
+      <xsd:enumeration value="darkSlateBlue"/>
+      <xsd:enumeration value="darkSlateGray"/>
+      <xsd:enumeration value="darkSlateGrey"/>
+      <xsd:enumeration value="darkTurquoise"/>
+      <xsd:enumeration value="darkViolet"/>
+      <xsd:enumeration value="dkBlue"/>
+      <xsd:enumeration value="dkCyan"/>
+      <xsd:enumeration value="dkGoldenrod"/>
+      <xsd:enumeration value="dkGray"/>
+      <xsd:enumeration value="dkGrey"/>
+      <xsd:enumeration value="dkGreen"/>
+      <xsd:enumeration value="dkKhaki"/>
+      <xsd:enumeration value="dkMagenta"/>
+      <xsd:enumeration value="dkOliveGreen"/>
+      <xsd:enumeration value="dkOrange"/>
+      <xsd:enumeration value="dkOrchid"/>
+      <xsd:enumeration value="dkRed"/>
+      <xsd:enumeration value="dkSalmon"/>
+      <xsd:enumeration value="dkSeaGreen"/>
+      <xsd:enumeration value="dkSlateBlue"/>
+      <xsd:enumeration value="dkSlateGray"/>
+      <xsd:enumeration value="dkSlateGrey"/>
+      <xsd:enumeration value="dkTurquoise"/>
+      <xsd:enumeration value="dkViolet"/>
+      <xsd:enumeration value="deepPink"/>
+      <xsd:enumeration value="deepSkyBlue"/>
+      <xsd:enumeration value="dimGray"/>
+      <xsd:enumeration value="dimGrey"/>
+      <xsd:enumeration value="dodgerBlue"/>
+      <xsd:enumeration value="firebrick"/>
+      <xsd:enumeration value="floralWhite"/>
+      <xsd:enumeration value="forestGreen"/>
+      <xsd:enumeration value="fuchsia"/>
+      <xsd:enumeration value="gainsboro"/>
+      <xsd:enumeration value="ghostWhite"/>
+      <xsd:enumeration value="gold"/>
+      <xsd:enumeration value="goldenrod"/>
+      <xsd:enumeration value="gray"/>
+      <xsd:enumeration value="grey"/>
+      <xsd:enumeration value="green"/>
+      <xsd:enumeration value="greenYellow"/>
+      <xsd:enumeration value="honeydew"/>
+      <xsd:enumeration value="hotPink"/>
+      <xsd:enumeration value="indianRed"/>
+      <xsd:enumeration value="indigo"/>
+      <xsd:enumeration value="ivory"/>
+      <xsd:enumeration value="khaki"/>
+      <xsd:enumeration value="lavender"/>
+      <xsd:enumeration value="lavenderBlush"/>
+      <xsd:enumeration value="lawnGreen"/>
+      <xsd:enumeration value="lemonChiffon"/>
+      <xsd:enumeration value="lightBlue"/>
+      <xsd:enumeration value="lightCoral"/>
+      <xsd:enumeration value="lightCyan"/>
+      <xsd:enumeration value="lightGoldenrodYellow"/>
+      <xsd:enumeration value="lightGray"/>
+      <xsd:enumeration value="lightGrey"/>
+      <xsd:enumeration value="lightGreen"/>
+      <xsd:enumeration value="lightPink"/>
+      <xsd:enumeration value="lightSalmon"/>
+      <xsd:enumeration value="lightSeaGreen"/>
+      <xsd:enumeration value="lightSkyBlue"/>
+      <xsd:enumeration value="lightSlateGray"/>
+      <xsd:enumeration value="lightSlateGrey"/>
+      <xsd:enumeration value="lightSteelBlue"/>
+      <xsd:enumeration value="lightYellow"/>
+      <xsd:enumeration value="ltBlue"/>
+      <xsd:enumeration value="ltCoral"/>
+      <xsd:enumeration value="ltCyan"/>
+      <xsd:enumeration value="ltGoldenrodYellow"/>
+      <xsd:enumeration value="ltGray"/>
+      <xsd:enumeration value="ltGrey"/>
+      <xsd:enumeration value="ltGreen"/>
+      <xsd:enumeration value="ltPink"/>
+      <xsd:enumeration value="ltSalmon"/>
+      <xsd:enumeration value="ltSeaGreen"/>
+      <xsd:enumeration value="ltSkyBlue"/>
+      <xsd:enumeration value="ltSlateGray"/>
+      <xsd:enumeration value="ltSlateGrey"/>
+      <xsd:enumeration value="ltSteelBlue"/>
+      <xsd:enumeration value="ltYellow"/>
+      <xsd:enumeration value="lime"/>
+      <xsd:enumeration value="limeGreen"/>
+      <xsd:enumeration value="linen"/>
+      <xsd:enumeration value="magenta"/>
+      <xsd:enumeration value="maroon"/>
+      <xsd:enumeration value="medAquamarine"/>
+      <xsd:enumeration value="medBlue"/>
+      <xsd:enumeration value="medOrchid"/>
+      <xsd:enumeration value="medPurple"/>
+      <xsd:enumeration value="medSeaGreen"/>
+      <xsd:enumeration value="medSlateBlue"/>
+      <xsd:enumeration value="medSpringGreen"/>
+      <xsd:enumeration value="medTurquoise"/>
+      <xsd:enumeration value="medVioletRed"/>
+      <xsd:enumeration value="mediumAquamarine"/>
+      <xsd:enumeration value="mediumBlue"/>
+      <xsd:enumeration value="mediumOrchid"/>
+      <xsd:enumeration value="mediumPurple"/>
+      <xsd:enumeration value="mediumSeaGreen"/>
+      <xsd:enumeration value="mediumSlateBlue"/>
+      <xsd:enumeration value="mediumSpringGreen"/>
+      <xsd:enumeration value="mediumTurquoise"/>
+      <xsd:enumeration value="mediumVioletRed"/>
+      <xsd:enumeration value="midnightBlue"/>
+      <xsd:enumeration value="mintCream"/>
+      <xsd:enumeration value="mistyRose"/>
+      <xsd:enumeration value="moccasin"/>
+      <xsd:enumeration value="navajoWhite"/>
+      <xsd:enumeration value="navy"/>
+      <xsd:enumeration value="oldLace"/>
+      <xsd:enumeration value="olive"/>
+      <xsd:enumeration value="oliveDrab"/>
+      <xsd:enumeration value="orange"/>
+      <xsd:enumeration value="orangeRed"/>
+      <xsd:enumeration value="orchid"/>
+      <xsd:enumeration value="paleGoldenrod"/>
+      <xsd:enumeration value="paleGreen"/>
+      <xsd:enumeration value="paleTurquoise"/>
+      <xsd:enumeration value="paleVioletRed"/>
+      <xsd:enumeration value="papayaWhip"/>
+      <xsd:enumeration value="peachPuff"/>
+      <xsd:enumeration value="peru"/>
+      <xsd:enumeration value="pink"/>
+      <xsd:enumeration value="plum"/>
+      <xsd:enumeration value="powderBlue"/>
+      <xsd:enumeration value="purple"/>
+      <xsd:enumeration value="red"/>
+      <xsd:enumeration value="rosyBrown"/>
+      <xsd:enumeration value="royalBlue"/>
+      <xsd:enumeration value="saddleBrown"/>
+      <xsd:enumeration value="salmon"/>
+      <xsd:enumeration value="sandyBrown"/>
+      <xsd:enumeration value="seaGreen"/>
+      <xsd:enumeration value="seaShell"/>
+      <xsd:enumeration value="sienna"/>
+      <xsd:enumeration value="silver"/>
+      <xsd:enumeration value="skyBlue"/>
+      <xsd:enumeration value="slateBlue"/>
+      <xsd:enumeration value="slateGray"/>
+      <xsd:enumeration value="slateGrey"/>
+      <xsd:enumeration value="snow"/>
+      <xsd:enumeration value="springGreen"/>
+      <xsd:enumeration value="steelBlue"/>
+      <xsd:enumeration value="tan"/>
+      <xsd:enumeration value="teal"/>
+      <xsd:enumeration value="thistle"/>
+      <xsd:enumeration value="tomato"/>
+      <xsd:enumeration value="turquoise"/>
+      <xsd:enumeration value="violet"/>
+      <xsd:enumeration value="wheat"/>
+      <xsd:enumeration value="white"/>
+      <xsd:enumeration value="whiteSmoke"/>
+      <xsd:enumeration value="yellow"/>
+      <xsd:enumeration value="yellowGreen"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_PresetColor">
+    <xsd:sequence>
+      <xsd:group ref="EG_ColorTransform" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="val" type="ST_PresetColorVal" use="required"/>
+  </xsd:complexType>
+  <xsd:group name="EG_OfficeArtExtensionList">
+    <xsd:sequence>
+      <xsd:element name="ext" type="CT_OfficeArtExtension" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:group>
+  <xsd:complexType name="CT_OfficeArtExtensionList">
+    <xsd:sequence>
+      <xsd:group ref="EG_OfficeArtExtensionList" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Scale2D">
+    <xsd:sequence>
+      <xsd:element name="sx" type="CT_Ratio" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="sy" type="CT_Ratio" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Transform2D">
+    <xsd:sequence>
+      <xsd:element name="off" type="CT_Point2D" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="ext" type="CT_PositiveSize2D" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="rot" type="ST_Angle" use="optional" default="0"/>
+    <xsd:attribute name="flipH" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="flipV" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GroupTransform2D">
+    <xsd:sequence>
+      <xsd:element name="off" type="CT_Point2D" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="ext" type="CT_PositiveSize2D" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="chOff" type="CT_Point2D" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="chExt" type="CT_PositiveSize2D" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="rot" type="ST_Angle" use="optional" default="0"/>
+    <xsd:attribute name="flipH" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="flipV" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Point3D">
+    <xsd:attribute name="x" type="ST_Coordinate" use="required"/>
+    <xsd:attribute name="y" type="ST_Coordinate" use="required"/>
+    <xsd:attribute name="z" type="ST_Coordinate" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Vector3D">
+    <xsd:attribute name="dx" type="ST_Coordinate" use="required"/>
+    <xsd:attribute name="dy" type="ST_Coordinate" use="required"/>
+    <xsd:attribute name="dz" type="ST_Coordinate" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SphereCoords">
+    <xsd:attribute name="lat" type="ST_PositiveFixedAngle" use="required"/>
+    <xsd:attribute name="lon" type="ST_PositiveFixedAngle" use="required"/>
+    <xsd:attribute name="rev" type="ST_PositiveFixedAngle" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_RelativeRect">
+    <xsd:attribute name="l" type="ST_Percentage" use="optional" default="0%"/>
+    <xsd:attribute name="t" type="ST_Percentage" use="optional" default="0%"/>
+    <xsd:attribute name="r" type="ST_Percentage" use="optional" default="0%"/>
+    <xsd:attribute name="b" type="ST_Percentage" use="optional" default="0%"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_RectAlignment">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="tl"/>
+      <xsd:enumeration value="t"/>
+      <xsd:enumeration value="tr"/>
+      <xsd:enumeration value="l"/>
+      <xsd:enumeration value="ctr"/>
+      <xsd:enumeration value="r"/>
+      <xsd:enumeration value="bl"/>
+      <xsd:enumeration value="b"/>
+      <xsd:enumeration value="br"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:group name="EG_ColorChoice">
+    <xsd:choice>
+      <xsd:element name="scrgbClr" type="CT_ScRgbColor" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="srgbClr" type="CT_SRgbColor" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="hslClr" type="CT_HslColor" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="sysClr" type="CT_SystemColor" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="schemeClr" type="CT_SchemeColor" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="prstClr" type="CT_PresetColor" minOccurs="1" maxOccurs="1"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:complexType name="CT_Color">
+    <xsd:sequence>
+      <xsd:group ref="EG_ColorChoice"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ColorMRU">
+    <xsd:sequence>
+      <xsd:group ref="EG_ColorChoice" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_BlackWhiteMode">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="clr"/>
+      <xsd:enumeration value="auto"/>
+      <xsd:enumeration value="gray"/>
+      <xsd:enumeration value="ltGray"/>
+      <xsd:enumeration value="invGray"/>
+      <xsd:enumeration value="grayWhite"/>
+      <xsd:enumeration value="blackGray"/>
+      <xsd:enumeration value="blackWhite"/>
+      <xsd:enumeration value="black"/>
+      <xsd:enumeration value="white"/>
+      <xsd:enumeration value="hidden"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:attributeGroup name="AG_Blob">
+    <xsd:attribute ref="r:embed" use="optional" default=""/>
+    <xsd:attribute ref="r:link" use="optional" default=""/>
+  </xsd:attributeGroup>
+  <xsd:complexType name="CT_EmbeddedWAVAudioFile">
+    <xsd:attribute ref="r:embed" use="required"/>
+    <xsd:attribute name="name" type="xsd:string" use="optional" default=""/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Hyperlink">
+    <xsd:sequence>
+      <xsd:element name="snd" type="CT_EmbeddedWAVAudioFile" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute ref="r:id" use="optional"/>
+    <xsd:attribute name="invalidUrl" type="xsd:string" use="optional" default=""/>
+    <xsd:attribute name="action" type="xsd:string" use="optional" default=""/>
+    <xsd:attribute name="tgtFrame" type="xsd:string" use="optional" default=""/>
+    <xsd:attribute name="tooltip" type="xsd:string" use="optional" default=""/>
+    <xsd:attribute name="history" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="highlightClick" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="endSnd" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_DrawingElementId">
+    <xsd:restriction base="xsd:unsignedInt"/>
+  </xsd:simpleType>
+  <xsd:attributeGroup name="AG_Locking">
+    <xsd:attribute name="noGrp" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="noSelect" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="noRot" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="noChangeAspect" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="noMove" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="noResize" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="noEditPoints" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="noAdjustHandles" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="noChangeArrowheads" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="noChangeShapeType" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:attributeGroup>
+  <xsd:complexType name="CT_ConnectorLocking">
+    <xsd:sequence>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attributeGroup ref="AG_Locking"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ShapeLocking">
+    <xsd:sequence>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attributeGroup ref="AG_Locking"/>
+    <xsd:attribute name="noTextEdit" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PictureLocking">
+    <xsd:sequence>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attributeGroup ref="AG_Locking"/>
+    <xsd:attribute name="noCrop" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GroupLocking">
+    <xsd:sequence>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="noGrp" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="noUngrp" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="noSelect" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="noRot" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="noChangeAspect" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="noMove" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="noResize" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GraphicalObjectFrameLocking">
+    <xsd:sequence>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="noGrp" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="noDrilldown" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="noSelect" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="noChangeAspect" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="noMove" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="noResize" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ContentPartLocking">
+    <xsd:sequence>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attributeGroup ref="AG_Locking"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_NonVisualDrawingProps">
+    <xsd:sequence>
+      <xsd:element name="hlinkClick" type="CT_Hyperlink" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="hlinkHover" type="CT_Hyperlink" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="ST_DrawingElementId" use="required"/>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="descr" type="xsd:string" use="optional" default=""/>
+    <xsd:attribute name="hidden" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="title" type="xsd:string" use="optional" default=""/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_NonVisualDrawingShapeProps">
+    <xsd:sequence>
+      <xsd:element name="spLocks" type="CT_ShapeLocking" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="txBox" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_NonVisualConnectorProperties">
+    <xsd:sequence>
+      <xsd:element name="cxnSpLocks" type="CT_ConnectorLocking" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="stCxn" type="CT_Connection" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="endCxn" type="CT_Connection" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_NonVisualPictureProperties">
+    <xsd:sequence>
+      <xsd:element name="picLocks" type="CT_PictureLocking" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="preferRelativeResize" type="xsd:boolean" use="optional" default="true"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_NonVisualGroupDrawingShapeProps">
+    <xsd:sequence>
+      <xsd:element name="grpSpLocks" type="CT_GroupLocking" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_NonVisualGraphicFrameProperties">
+    <xsd:sequence>
+      <xsd:element name="graphicFrameLocks" type="CT_GraphicalObjectFrameLocking" minOccurs="0"
+        maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_NonVisualContentPartProperties">
+    <xsd:sequence>
+      <xsd:element name="cpLocks" type="CT_ContentPartLocking" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="isComment" type="xsd:boolean" use="optional" default="true"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GraphicalObjectData">
+    <xsd:sequence>
+      <xsd:any minOccurs="0" maxOccurs="unbounded" processContents="strict"/>
+    </xsd:sequence>
+    <xsd:attribute name="uri" type="xsd:token" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GraphicalObject">
+    <xsd:sequence>
+      <xsd:element name="graphicData" type="CT_GraphicalObjectData"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="graphic" type="CT_GraphicalObject"/>
+  <xsd:simpleType name="ST_ChartBuildStep">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="category"/>
+      <xsd:enumeration value="ptInCategory"/>
+      <xsd:enumeration value="series"/>
+      <xsd:enumeration value="ptInSeries"/>
+      <xsd:enumeration value="allPts"/>
+      <xsd:enumeration value="gridLegend"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_DgmBuildStep">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="sp"/>
+      <xsd:enumeration value="bg"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_AnimationDgmElement">
+    <xsd:attribute name="id" type="s:ST_Guid" use="optional"
+      default="{00000000-0000-0000-0000-000000000000}"/>
+    <xsd:attribute name="bldStep" type="ST_DgmBuildStep" use="optional" default="sp"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_AnimationChartElement">
+    <xsd:attribute name="seriesIdx" type="xsd:int" use="optional" default="-1"/>
+    <xsd:attribute name="categoryIdx" type="xsd:int" use="optional" default="-1"/>
+    <xsd:attribute name="bldStep" type="ST_ChartBuildStep" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_AnimationElementChoice">
+    <xsd:choice minOccurs="1" maxOccurs="1">
+      <xsd:element name="dgm" type="CT_AnimationDgmElement"/>
+      <xsd:element name="chart" type="CT_AnimationChartElement"/>
+    </xsd:choice>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_AnimationBuildType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="allAtOnce"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_AnimationDgmOnlyBuildType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="one"/>
+      <xsd:enumeration value="lvlOne"/>
+      <xsd:enumeration value="lvlAtOnce"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_AnimationDgmBuildType">
+    <xsd:union memberTypes="ST_AnimationBuildType ST_AnimationDgmOnlyBuildType"/>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_AnimationDgmBuildProperties">
+    <xsd:attribute name="bld" type="ST_AnimationDgmBuildType" use="optional" default="allAtOnce"/>
+    <xsd:attribute name="rev" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_AnimationChartOnlyBuildType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="series"/>
+      <xsd:enumeration value="category"/>
+      <xsd:enumeration value="seriesEl"/>
+      <xsd:enumeration value="categoryEl"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_AnimationChartBuildType">
+    <xsd:union memberTypes="ST_AnimationBuildType ST_AnimationChartOnlyBuildType"/>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_AnimationChartBuildProperties">
+    <xsd:attribute name="bld" type="ST_AnimationChartBuildType" use="optional" default="allAtOnce"/>
+    <xsd:attribute name="animBg" type="xsd:boolean" use="optional" default="true"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_AnimationGraphicalObjectBuildProperties">
+    <xsd:choice>
+      <xsd:element name="bldDgm" type="CT_AnimationDgmBuildProperties"/>
+      <xsd:element name="bldChart" type="CT_AnimationChartBuildProperties"/>
+    </xsd:choice>
+  </xsd:complexType>
+  <xsd:complexType name="CT_BackgroundFormatting">
+    <xsd:sequence>
+      <xsd:group ref="EG_FillProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:group ref="EG_EffectProperties" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_WholeE2oFormatting">
+    <xsd:sequence>
+      <xsd:element name="ln" type="CT_LineProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:group ref="EG_EffectProperties" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GvmlUseShapeRectangle"/>
+  <xsd:complexType name="CT_GvmlTextShape">
+    <xsd:sequence>
+      <xsd:element name="txBody" type="CT_TextBody" minOccurs="1" maxOccurs="1"/>
+      <xsd:choice>
+        <xsd:element name="useSpRect" type="CT_GvmlUseShapeRectangle" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="xfrm" type="CT_Transform2D" minOccurs="1" maxOccurs="1"/>
+      </xsd:choice>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GvmlShapeNonVisual">
+    <xsd:sequence>
+      <xsd:element name="cNvPr" type="CT_NonVisualDrawingProps" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="cNvSpPr" type="CT_NonVisualDrawingShapeProps" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GvmlShape">
+    <xsd:sequence>
+      <xsd:element name="nvSpPr" type="CT_GvmlShapeNonVisual" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="spPr" type="CT_ShapeProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="txSp" type="CT_GvmlTextShape" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="style" type="CT_ShapeStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GvmlConnectorNonVisual">
+    <xsd:sequence>
+      <xsd:element name="cNvPr" type="CT_NonVisualDrawingProps" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="cNvCxnSpPr" type="CT_NonVisualConnectorProperties" minOccurs="1"
+        maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GvmlConnector">
+    <xsd:sequence>
+      <xsd:element name="nvCxnSpPr" type="CT_GvmlConnectorNonVisual" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="spPr" type="CT_ShapeProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="style" type="CT_ShapeStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GvmlPictureNonVisual">
+    <xsd:sequence>
+      <xsd:element name="cNvPr" type="CT_NonVisualDrawingProps" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="cNvPicPr" type="CT_NonVisualPictureProperties" minOccurs="1" maxOccurs="1"
+      />
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GvmlPicture">
+    <xsd:sequence>
+      <xsd:element name="nvPicPr" type="CT_GvmlPictureNonVisual" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="blipFill" type="CT_BlipFillProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="spPr" type="CT_ShapeProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="style" type="CT_ShapeStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GvmlGraphicFrameNonVisual">
+    <xsd:sequence>
+      <xsd:element name="cNvPr" type="CT_NonVisualDrawingProps" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="cNvGraphicFramePr" type="CT_NonVisualGraphicFrameProperties" minOccurs="1"
+        maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GvmlGraphicalObjectFrame">
+    <xsd:sequence>
+      <xsd:element name="nvGraphicFramePr" type="CT_GvmlGraphicFrameNonVisual" minOccurs="1"
+        maxOccurs="1"/>
+      <xsd:element ref="graphic" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="xfrm" type="CT_Transform2D" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GvmlGroupShapeNonVisual">
+    <xsd:sequence>
+      <xsd:element name="cNvPr" type="CT_NonVisualDrawingProps" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="cNvGrpSpPr" type="CT_NonVisualGroupDrawingShapeProps" minOccurs="1"
+        maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GvmlGroupShape">
+    <xsd:sequence>
+      <xsd:element name="nvGrpSpPr" type="CT_GvmlGroupShapeNonVisual" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="grpSpPr" type="CT_GroupShapeProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:choice minOccurs="0" maxOccurs="unbounded">
+        <xsd:element name="txSp" type="CT_GvmlTextShape"/>
+        <xsd:element name="sp" type="CT_GvmlShape"/>
+        <xsd:element name="cxnSp" type="CT_GvmlConnector"/>
+        <xsd:element name="pic" type="CT_GvmlPicture"/>
+        <xsd:element name="graphicFrame" type="CT_GvmlGraphicalObjectFrame"/>
+        <xsd:element name="grpSp" type="CT_GvmlGroupShape"/>
+      </xsd:choice>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_PresetCameraType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="legacyObliqueTopLeft"/>
+      <xsd:enumeration value="legacyObliqueTop"/>
+      <xsd:enumeration value="legacyObliqueTopRight"/>
+      <xsd:enumeration value="legacyObliqueLeft"/>
+      <xsd:enumeration value="legacyObliqueFront"/>
+      <xsd:enumeration value="legacyObliqueRight"/>
+      <xsd:enumeration value="legacyObliqueBottomLeft"/>
+      <xsd:enumeration value="legacyObliqueBottom"/>
+      <xsd:enumeration value="legacyObliqueBottomRight"/>
+      <xsd:enumeration value="legacyPerspectiveTopLeft"/>
+      <xsd:enumeration value="legacyPerspectiveTop"/>
+      <xsd:enumeration value="legacyPerspectiveTopRight"/>
+      <xsd:enumeration value="legacyPerspectiveLeft"/>
+      <xsd:enumeration value="legacyPerspectiveFront"/>
+      <xsd:enumeration value="legacyPerspectiveRight"/>
+      <xsd:enumeration value="legacyPerspectiveBottomLeft"/>
+      <xsd:enumeration value="legacyPerspectiveBottom"/>
+      <xsd:enumeration value="legacyPerspectiveBottomRight"/>
+      <xsd:enumeration value="orthographicFront"/>
+      <xsd:enumeration value="isometricTopUp"/>
+      <xsd:enumeration value="isometricTopDown"/>
+      <xsd:enumeration value="isometricBottomUp"/>
+      <xsd:enumeration value="isometricBottomDown"/>
+      <xsd:enumeration value="isometricLeftUp"/>
+      <xsd:enumeration value="isometricLeftDown"/>
+      <xsd:enumeration value="isometricRightUp"/>
+      <xsd:enumeration value="isometricRightDown"/>
+      <xsd:enumeration value="isometricOffAxis1Left"/>
+      <xsd:enumeration value="isometricOffAxis1Right"/>
+      <xsd:enumeration value="isometricOffAxis1Top"/>
+      <xsd:enumeration value="isometricOffAxis2Left"/>
+      <xsd:enumeration value="isometricOffAxis2Right"/>
+      <xsd:enumeration value="isometricOffAxis2Top"/>
+      <xsd:enumeration value="isometricOffAxis3Left"/>
+      <xsd:enumeration value="isometricOffAxis3Right"/>
+      <xsd:enumeration value="isometricOffAxis3Bottom"/>
+      <xsd:enumeration value="isometricOffAxis4Left"/>
+      <xsd:enumeration value="isometricOffAxis4Right"/>
+      <xsd:enumeration value="isometricOffAxis4Bottom"/>
+      <xsd:enumeration value="obliqueTopLeft"/>
+      <xsd:enumeration value="obliqueTop"/>
+      <xsd:enumeration value="obliqueTopRight"/>
+      <xsd:enumeration value="obliqueLeft"/>
+      <xsd:enumeration value="obliqueRight"/>
+      <xsd:enumeration value="obliqueBottomLeft"/>
+      <xsd:enumeration value="obliqueBottom"/>
+      <xsd:enumeration value="obliqueBottomRight"/>
+      <xsd:enumeration value="perspectiveFront"/>
+      <xsd:enumeration value="perspectiveLeft"/>
+      <xsd:enumeration value="perspectiveRight"/>
+      <xsd:enumeration value="perspectiveAbove"/>
+      <xsd:enumeration value="perspectiveBelow"/>
+      <xsd:enumeration value="perspectiveAboveLeftFacing"/>
+      <xsd:enumeration value="perspectiveAboveRightFacing"/>
+      <xsd:enumeration value="perspectiveContrastingLeftFacing"/>
+      <xsd:enumeration value="perspectiveContrastingRightFacing"/>
+      <xsd:enumeration value="perspectiveHeroicLeftFacing"/>
+      <xsd:enumeration value="perspectiveHeroicRightFacing"/>
+      <xsd:enumeration value="perspectiveHeroicExtremeLeftFacing"/>
+      <xsd:enumeration value="perspectiveHeroicExtremeRightFacing"/>
+      <xsd:enumeration value="perspectiveRelaxed"/>
+      <xsd:enumeration value="perspectiveRelaxedModerately"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_FOVAngle">
+    <xsd:restriction base="ST_Angle">
+      <xsd:minInclusive value="0"/>
+      <xsd:maxInclusive value="10800000"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Camera">
+    <xsd:sequence>
+      <xsd:element name="rot" type="CT_SphereCoords" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="prst" type="ST_PresetCameraType" use="required"/>
+    <xsd:attribute name="fov" type="ST_FOVAngle" use="optional"/>
+    <xsd:attribute name="zoom" type="ST_PositivePercentage" use="optional" default="100%"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_LightRigDirection">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="tl"/>
+      <xsd:enumeration value="t"/>
+      <xsd:enumeration value="tr"/>
+      <xsd:enumeration value="l"/>
+      <xsd:enumeration value="r"/>
+      <xsd:enumeration value="bl"/>
+      <xsd:enumeration value="b"/>
+      <xsd:enumeration value="br"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_LightRigType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="legacyFlat1"/>
+      <xsd:enumeration value="legacyFlat2"/>
+      <xsd:enumeration value="legacyFlat3"/>
+      <xsd:enumeration value="legacyFlat4"/>
+      <xsd:enumeration value="legacyNormal1"/>
+      <xsd:enumeration value="legacyNormal2"/>
+      <xsd:enumeration value="legacyNormal3"/>
+      <xsd:enumeration value="legacyNormal4"/>
+      <xsd:enumeration value="legacyHarsh1"/>
+      <xsd:enumeration value="legacyHarsh2"/>
+      <xsd:enumeration value="legacyHarsh3"/>
+      <xsd:enumeration value="legacyHarsh4"/>
+      <xsd:enumeration value="threePt"/>
+      <xsd:enumeration value="balanced"/>
+      <xsd:enumeration value="soft"/>
+      <xsd:enumeration value="harsh"/>
+      <xsd:enumeration value="flood"/>
+      <xsd:enumeration value="contrasting"/>
+      <xsd:enumeration value="morning"/>
+      <xsd:enumeration value="sunrise"/>
+      <xsd:enumeration value="sunset"/>
+      <xsd:enumeration value="chilly"/>
+      <xsd:enumeration value="freezing"/>
+      <xsd:enumeration value="flat"/>
+      <xsd:enumeration value="twoPt"/>
+      <xsd:enumeration value="glow"/>
+      <xsd:enumeration value="brightRoom"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_LightRig">
+    <xsd:sequence>
+      <xsd:element name="rot" type="CT_SphereCoords" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="rig" type="ST_LightRigType" use="required"/>
+    <xsd:attribute name="dir" type="ST_LightRigDirection" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Scene3D">
+    <xsd:sequence>
+      <xsd:element name="camera" type="CT_Camera" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="lightRig" type="CT_LightRig" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="backdrop" type="CT_Backdrop" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Backdrop">
+    <xsd:sequence>
+      <xsd:element name="anchor" type="CT_Point3D" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="norm" type="CT_Vector3D" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="up" type="CT_Vector3D" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_BevelPresetType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="relaxedInset"/>
+      <xsd:enumeration value="circle"/>
+      <xsd:enumeration value="slope"/>
+      <xsd:enumeration value="cross"/>
+      <xsd:enumeration value="angle"/>
+      <xsd:enumeration value="softRound"/>
+      <xsd:enumeration value="convex"/>
+      <xsd:enumeration value="coolSlant"/>
+      <xsd:enumeration value="divot"/>
+      <xsd:enumeration value="riblet"/>
+      <xsd:enumeration value="hardEdge"/>
+      <xsd:enumeration value="artDeco"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Bevel">
+    <xsd:attribute name="w" type="ST_PositiveCoordinate" use="optional" default="76200"/>
+    <xsd:attribute name="h" type="ST_PositiveCoordinate" use="optional" default="76200"/>
+    <xsd:attribute name="prst" type="ST_BevelPresetType" use="optional" default="circle"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_PresetMaterialType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="legacyMatte"/>
+      <xsd:enumeration value="legacyPlastic"/>
+      <xsd:enumeration value="legacyMetal"/>
+      <xsd:enumeration value="legacyWireframe"/>
+      <xsd:enumeration value="matte"/>
+      <xsd:enumeration value="plastic"/>
+      <xsd:enumeration value="metal"/>
+      <xsd:enumeration value="warmMatte"/>
+      <xsd:enumeration value="translucentPowder"/>
+      <xsd:enumeration value="powder"/>
+      <xsd:enumeration value="dkEdge"/>
+      <xsd:enumeration value="softEdge"/>
+      <xsd:enumeration value="clear"/>
+      <xsd:enumeration value="flat"/>
+      <xsd:enumeration value="softmetal"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Shape3D">
+    <xsd:sequence>
+      <xsd:element name="bevelT" type="CT_Bevel" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="bevelB" type="CT_Bevel" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extrusionClr" type="CT_Color" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="contourClr" type="CT_Color" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="z" type="ST_Coordinate" use="optional" default="0"/>
+    <xsd:attribute name="extrusionH" type="ST_PositiveCoordinate" use="optional" default="0"/>
+    <xsd:attribute name="contourW" type="ST_PositiveCoordinate" use="optional" default="0"/>
+    <xsd:attribute name="prstMaterial" type="ST_PresetMaterialType" use="optional"
+      default="warmMatte"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_FlatText">
+    <xsd:attribute name="z" type="ST_Coordinate" use="optional" default="0"/>
+  </xsd:complexType>
+  <xsd:group name="EG_Text3D">
+    <xsd:choice>
+      <xsd:element name="sp3d" type="CT_Shape3D" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="flatTx" type="CT_FlatText" minOccurs="1" maxOccurs="1"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:complexType name="CT_AlphaBiLevelEffect">
+    <xsd:attribute name="thresh" type="ST_PositiveFixedPercentage" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_AlphaCeilingEffect"/>
+  <xsd:complexType name="CT_AlphaFloorEffect"/>
+  <xsd:complexType name="CT_AlphaInverseEffect">
+    <xsd:sequence>
+      <xsd:group ref="EG_ColorChoice" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_AlphaModulateFixedEffect">
+    <xsd:attribute name="amt" type="ST_PositivePercentage" use="optional" default="100%"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_AlphaOutsetEffect">
+    <xsd:attribute name="rad" type="ST_Coordinate" use="optional" default="0"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_AlphaReplaceEffect">
+    <xsd:attribute name="a" type="ST_PositiveFixedPercentage" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_BiLevelEffect">
+    <xsd:attribute name="thresh" type="ST_PositiveFixedPercentage" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_BlurEffect">
+    <xsd:attribute name="rad" type="ST_PositiveCoordinate" use="optional" default="0"/>
+    <xsd:attribute name="grow" type="xsd:boolean" use="optional" default="true"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ColorChangeEffect">
+    <xsd:sequence>
+      <xsd:element name="clrFrom" type="CT_Color" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="clrTo" type="CT_Color" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="useA" type="xsd:boolean" use="optional" default="true"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ColorReplaceEffect">
+    <xsd:sequence>
+      <xsd:group ref="EG_ColorChoice" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DuotoneEffect">
+    <xsd:sequence>
+      <xsd:group ref="EG_ColorChoice" minOccurs="2" maxOccurs="2"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GlowEffect">
+    <xsd:sequence>
+      <xsd:group ref="EG_ColorChoice" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="rad" type="ST_PositiveCoordinate" use="optional" default="0"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GrayscaleEffect"/>
+  <xsd:complexType name="CT_HSLEffect">
+    <xsd:attribute name="hue" type="ST_PositiveFixedAngle" use="optional" default="0"/>
+    <xsd:attribute name="sat" type="ST_FixedPercentage" use="optional" default="0%"/>
+    <xsd:attribute name="lum" type="ST_FixedPercentage" use="optional" default="0%"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_InnerShadowEffect">
+    <xsd:sequence>
+      <xsd:group ref="EG_ColorChoice" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="blurRad" type="ST_PositiveCoordinate" use="optional" default="0"/>
+    <xsd:attribute name="dist" type="ST_PositiveCoordinate" use="optional" default="0"/>
+    <xsd:attribute name="dir" type="ST_PositiveFixedAngle" use="optional" default="0"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_LuminanceEffect">
+    <xsd:attribute name="bright" type="ST_FixedPercentage" use="optional" default="0%"/>
+    <xsd:attribute name="contrast" type="ST_FixedPercentage" use="optional" default="0%"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_OuterShadowEffect">
+    <xsd:sequence>
+      <xsd:group ref="EG_ColorChoice" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="blurRad" type="ST_PositiveCoordinate" use="optional" default="0"/>
+    <xsd:attribute name="dist" type="ST_PositiveCoordinate" use="optional" default="0"/>
+    <xsd:attribute name="dir" type="ST_PositiveFixedAngle" use="optional" default="0"/>
+    <xsd:attribute name="sx" type="ST_Percentage" use="optional" default="100%"/>
+    <xsd:attribute name="sy" type="ST_Percentage" use="optional" default="100%"/>
+    <xsd:attribute name="kx" type="ST_FixedAngle" use="optional" default="0"/>
+    <xsd:attribute name="ky" type="ST_FixedAngle" use="optional" default="0"/>
+    <xsd:attribute name="algn" type="ST_RectAlignment" use="optional" default="b"/>
+    <xsd:attribute name="rotWithShape" type="xsd:boolean" use="optional" default="true"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_PresetShadowVal">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="shdw1"/>
+      <xsd:enumeration value="shdw2"/>
+      <xsd:enumeration value="shdw3"/>
+      <xsd:enumeration value="shdw4"/>
+      <xsd:enumeration value="shdw5"/>
+      <xsd:enumeration value="shdw6"/>
+      <xsd:enumeration value="shdw7"/>
+      <xsd:enumeration value="shdw8"/>
+      <xsd:enumeration value="shdw9"/>
+      <xsd:enumeration value="shdw10"/>
+      <xsd:enumeration value="shdw11"/>
+      <xsd:enumeration value="shdw12"/>
+      <xsd:enumeration value="shdw13"/>
+      <xsd:enumeration value="shdw14"/>
+      <xsd:enumeration value="shdw15"/>
+      <xsd:enumeration value="shdw16"/>
+      <xsd:enumeration value="shdw17"/>
+      <xsd:enumeration value="shdw18"/>
+      <xsd:enumeration value="shdw19"/>
+      <xsd:enumeration value="shdw20"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_PresetShadowEffect">
+    <xsd:sequence>
+      <xsd:group ref="EG_ColorChoice" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="prst" type="ST_PresetShadowVal" use="required"/>
+    <xsd:attribute name="dist" type="ST_PositiveCoordinate" use="optional" default="0"/>
+    <xsd:attribute name="dir" type="ST_PositiveFixedAngle" use="optional" default="0"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ReflectionEffect">
+    <xsd:attribute name="blurRad" type="ST_PositiveCoordinate" use="optional" default="0"/>
+    <xsd:attribute name="stA" type="ST_PositiveFixedPercentage" use="optional" default="100%"/>
+    <xsd:attribute name="stPos" type="ST_PositiveFixedPercentage" use="optional" default="0%"/>
+    <xsd:attribute name="endA" type="ST_PositiveFixedPercentage" use="optional" default="0%"/>
+    <xsd:attribute name="endPos" type="ST_PositiveFixedPercentage" use="optional" default="100%"/>
+    <xsd:attribute name="dist" type="ST_PositiveCoordinate" use="optional" default="0"/>
+    <xsd:attribute name="dir" type="ST_PositiveFixedAngle" use="optional" default="0"/>
+    <xsd:attribute name="fadeDir" type="ST_PositiveFixedAngle" use="optional" default="5400000"/>
+    <xsd:attribute name="sx" type="ST_Percentage" use="optional" default="100%"/>
+    <xsd:attribute name="sy" type="ST_Percentage" use="optional" default="100%"/>
+    <xsd:attribute name="kx" type="ST_FixedAngle" use="optional" default="0"/>
+    <xsd:attribute name="ky" type="ST_FixedAngle" use="optional" default="0"/>
+    <xsd:attribute name="algn" type="ST_RectAlignment" use="optional" default="b"/>
+    <xsd:attribute name="rotWithShape" type="xsd:boolean" use="optional" default="true"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_RelativeOffsetEffect">
+    <xsd:attribute name="tx" type="ST_Percentage" use="optional" default="0%"/>
+    <xsd:attribute name="ty" type="ST_Percentage" use="optional" default="0%"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SoftEdgesEffect">
+    <xsd:attribute name="rad" type="ST_PositiveCoordinate" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TintEffect">
+    <xsd:attribute name="hue" type="ST_PositiveFixedAngle" use="optional" default="0"/>
+    <xsd:attribute name="amt" type="ST_FixedPercentage" use="optional" default="0%"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TransformEffect">
+    <xsd:attribute name="sx" type="ST_Percentage" use="optional" default="100%"/>
+    <xsd:attribute name="sy" type="ST_Percentage" use="optional" default="100%"/>
+    <xsd:attribute name="kx" type="ST_FixedAngle" use="optional" default="0"/>
+    <xsd:attribute name="ky" type="ST_FixedAngle" use="optional" default="0"/>
+    <xsd:attribute name="tx" type="ST_Coordinate" use="optional" default="0"/>
+    <xsd:attribute name="ty" type="ST_Coordinate" use="optional" default="0"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_NoFillProperties"/>
+  <xsd:complexType name="CT_SolidColorFillProperties">
+    <xsd:sequence>
+      <xsd:group ref="EG_ColorChoice" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_LinearShadeProperties">
+    <xsd:attribute name="ang" type="ST_PositiveFixedAngle" use="optional"/>
+    <xsd:attribute name="scaled" type="xsd:boolean" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_PathShadeType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="shape"/>
+      <xsd:enumeration value="circle"/>
+      <xsd:enumeration value="rect"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_PathShadeProperties">
+    <xsd:sequence>
+      <xsd:element name="fillToRect" type="CT_RelativeRect" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="path" type="ST_PathShadeType" use="optional"/>
+  </xsd:complexType>
+  <xsd:group name="EG_ShadeProperties">
+    <xsd:choice>
+      <xsd:element name="lin" type="CT_LinearShadeProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="path" type="CT_PathShadeProperties" minOccurs="1" maxOccurs="1"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:simpleType name="ST_TileFlipMode">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="x"/>
+      <xsd:enumeration value="y"/>
+      <xsd:enumeration value="xy"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_GradientStop">
+    <xsd:sequence>
+      <xsd:group ref="EG_ColorChoice" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="pos" type="ST_PositiveFixedPercentage" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GradientStopList">
+    <xsd:sequence>
+      <xsd:element name="gs" type="CT_GradientStop" minOccurs="2" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GradientFillProperties">
+    <xsd:sequence>
+      <xsd:element name="gsLst" type="CT_GradientStopList" minOccurs="0" maxOccurs="1"/>
+      <xsd:group ref="EG_ShadeProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tileRect" type="CT_RelativeRect" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="flip" type="ST_TileFlipMode" use="optional" default="none"/>
+    <xsd:attribute name="rotWithShape" type="xsd:boolean" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TileInfoProperties">
+    <xsd:attribute name="tx" type="ST_Coordinate" use="optional"/>
+    <xsd:attribute name="ty" type="ST_Coordinate" use="optional"/>
+    <xsd:attribute name="sx" type="ST_Percentage" use="optional"/>
+    <xsd:attribute name="sy" type="ST_Percentage" use="optional"/>
+    <xsd:attribute name="flip" type="ST_TileFlipMode" use="optional" default="none"/>
+    <xsd:attribute name="algn" type="ST_RectAlignment" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_StretchInfoProperties">
+    <xsd:sequence>
+      <xsd:element name="fillRect" type="CT_RelativeRect" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:group name="EG_FillModeProperties">
+    <xsd:choice>
+      <xsd:element name="tile" type="CT_TileInfoProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="stretch" type="CT_StretchInfoProperties" minOccurs="1" maxOccurs="1"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:simpleType name="ST_BlipCompression">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="email"/>
+      <xsd:enumeration value="screen"/>
+      <xsd:enumeration value="print"/>
+      <xsd:enumeration value="hqprint"/>
+      <xsd:enumeration value="none"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Blip">
+    <xsd:sequence>
+      <xsd:choice minOccurs="0" maxOccurs="unbounded">
+        <xsd:element name="alphaBiLevel" type="CT_AlphaBiLevelEffect" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="alphaCeiling" type="CT_AlphaCeilingEffect" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="alphaFloor" type="CT_AlphaFloorEffect" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="alphaInv" type="CT_AlphaInverseEffect" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="alphaMod" type="CT_AlphaModulateEffect" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="alphaModFix" type="CT_AlphaModulateFixedEffect" minOccurs="1"
+          maxOccurs="1"/>
+        <xsd:element name="alphaRepl" type="CT_AlphaReplaceEffect" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="biLevel" type="CT_BiLevelEffect" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="blur" type="CT_BlurEffect" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="clrChange" type="CT_ColorChangeEffect" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="clrRepl" type="CT_ColorReplaceEffect" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="duotone" type="CT_DuotoneEffect" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="fillOverlay" type="CT_FillOverlayEffect" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="grayscl" type="CT_GrayscaleEffect" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="hsl" type="CT_HSLEffect" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="lum" type="CT_LuminanceEffect" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="tint" type="CT_TintEffect" minOccurs="1" maxOccurs="1"/>
+      </xsd:choice>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attributeGroup ref="AG_Blob"/>
+    <xsd:attribute name="cstate" type="ST_BlipCompression" use="optional" default="none"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_BlipFillProperties">
+    <xsd:sequence>
+      <xsd:element name="blip" type="CT_Blip" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="srcRect" type="CT_RelativeRect" minOccurs="0" maxOccurs="1"/>
+      <xsd:group ref="EG_FillModeProperties" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="dpi" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="rotWithShape" type="xsd:boolean" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_PresetPatternVal">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="pct5"/>
+      <xsd:enumeration value="pct10"/>
+      <xsd:enumeration value="pct20"/>
+      <xsd:enumeration value="pct25"/>
+      <xsd:enumeration value="pct30"/>
+      <xsd:enumeration value="pct40"/>
+      <xsd:enumeration value="pct50"/>
+      <xsd:enumeration value="pct60"/>
+      <xsd:enumeration value="pct70"/>
+      <xsd:enumeration value="pct75"/>
+      <xsd:enumeration value="pct80"/>
+      <xsd:enumeration value="pct90"/>
+      <xsd:enumeration value="horz"/>
+      <xsd:enumeration value="vert"/>
+      <xsd:enumeration value="ltHorz"/>
+      <xsd:enumeration value="ltVert"/>
+      <xsd:enumeration value="dkHorz"/>
+      <xsd:enumeration value="dkVert"/>
+      <xsd:enumeration value="narHorz"/>
+      <xsd:enumeration value="narVert"/>
+      <xsd:enumeration value="dashHorz"/>
+      <xsd:enumeration value="dashVert"/>
+      <xsd:enumeration value="cross"/>
+      <xsd:enumeration value="dnDiag"/>
+      <xsd:enumeration value="upDiag"/>
+      <xsd:enumeration value="ltDnDiag"/>
+      <xsd:enumeration value="ltUpDiag"/>
+      <xsd:enumeration value="dkDnDiag"/>
+      <xsd:enumeration value="dkUpDiag"/>
+      <xsd:enumeration value="wdDnDiag"/>
+      <xsd:enumeration value="wdUpDiag"/>
+      <xsd:enumeration value="dashDnDiag"/>
+      <xsd:enumeration value="dashUpDiag"/>
+      <xsd:enumeration value="diagCross"/>
+      <xsd:enumeration value="smCheck"/>
+      <xsd:enumeration value="lgCheck"/>
+      <xsd:enumeration value="smGrid"/>
+      <xsd:enumeration value="lgGrid"/>
+      <xsd:enumeration value="dotGrid"/>
+      <xsd:enumeration value="smConfetti"/>
+      <xsd:enumeration value="lgConfetti"/>
+      <xsd:enumeration value="horzBrick"/>
+      <xsd:enumeration value="diagBrick"/>
+      <xsd:enumeration value="solidDmnd"/>
+      <xsd:enumeration value="openDmnd"/>
+      <xsd:enumeration value="dotDmnd"/>
+      <xsd:enumeration value="plaid"/>
+      <xsd:enumeration value="sphere"/>
+      <xsd:enumeration value="weave"/>
+      <xsd:enumeration value="divot"/>
+      <xsd:enumeration value="shingle"/>
+      <xsd:enumeration value="wave"/>
+      <xsd:enumeration value="trellis"/>
+      <xsd:enumeration value="zigZag"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_PatternFillProperties">
+    <xsd:sequence>
+      <xsd:element name="fgClr" type="CT_Color" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="bgClr" type="CT_Color" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="prst" type="ST_PresetPatternVal" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GroupFillProperties"/>
+  <xsd:group name="EG_FillProperties">
+    <xsd:choice>
+      <xsd:element name="noFill" type="CT_NoFillProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="solidFill" type="CT_SolidColorFillProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="gradFill" type="CT_GradientFillProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="blipFill" type="CT_BlipFillProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="pattFill" type="CT_PatternFillProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="grpFill" type="CT_GroupFillProperties" minOccurs="1" maxOccurs="1"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:complexType name="CT_FillProperties">
+    <xsd:sequence>
+      <xsd:group ref="EG_FillProperties" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_FillEffect">
+    <xsd:sequence>
+      <xsd:group ref="EG_FillProperties" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_BlendMode">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="over"/>
+      <xsd:enumeration value="mult"/>
+      <xsd:enumeration value="screen"/>
+      <xsd:enumeration value="darken"/>
+      <xsd:enumeration value="lighten"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_FillOverlayEffect">
+    <xsd:sequence>
+      <xsd:group ref="EG_FillProperties" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="blend" type="ST_BlendMode" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_EffectReference">
+    <xsd:attribute name="ref" type="xsd:token" use="required"/>
+  </xsd:complexType>
+  <xsd:group name="EG_Effect">
+    <xsd:choice>
+      <xsd:element name="cont" type="CT_EffectContainer" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="effect" type="CT_EffectReference" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="alphaBiLevel" type="CT_AlphaBiLevelEffect" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="alphaCeiling" type="CT_AlphaCeilingEffect" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="alphaFloor" type="CT_AlphaFloorEffect" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="alphaInv" type="CT_AlphaInverseEffect" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="alphaMod" type="CT_AlphaModulateEffect" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="alphaModFix" type="CT_AlphaModulateFixedEffect" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="alphaOutset" type="CT_AlphaOutsetEffect" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="alphaRepl" type="CT_AlphaReplaceEffect" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="biLevel" type="CT_BiLevelEffect" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="blend" type="CT_BlendEffect" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="blur" type="CT_BlurEffect" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="clrChange" type="CT_ColorChangeEffect" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="clrRepl" type="CT_ColorReplaceEffect" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="duotone" type="CT_DuotoneEffect" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="fill" type="CT_FillEffect" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="fillOverlay" type="CT_FillOverlayEffect" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="glow" type="CT_GlowEffect" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="grayscl" type="CT_GrayscaleEffect" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="hsl" type="CT_HSLEffect" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="innerShdw" type="CT_InnerShadowEffect" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="lum" type="CT_LuminanceEffect" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="outerShdw" type="CT_OuterShadowEffect" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="prstShdw" type="CT_PresetShadowEffect" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="reflection" type="CT_ReflectionEffect" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="relOff" type="CT_RelativeOffsetEffect" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="softEdge" type="CT_SoftEdgesEffect" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="tint" type="CT_TintEffect" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="xfrm" type="CT_TransformEffect" minOccurs="1" maxOccurs="1"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:simpleType name="ST_EffectContainerType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="sib"/>
+      <xsd:enumeration value="tree"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_EffectContainer">
+    <xsd:group ref="EG_Effect" minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:attribute name="type" type="ST_EffectContainerType" use="optional" default="sib"/>
+    <xsd:attribute name="name" type="xsd:token" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_AlphaModulateEffect">
+    <xsd:sequence>
+      <xsd:element name="cont" type="CT_EffectContainer" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_BlendEffect">
+    <xsd:sequence>
+      <xsd:element name="cont" type="CT_EffectContainer" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="blend" type="ST_BlendMode" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_EffectList">
+    <xsd:sequence>
+      <xsd:element name="blur" type="CT_BlurEffect" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="fillOverlay" type="CT_FillOverlayEffect" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="glow" type="CT_GlowEffect" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="innerShdw" type="CT_InnerShadowEffect" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="outerShdw" type="CT_OuterShadowEffect" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="prstShdw" type="CT_PresetShadowEffect" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="reflection" type="CT_ReflectionEffect" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="softEdge" type="CT_SoftEdgesEffect" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:group name="EG_EffectProperties">
+    <xsd:choice>
+      <xsd:element name="effectLst" type="CT_EffectList" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="effectDag" type="CT_EffectContainer" minOccurs="1" maxOccurs="1"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:complexType name="CT_EffectProperties">
+    <xsd:sequence>
+      <xsd:group ref="EG_EffectProperties" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="blip" type="CT_Blip"/>
+  <xsd:simpleType name="ST_ShapeType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="line"/>
+      <xsd:enumeration value="lineInv"/>
+      <xsd:enumeration value="triangle"/>
+      <xsd:enumeration value="rtTriangle"/>
+      <xsd:enumeration value="rect"/>
+      <xsd:enumeration value="diamond"/>
+      <xsd:enumeration value="parallelogram"/>
+      <xsd:enumeration value="trapezoid"/>
+      <xsd:enumeration value="nonIsoscelesTrapezoid"/>
+      <xsd:enumeration value="pentagon"/>
+      <xsd:enumeration value="hexagon"/>
+      <xsd:enumeration value="heptagon"/>
+      <xsd:enumeration value="octagon"/>
+      <xsd:enumeration value="decagon"/>
+      <xsd:enumeration value="dodecagon"/>
+      <xsd:enumeration value="star4"/>
+      <xsd:enumeration value="star5"/>
+      <xsd:enumeration value="star6"/>
+      <xsd:enumeration value="star7"/>
+      <xsd:enumeration value="star8"/>
+      <xsd:enumeration value="star10"/>
+      <xsd:enumeration value="star12"/>
+      <xsd:enumeration value="star16"/>
+      <xsd:enumeration value="star24"/>
+      <xsd:enumeration value="star32"/>
+      <xsd:enumeration value="roundRect"/>
+      <xsd:enumeration value="round1Rect"/>
+      <xsd:enumeration value="round2SameRect"/>
+      <xsd:enumeration value="round2DiagRect"/>
+      <xsd:enumeration value="snipRoundRect"/>
+      <xsd:enumeration value="snip1Rect"/>
+      <xsd:enumeration value="snip2SameRect"/>
+      <xsd:enumeration value="snip2DiagRect"/>
+      <xsd:enumeration value="plaque"/>
+      <xsd:enumeration value="ellipse"/>
+      <xsd:enumeration value="teardrop"/>
+      <xsd:enumeration value="homePlate"/>
+      <xsd:enumeration value="chevron"/>
+      <xsd:enumeration value="pieWedge"/>
+      <xsd:enumeration value="pie"/>
+      <xsd:enumeration value="blockArc"/>
+      <xsd:enumeration value="donut"/>
+      <xsd:enumeration value="noSmoking"/>
+      <xsd:enumeration value="rightArrow"/>
+      <xsd:enumeration value="leftArrow"/>
+      <xsd:enumeration value="upArrow"/>
+      <xsd:enumeration value="downArrow"/>
+      <xsd:enumeration value="stripedRightArrow"/>
+      <xsd:enumeration value="notchedRightArrow"/>
+      <xsd:enumeration value="bentUpArrow"/>
+      <xsd:enumeration value="leftRightArrow"/>
+      <xsd:enumeration value="upDownArrow"/>
+      <xsd:enumeration value="leftUpArrow"/>
+      <xsd:enumeration value="leftRightUpArrow"/>
+      <xsd:enumeration value="quadArrow"/>
+      <xsd:enumeration value="leftArrowCallout"/>
+      <xsd:enumeration value="rightArrowCallout"/>
+      <xsd:enumeration value="upArrowCallout"/>
+      <xsd:enumeration value="downArrowCallout"/>
+      <xsd:enumeration value="leftRightArrowCallout"/>
+      <xsd:enumeration value="upDownArrowCallout"/>
+      <xsd:enumeration value="quadArrowCallout"/>
+      <xsd:enumeration value="bentArrow"/>
+      <xsd:enumeration value="uturnArrow"/>
+      <xsd:enumeration value="circularArrow"/>
+      <xsd:enumeration value="leftCircularArrow"/>
+      <xsd:enumeration value="leftRightCircularArrow"/>
+      <xsd:enumeration value="curvedRightArrow"/>
+      <xsd:enumeration value="curvedLeftArrow"/>
+      <xsd:enumeration value="curvedUpArrow"/>
+      <xsd:enumeration value="curvedDownArrow"/>
+      <xsd:enumeration value="swooshArrow"/>
+      <xsd:enumeration value="cube"/>
+      <xsd:enumeration value="can"/>
+      <xsd:enumeration value="lightningBolt"/>
+      <xsd:enumeration value="heart"/>
+      <xsd:enumeration value="sun"/>
+      <xsd:enumeration value="moon"/>
+      <xsd:enumeration value="smileyFace"/>
+      <xsd:enumeration value="irregularSeal1"/>
+      <xsd:enumeration value="irregularSeal2"/>
+      <xsd:enumeration value="foldedCorner"/>
+      <xsd:enumeration value="bevel"/>
+      <xsd:enumeration value="frame"/>
+      <xsd:enumeration value="halfFrame"/>
+      <xsd:enumeration value="corner"/>
+      <xsd:enumeration value="diagStripe"/>
+      <xsd:enumeration value="chord"/>
+      <xsd:enumeration value="arc"/>
+      <xsd:enumeration value="leftBracket"/>
+      <xsd:enumeration value="rightBracket"/>
+      <xsd:enumeration value="leftBrace"/>
+      <xsd:enumeration value="rightBrace"/>
+      <xsd:enumeration value="bracketPair"/>
+      <xsd:enumeration value="bracePair"/>
+      <xsd:enumeration value="straightConnector1"/>
+      <xsd:enumeration value="bentConnector2"/>
+      <xsd:enumeration value="bentConnector3"/>
+      <xsd:enumeration value="bentConnector4"/>
+      <xsd:enumeration value="bentConnector5"/>
+      <xsd:enumeration value="curvedConnector2"/>
+      <xsd:enumeration value="curvedConnector3"/>
+      <xsd:enumeration value="curvedConnector4"/>
+      <xsd:enumeration value="curvedConnector5"/>
+      <xsd:enumeration value="callout1"/>
+      <xsd:enumeration value="callout2"/>
+      <xsd:enumeration value="callout3"/>
+      <xsd:enumeration value="accentCallout1"/>
+      <xsd:enumeration value="accentCallout2"/>
+      <xsd:enumeration value="accentCallout3"/>
+      <xsd:enumeration value="borderCallout1"/>
+      <xsd:enumeration value="borderCallout2"/>
+      <xsd:enumeration value="borderCallout3"/>
+      <xsd:enumeration value="accentBorderCallout1"/>
+      <xsd:enumeration value="accentBorderCallout2"/>
+      <xsd:enumeration value="accentBorderCallout3"/>
+      <xsd:enumeration value="wedgeRectCallout"/>
+      <xsd:enumeration value="wedgeRoundRectCallout"/>
+      <xsd:enumeration value="wedgeEllipseCallout"/>
+      <xsd:enumeration value="cloudCallout"/>
+      <xsd:enumeration value="cloud"/>
+      <xsd:enumeration value="ribbon"/>
+      <xsd:enumeration value="ribbon2"/>
+      <xsd:enumeration value="ellipseRibbon"/>
+      <xsd:enumeration value="ellipseRibbon2"/>
+      <xsd:enumeration value="leftRightRibbon"/>
+      <xsd:enumeration value="verticalScroll"/>
+      <xsd:enumeration value="horizontalScroll"/>
+      <xsd:enumeration value="wave"/>
+      <xsd:enumeration value="doubleWave"/>
+      <xsd:enumeration value="plus"/>
+      <xsd:enumeration value="flowChartProcess"/>
+      <xsd:enumeration value="flowChartDecision"/>
+      <xsd:enumeration value="flowChartInputOutput"/>
+      <xsd:enumeration value="flowChartPredefinedProcess"/>
+      <xsd:enumeration value="flowChartInternalStorage"/>
+      <xsd:enumeration value="flowChartDocument"/>
+      <xsd:enumeration value="flowChartMultidocument"/>
+      <xsd:enumeration value="flowChartTerminator"/>
+      <xsd:enumeration value="flowChartPreparation"/>
+      <xsd:enumeration value="flowChartManualInput"/>
+      <xsd:enumeration value="flowChartManualOperation"/>
+      <xsd:enumeration value="flowChartConnector"/>
+      <xsd:enumeration value="flowChartPunchedCard"/>
+      <xsd:enumeration value="flowChartPunchedTape"/>
+      <xsd:enumeration value="flowChartSummingJunction"/>
+      <xsd:enumeration value="flowChartOr"/>
+      <xsd:enumeration value="flowChartCollate"/>
+      <xsd:enumeration value="flowChartSort"/>
+      <xsd:enumeration value="flowChartExtract"/>
+      <xsd:enumeration value="flowChartMerge"/>
+      <xsd:enumeration value="flowChartOfflineStorage"/>
+      <xsd:enumeration value="flowChartOnlineStorage"/>
+      <xsd:enumeration value="flowChartMagneticTape"/>
+      <xsd:enumeration value="flowChartMagneticDisk"/>
+      <xsd:enumeration value="flowChartMagneticDrum"/>
+      <xsd:enumeration value="flowChartDisplay"/>
+      <xsd:enumeration value="flowChartDelay"/>
+      <xsd:enumeration value="flowChartAlternateProcess"/>
+      <xsd:enumeration value="flowChartOffpageConnector"/>
+      <xsd:enumeration value="actionButtonBlank"/>
+      <xsd:enumeration value="actionButtonHome"/>
+      <xsd:enumeration value="actionButtonHelp"/>
+      <xsd:enumeration value="actionButtonInformation"/>
+      <xsd:enumeration value="actionButtonForwardNext"/>
+      <xsd:enumeration value="actionButtonBackPrevious"/>
+      <xsd:enumeration value="actionButtonEnd"/>
+      <xsd:enumeration value="actionButtonBeginning"/>
+      <xsd:enumeration value="actionButtonReturn"/>
+      <xsd:enumeration value="actionButtonDocument"/>
+      <xsd:enumeration value="actionButtonSound"/>
+      <xsd:enumeration value="actionButtonMovie"/>
+      <xsd:enumeration value="gear6"/>
+      <xsd:enumeration value="gear9"/>
+      <xsd:enumeration value="funnel"/>
+      <xsd:enumeration value="mathPlus"/>
+      <xsd:enumeration value="mathMinus"/>
+      <xsd:enumeration value="mathMultiply"/>
+      <xsd:enumeration value="mathDivide"/>
+      <xsd:enumeration value="mathEqual"/>
+      <xsd:enumeration value="mathNotEqual"/>
+      <xsd:enumeration value="cornerTabs"/>
+      <xsd:enumeration value="squareTabs"/>
+      <xsd:enumeration value="plaqueTabs"/>
+      <xsd:enumeration value="chartX"/>
+      <xsd:enumeration value="chartStar"/>
+      <xsd:enumeration value="chartPlus"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TextShapeType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="textNoShape"/>
+      <xsd:enumeration value="textPlain"/>
+      <xsd:enumeration value="textStop"/>
+      <xsd:enumeration value="textTriangle"/>
+      <xsd:enumeration value="textTriangleInverted"/>
+      <xsd:enumeration value="textChevron"/>
+      <xsd:enumeration value="textChevronInverted"/>
+      <xsd:enumeration value="textRingInside"/>
+      <xsd:enumeration value="textRingOutside"/>
+      <xsd:enumeration value="textArchUp"/>
+      <xsd:enumeration value="textArchDown"/>
+      <xsd:enumeration value="textCircle"/>
+      <xsd:enumeration value="textButton"/>
+      <xsd:enumeration value="textArchUpPour"/>
+      <xsd:enumeration value="textArchDownPour"/>
+      <xsd:enumeration value="textCirclePour"/>
+      <xsd:enumeration value="textButtonPour"/>
+      <xsd:enumeration value="textCurveUp"/>
+      <xsd:enumeration value="textCurveDown"/>
+      <xsd:enumeration value="textCanUp"/>
+      <xsd:enumeration value="textCanDown"/>
+      <xsd:enumeration value="textWave1"/>
+      <xsd:enumeration value="textWave2"/>
+      <xsd:enumeration value="textDoubleWave1"/>
+      <xsd:enumeration value="textWave4"/>
+      <xsd:enumeration value="textInflate"/>
+      <xsd:enumeration value="textDeflate"/>
+      <xsd:enumeration value="textInflateBottom"/>
+      <xsd:enumeration value="textDeflateBottom"/>
+      <xsd:enumeration value="textInflateTop"/>
+      <xsd:enumeration value="textDeflateTop"/>
+      <xsd:enumeration value="textDeflateInflate"/>
+      <xsd:enumeration value="textDeflateInflateDeflate"/>
+      <xsd:enumeration value="textFadeRight"/>
+      <xsd:enumeration value="textFadeLeft"/>
+      <xsd:enumeration value="textFadeUp"/>
+      <xsd:enumeration value="textFadeDown"/>
+      <xsd:enumeration value="textSlantUp"/>
+      <xsd:enumeration value="textSlantDown"/>
+      <xsd:enumeration value="textCascadeUp"/>
+      <xsd:enumeration value="textCascadeDown"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_GeomGuideName">
+    <xsd:restriction base="xsd:token"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_GeomGuideFormula">
+    <xsd:restriction base="xsd:string"/>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_GeomGuide">
+    <xsd:attribute name="name" type="ST_GeomGuideName" use="required"/>
+    <xsd:attribute name="fmla" type="ST_GeomGuideFormula" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GeomGuideList">
+    <xsd:sequence>
+      <xsd:element name="gd" type="CT_GeomGuide" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_AdjCoordinate">
+    <xsd:union memberTypes="ST_Coordinate ST_GeomGuideName"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_AdjAngle">
+    <xsd:union memberTypes="ST_Angle ST_GeomGuideName"/>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_AdjPoint2D">
+    <xsd:attribute name="x" type="ST_AdjCoordinate" use="required"/>
+    <xsd:attribute name="y" type="ST_AdjCoordinate" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GeomRect">
+    <xsd:attribute name="l" type="ST_AdjCoordinate" use="required"/>
+    <xsd:attribute name="t" type="ST_AdjCoordinate" use="required"/>
+    <xsd:attribute name="r" type="ST_AdjCoordinate" use="required"/>
+    <xsd:attribute name="b" type="ST_AdjCoordinate" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_XYAdjustHandle">
+    <xsd:sequence>
+      <xsd:element name="pos" type="CT_AdjPoint2D" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="gdRefX" type="ST_GeomGuideName" use="optional"/>
+    <xsd:attribute name="minX" type="ST_AdjCoordinate" use="optional"/>
+    <xsd:attribute name="maxX" type="ST_AdjCoordinate" use="optional"/>
+    <xsd:attribute name="gdRefY" type="ST_GeomGuideName" use="optional"/>
+    <xsd:attribute name="minY" type="ST_AdjCoordinate" use="optional"/>
+    <xsd:attribute name="maxY" type="ST_AdjCoordinate" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PolarAdjustHandle">
+    <xsd:sequence>
+      <xsd:element name="pos" type="CT_AdjPoint2D" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="gdRefR" type="ST_GeomGuideName" use="optional"/>
+    <xsd:attribute name="minR" type="ST_AdjCoordinate" use="optional"/>
+    <xsd:attribute name="maxR" type="ST_AdjCoordinate" use="optional"/>
+    <xsd:attribute name="gdRefAng" type="ST_GeomGuideName" use="optional"/>
+    <xsd:attribute name="minAng" type="ST_AdjAngle" use="optional"/>
+    <xsd:attribute name="maxAng" type="ST_AdjAngle" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ConnectionSite">
+    <xsd:sequence>
+      <xsd:element name="pos" type="CT_AdjPoint2D" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="ang" type="ST_AdjAngle" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_AdjustHandleList">
+    <xsd:choice minOccurs="0" maxOccurs="unbounded">
+      <xsd:element name="ahXY" type="CT_XYAdjustHandle" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="ahPolar" type="CT_PolarAdjustHandle" minOccurs="1" maxOccurs="1"/>
+    </xsd:choice>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ConnectionSiteList">
+    <xsd:sequence>
+      <xsd:element name="cxn" type="CT_ConnectionSite" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Connection">
+    <xsd:attribute name="id" type="ST_DrawingElementId" use="required"/>
+    <xsd:attribute name="idx" type="xsd:unsignedInt" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Path2DMoveTo">
+    <xsd:sequence>
+      <xsd:element name="pt" type="CT_AdjPoint2D" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Path2DLineTo">
+    <xsd:sequence>
+      <xsd:element name="pt" type="CT_AdjPoint2D" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Path2DArcTo">
+    <xsd:attribute name="wR" type="ST_AdjCoordinate" use="required"/>
+    <xsd:attribute name="hR" type="ST_AdjCoordinate" use="required"/>
+    <xsd:attribute name="stAng" type="ST_AdjAngle" use="required"/>
+    <xsd:attribute name="swAng" type="ST_AdjAngle" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Path2DQuadBezierTo">
+    <xsd:sequence>
+      <xsd:element name="pt" type="CT_AdjPoint2D" minOccurs="2" maxOccurs="2"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Path2DCubicBezierTo">
+    <xsd:sequence>
+      <xsd:element name="pt" type="CT_AdjPoint2D" minOccurs="3" maxOccurs="3"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Path2DClose"/>
+  <xsd:simpleType name="ST_PathFillMode">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="norm"/>
+      <xsd:enumeration value="lighten"/>
+      <xsd:enumeration value="lightenLess"/>
+      <xsd:enumeration value="darken"/>
+      <xsd:enumeration value="darkenLess"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Path2D">
+    <xsd:choice minOccurs="0" maxOccurs="unbounded">
+      <xsd:element name="close" type="CT_Path2DClose" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="moveTo" type="CT_Path2DMoveTo" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="lnTo" type="CT_Path2DLineTo" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="arcTo" type="CT_Path2DArcTo" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="quadBezTo" type="CT_Path2DQuadBezierTo" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="cubicBezTo" type="CT_Path2DCubicBezierTo" minOccurs="1" maxOccurs="1"/>
+    </xsd:choice>
+    <xsd:attribute name="w" type="ST_PositiveCoordinate" use="optional" default="0"/>
+    <xsd:attribute name="h" type="ST_PositiveCoordinate" use="optional" default="0"/>
+    <xsd:attribute name="fill" type="ST_PathFillMode" use="optional" default="norm"/>
+    <xsd:attribute name="stroke" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="extrusionOk" type="xsd:boolean" use="optional" default="true"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Path2DList">
+    <xsd:sequence>
+      <xsd:element name="path" type="CT_Path2D" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PresetGeometry2D">
+    <xsd:sequence>
+      <xsd:element name="avLst" type="CT_GeomGuideList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="prst" type="ST_ShapeType" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PresetTextShape">
+    <xsd:sequence>
+      <xsd:element name="avLst" type="CT_GeomGuideList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="prst" type="ST_TextShapeType" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CustomGeometry2D">
+    <xsd:sequence>
+      <xsd:element name="avLst" type="CT_GeomGuideList" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="gdLst" type="CT_GeomGuideList" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="ahLst" type="CT_AdjustHandleList" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="cxnLst" type="CT_ConnectionSiteList" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="rect" type="CT_GeomRect" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="pathLst" type="CT_Path2DList" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:group name="EG_Geometry">
+    <xsd:choice>
+      <xsd:element name="custGeom" type="CT_CustomGeometry2D" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="prstGeom" type="CT_PresetGeometry2D" minOccurs="1" maxOccurs="1"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:group name="EG_TextGeometry">
+    <xsd:choice>
+      <xsd:element name="custGeom" type="CT_CustomGeometry2D" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="prstTxWarp" type="CT_PresetTextShape" minOccurs="1" maxOccurs="1"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:simpleType name="ST_LineEndType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="triangle"/>
+      <xsd:enumeration value="stealth"/>
+      <xsd:enumeration value="diamond"/>
+      <xsd:enumeration value="oval"/>
+      <xsd:enumeration value="arrow"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_LineEndWidth">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="sm"/>
+      <xsd:enumeration value="med"/>
+      <xsd:enumeration value="lg"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_LineEndLength">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="sm"/>
+      <xsd:enumeration value="med"/>
+      <xsd:enumeration value="lg"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_LineEndProperties">
+    <xsd:attribute name="type" type="ST_LineEndType" use="optional" default="none"/>
+    <xsd:attribute name="w" type="ST_LineEndWidth" use="optional"/>
+    <xsd:attribute name="len" type="ST_LineEndLength" use="optional"/>
+  </xsd:complexType>
+  <xsd:group name="EG_LineFillProperties">
+    <xsd:choice>
+      <xsd:element name="noFill" type="CT_NoFillProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="solidFill" type="CT_SolidColorFillProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="gradFill" type="CT_GradientFillProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="pattFill" type="CT_PatternFillProperties" minOccurs="1" maxOccurs="1"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:complexType name="CT_LineJoinBevel"/>
+  <xsd:complexType name="CT_LineJoinRound"/>
+  <xsd:complexType name="CT_LineJoinMiterProperties">
+    <xsd:attribute name="lim" type="ST_PositivePercentage" use="optional"/>
+  </xsd:complexType>
+  <xsd:group name="EG_LineJoinProperties">
+    <xsd:choice>
+      <xsd:element name="round" type="CT_LineJoinRound" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="bevel" type="CT_LineJoinBevel" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="miter" type="CT_LineJoinMiterProperties" minOccurs="1" maxOccurs="1"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:simpleType name="ST_PresetLineDashVal">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="solid"/>
+      <xsd:enumeration value="dot"/>
+      <xsd:enumeration value="dash"/>
+      <xsd:enumeration value="lgDash"/>
+      <xsd:enumeration value="dashDot"/>
+      <xsd:enumeration value="lgDashDot"/>
+      <xsd:enumeration value="lgDashDotDot"/>
+      <xsd:enumeration value="sysDash"/>
+      <xsd:enumeration value="sysDot"/>
+      <xsd:enumeration value="sysDashDot"/>
+      <xsd:enumeration value="sysDashDotDot"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_PresetLineDashProperties">
+    <xsd:attribute name="val" type="ST_PresetLineDashVal" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DashStop">
+    <xsd:attribute name="d" type="ST_PositivePercentage" use="required"/>
+    <xsd:attribute name="sp" type="ST_PositivePercentage" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DashStopList">
+    <xsd:sequence>
+      <xsd:element name="ds" type="CT_DashStop" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:group name="EG_LineDashProperties">
+    <xsd:choice>
+      <xsd:element name="prstDash" type="CT_PresetLineDashProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="custDash" type="CT_DashStopList" minOccurs="1" maxOccurs="1"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:simpleType name="ST_LineCap">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="rnd"/>
+      <xsd:enumeration value="sq"/>
+      <xsd:enumeration value="flat"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_LineWidth">
+    <xsd:restriction base="ST_Coordinate32Unqualified">
+      <xsd:minInclusive value="0"/>
+      <xsd:maxInclusive value="20116800"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_PenAlignment">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="ctr"/>
+      <xsd:enumeration value="in"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_CompoundLine">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="sng"/>
+      <xsd:enumeration value="dbl"/>
+      <xsd:enumeration value="thickThin"/>
+      <xsd:enumeration value="thinThick"/>
+      <xsd:enumeration value="tri"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_LineProperties">
+    <xsd:sequence>
+      <xsd:group ref="EG_LineFillProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:group ref="EG_LineDashProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:group ref="EG_LineJoinProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="headEnd" type="CT_LineEndProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tailEnd" type="CT_LineEndProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="w" type="ST_LineWidth" use="optional"/>
+    <xsd:attribute name="cap" type="ST_LineCap" use="optional"/>
+    <xsd:attribute name="cmpd" type="ST_CompoundLine" use="optional"/>
+    <xsd:attribute name="algn" type="ST_PenAlignment" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_ShapeID">
+    <xsd:restriction base="xsd:token"/>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_ShapeProperties">
+    <xsd:sequence>
+      <xsd:element name="xfrm" type="CT_Transform2D" minOccurs="0" maxOccurs="1"/>
+      <xsd:group ref="EG_Geometry" minOccurs="0" maxOccurs="1"/>
+      <xsd:group ref="EG_FillProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="ln" type="CT_LineProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:group ref="EG_EffectProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="scene3d" type="CT_Scene3D" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="sp3d" type="CT_Shape3D" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="bwMode" type="ST_BlackWhiteMode" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GroupShapeProperties">
+    <xsd:sequence>
+      <xsd:element name="xfrm" type="CT_GroupTransform2D" minOccurs="0" maxOccurs="1"/>
+      <xsd:group ref="EG_FillProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:group ref="EG_EffectProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="scene3d" type="CT_Scene3D" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="bwMode" type="ST_BlackWhiteMode" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_StyleMatrixReference">
+    <xsd:sequence>
+      <xsd:group ref="EG_ColorChoice" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="idx" type="ST_StyleMatrixColumnIndex" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_FontReference">
+    <xsd:sequence>
+      <xsd:group ref="EG_ColorChoice" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="idx" type="ST_FontCollectionIndex" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ShapeStyle">
+    <xsd:sequence>
+      <xsd:element name="lnRef" type="CT_StyleMatrixReference" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="fillRef" type="CT_StyleMatrixReference" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="effectRef" type="CT_StyleMatrixReference" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="fontRef" type="CT_FontReference" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DefaultShapeDefinition">
+    <xsd:sequence>
+      <xsd:element name="spPr" type="CT_ShapeProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="bodyPr" type="CT_TextBodyProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="lstStyle" type="CT_TextListStyle" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="style" type="CT_ShapeStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ObjectStyleDefaults">
+    <xsd:sequence>
+      <xsd:element name="spDef" type="CT_DefaultShapeDefinition" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="lnDef" type="CT_DefaultShapeDefinition" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="txDef" type="CT_DefaultShapeDefinition" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_EmptyElement"/>
+  <xsd:complexType name="CT_ColorMapping">
+    <xsd:sequence>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="bg1" type="ST_ColorSchemeIndex" use="required"/>
+    <xsd:attribute name="tx1" type="ST_ColorSchemeIndex" use="required"/>
+    <xsd:attribute name="bg2" type="ST_ColorSchemeIndex" use="required"/>
+    <xsd:attribute name="tx2" type="ST_ColorSchemeIndex" use="required"/>
+    <xsd:attribute name="accent1" type="ST_ColorSchemeIndex" use="required"/>
+    <xsd:attribute name="accent2" type="ST_ColorSchemeIndex" use="required"/>
+    <xsd:attribute name="accent3" type="ST_ColorSchemeIndex" use="required"/>
+    <xsd:attribute name="accent4" type="ST_ColorSchemeIndex" use="required"/>
+    <xsd:attribute name="accent5" type="ST_ColorSchemeIndex" use="required"/>
+    <xsd:attribute name="accent6" type="ST_ColorSchemeIndex" use="required"/>
+    <xsd:attribute name="hlink" type="ST_ColorSchemeIndex" use="required"/>
+    <xsd:attribute name="folHlink" type="ST_ColorSchemeIndex" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ColorMappingOverride">
+    <xsd:sequence>
+      <xsd:choice minOccurs="1" maxOccurs="1">
+        <xsd:element name="masterClrMapping" type="CT_EmptyElement"/>
+        <xsd:element name="overrideClrMapping" type="CT_ColorMapping"/>
+      </xsd:choice>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ColorSchemeAndMapping">
+    <xsd:sequence>
+      <xsd:element name="clrScheme" type="CT_ColorScheme" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="clrMap" type="CT_ColorMapping" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ColorSchemeList">
+    <xsd:sequence>
+      <xsd:element name="extraClrScheme" type="CT_ColorSchemeAndMapping" minOccurs="0"
+        maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_OfficeStyleSheet">
+    <xsd:sequence>
+      <xsd:element name="themeElements" type="CT_BaseStyles" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="objectDefaults" type="CT_ObjectStyleDefaults" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extraClrSchemeLst" type="CT_ColorSchemeList" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="custClrLst" type="CT_CustomColorList" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="optional" default=""/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_BaseStylesOverride">
+    <xsd:sequence>
+      <xsd:element name="clrScheme" type="CT_ColorScheme" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="fontScheme" type="CT_FontScheme" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="fmtScheme" type="CT_StyleMatrix" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ClipboardStyleSheet">
+    <xsd:sequence>
+      <xsd:element name="themeElements" type="CT_BaseStyles" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="clrMap" type="CT_ColorMapping" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="theme" type="CT_OfficeStyleSheet"/>
+  <xsd:element name="themeOverride" type="CT_BaseStylesOverride"/>
+  <xsd:element name="themeManager" type="CT_EmptyElement"/>
+  <xsd:complexType name="CT_TableCellProperties">
+    <xsd:sequence>
+      <xsd:element name="lnL" type="CT_LineProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="lnR" type="CT_LineProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="lnT" type="CT_LineProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="lnB" type="CT_LineProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="lnTlToBr" type="CT_LineProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="lnBlToTr" type="CT_LineProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="cell3D" type="CT_Cell3D" minOccurs="0" maxOccurs="1"/>
+      <xsd:group ref="EG_FillProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="headers" type="CT_Headers" minOccurs="0"/>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="marL" type="ST_Coordinate32" use="optional" default="91440"/>
+    <xsd:attribute name="marR" type="ST_Coordinate32" use="optional" default="91440"/>
+    <xsd:attribute name="marT" type="ST_Coordinate32" use="optional" default="45720"/>
+    <xsd:attribute name="marB" type="ST_Coordinate32" use="optional" default="45720"/>
+    <xsd:attribute name="vert" type="ST_TextVerticalType" use="optional" default="horz"/>
+    <xsd:attribute name="anchor" type="ST_TextAnchoringType" use="optional" default="t"/>
+    <xsd:attribute name="anchorCtr" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="horzOverflow" type="ST_TextHorzOverflowType" use="optional" default="clip"
+    />
+  </xsd:complexType>
+  <xsd:complexType name="CT_Headers">
+    <xsd:sequence minOccurs="0" maxOccurs="unbounded">
+      <xsd:element name="header" type="xsd:string"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TableCol">
+    <xsd:sequence>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="w" type="ST_Coordinate" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TableGrid">
+    <xsd:sequence>
+      <xsd:element name="gridCol" type="CT_TableCol" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TableCell">
+    <xsd:sequence>
+      <xsd:element name="txBody" type="CT_TextBody" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tcPr" type="CT_TableCellProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="rowSpan" type="xsd:int" use="optional" default="1"/>
+    <xsd:attribute name="gridSpan" type="xsd:int" use="optional" default="1"/>
+    <xsd:attribute name="hMerge" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="vMerge" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="id" type="xsd:string" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TableRow">
+    <xsd:sequence>
+      <xsd:element name="tc" type="CT_TableCell" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="h" type="ST_Coordinate" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TableProperties">
+    <xsd:sequence>
+      <xsd:group ref="EG_FillProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:group ref="EG_EffectProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:choice minOccurs="0" maxOccurs="1">
+        <xsd:element name="tableStyle" type="CT_TableStyle"/>
+        <xsd:element name="tableStyleId" type="s:ST_Guid"/>
+      </xsd:choice>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="rtl" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="firstRow" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="firstCol" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="lastRow" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="lastCol" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="bandRow" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="bandCol" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Table">
+    <xsd:sequence>
+      <xsd:element name="tblPr" type="CT_TableProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tblGrid" type="CT_TableGrid" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="tr" type="CT_TableRow" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="tbl" type="CT_Table"/>
+  <xsd:complexType name="CT_Cell3D">
+    <xsd:sequence>
+      <xsd:element name="bevel" type="CT_Bevel" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="lightRig" type="CT_LightRig" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="prstMaterial" type="ST_PresetMaterialType" use="optional" default="plastic"
+    />
+  </xsd:complexType>
+  <xsd:group name="EG_ThemeableFillStyle">
+    <xsd:choice>
+      <xsd:element name="fill" type="CT_FillProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="fillRef" type="CT_StyleMatrixReference" minOccurs="1" maxOccurs="1"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:complexType name="CT_ThemeableLineStyle">
+    <xsd:choice>
+      <xsd:element name="ln" type="CT_LineProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="lnRef" type="CT_StyleMatrixReference" minOccurs="1" maxOccurs="1"/>
+    </xsd:choice>
+  </xsd:complexType>
+  <xsd:group name="EG_ThemeableEffectStyle">
+    <xsd:choice>
+      <xsd:element name="effect" type="CT_EffectProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="effectRef" type="CT_StyleMatrixReference" minOccurs="1" maxOccurs="1"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:group name="EG_ThemeableFontStyles">
+    <xsd:choice>
+      <xsd:element name="font" type="CT_FontCollection" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="fontRef" type="CT_FontReference" minOccurs="1" maxOccurs="1"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:simpleType name="ST_OnOffStyleType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="on"/>
+      <xsd:enumeration value="off"/>
+      <xsd:enumeration value="def"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TableStyleTextStyle">
+    <xsd:sequence>
+      <xsd:group ref="EG_ThemeableFontStyles" minOccurs="0" maxOccurs="1"/>
+      <xsd:group ref="EG_ColorChoice" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="b" type="ST_OnOffStyleType" use="optional" default="def"/>
+    <xsd:attribute name="i" type="ST_OnOffStyleType" use="optional" default="def"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TableCellBorderStyle">
+    <xsd:sequence>
+      <xsd:element name="left" type="CT_ThemeableLineStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="right" type="CT_ThemeableLineStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="top" type="CT_ThemeableLineStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="bottom" type="CT_ThemeableLineStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="insideH" type="CT_ThemeableLineStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="insideV" type="CT_ThemeableLineStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tl2br" type="CT_ThemeableLineStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tr2bl" type="CT_ThemeableLineStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TableBackgroundStyle">
+    <xsd:sequence>
+      <xsd:group ref="EG_ThemeableFillStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:group ref="EG_ThemeableEffectStyle" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TableStyleCellStyle">
+    <xsd:sequence>
+      <xsd:element name="tcBdr" type="CT_TableCellBorderStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:group ref="EG_ThemeableFillStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="cell3D" type="CT_Cell3D" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TablePartStyle">
+    <xsd:sequence>
+      <xsd:element name="tcTxStyle" type="CT_TableStyleTextStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tcStyle" type="CT_TableStyleCellStyle" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TableStyle">
+    <xsd:sequence>
+      <xsd:element name="tblBg" type="CT_TableBackgroundStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="wholeTbl" type="CT_TablePartStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="band1H" type="CT_TablePartStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="band2H" type="CT_TablePartStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="band1V" type="CT_TablePartStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="band2V" type="CT_TablePartStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="lastCol" type="CT_TablePartStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="firstCol" type="CT_TablePartStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="lastRow" type="CT_TablePartStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="seCell" type="CT_TablePartStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="swCell" type="CT_TablePartStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="firstRow" type="CT_TablePartStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="neCell" type="CT_TablePartStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="nwCell" type="CT_TablePartStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="styleId" type="s:ST_Guid" use="required"/>
+    <xsd:attribute name="styleName" type="xsd:string" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TableStyleList">
+    <xsd:sequence>
+      <xsd:element name="tblStyle" type="CT_TableStyle" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="def" type="s:ST_Guid" use="required"/>
+  </xsd:complexType>
+  <xsd:element name="tblStyleLst" type="CT_TableStyleList"/>
+  <xsd:complexType name="CT_TextParagraph">
+    <xsd:sequence>
+      <xsd:element name="pPr" type="CT_TextParagraphProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:group ref="EG_TextRun" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="endParaRPr" type="CT_TextCharacterProperties" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TextAnchoringType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="t"/>
+      <xsd:enumeration value="ctr"/>
+      <xsd:enumeration value="b"/>
+      <xsd:enumeration value="just"/>
+      <xsd:enumeration value="dist"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TextVertOverflowType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="overflow"/>
+      <xsd:enumeration value="ellipsis"/>
+      <xsd:enumeration value="clip"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TextHorzOverflowType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="overflow"/>
+      <xsd:enumeration value="clip"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TextVerticalType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="horz"/>
+      <xsd:enumeration value="vert"/>
+      <xsd:enumeration value="vert270"/>
+      <xsd:enumeration value="wordArtVert"/>
+      <xsd:enumeration value="eaVert"/>
+      <xsd:enumeration value="mongolianVert"/>
+      <xsd:enumeration value="wordArtVertRtl"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TextWrappingType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="square"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TextColumnCount">
+    <xsd:restriction base="xsd:int">
+      <xsd:minInclusive value="1"/>
+      <xsd:maxInclusive value="16"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TextListStyle">
+    <xsd:sequence>
+      <xsd:element name="defPPr" type="CT_TextParagraphProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="lvl1pPr" type="CT_TextParagraphProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="lvl2pPr" type="CT_TextParagraphProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="lvl3pPr" type="CT_TextParagraphProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="lvl4pPr" type="CT_TextParagraphProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="lvl5pPr" type="CT_TextParagraphProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="lvl6pPr" type="CT_TextParagraphProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="lvl7pPr" type="CT_TextParagraphProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="lvl8pPr" type="CT_TextParagraphProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="lvl9pPr" type="CT_TextParagraphProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TextFontScalePercentOrPercentString">
+    <xsd:union memberTypes="ST_TextFontScalePercent s:ST_Percentage"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TextFontScalePercent">
+    <xsd:restriction base="ST_PercentageDecimal">
+      <xsd:minInclusive value="1000"/>
+      <xsd:maxInclusive value="100000"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TextNormalAutofit">
+    <xsd:attribute name="fontScale" type="ST_TextFontScalePercentOrPercentString" use="optional"
+      default="100%"/>
+    <xsd:attribute name="lnSpcReduction" type="ST_TextSpacingPercentOrPercentString" use="optional"
+      default="0%"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TextShapeAutofit"/>
+  <xsd:complexType name="CT_TextNoAutofit"/>
+  <xsd:group name="EG_TextAutofit">
+    <xsd:choice>
+      <xsd:element name="noAutofit" type="CT_TextNoAutofit"/>
+      <xsd:element name="normAutofit" type="CT_TextNormalAutofit"/>
+      <xsd:element name="spAutoFit" type="CT_TextShapeAutofit"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:complexType name="CT_TextBodyProperties">
+    <xsd:sequence>
+      <xsd:element name="prstTxWarp" type="CT_PresetTextShape" minOccurs="0" maxOccurs="1"/>
+      <xsd:group ref="EG_TextAutofit" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="scene3d" type="CT_Scene3D" minOccurs="0" maxOccurs="1"/>
+      <xsd:group ref="EG_Text3D" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="rot" type="ST_Angle" use="optional"/>
+    <xsd:attribute name="spcFirstLastPara" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="vertOverflow" type="ST_TextVertOverflowType" use="optional"/>
+    <xsd:attribute name="horzOverflow" type="ST_TextHorzOverflowType" use="optional"/>
+    <xsd:attribute name="vert" type="ST_TextVerticalType" use="optional"/>
+    <xsd:attribute name="wrap" type="ST_TextWrappingType" use="optional"/>
+    <xsd:attribute name="lIns" type="ST_Coordinate32" use="optional"/>
+    <xsd:attribute name="tIns" type="ST_Coordinate32" use="optional"/>
+    <xsd:attribute name="rIns" type="ST_Coordinate32" use="optional"/>
+    <xsd:attribute name="bIns" type="ST_Coordinate32" use="optional"/>
+    <xsd:attribute name="numCol" type="ST_TextColumnCount" use="optional"/>
+    <xsd:attribute name="spcCol" type="ST_PositiveCoordinate32" use="optional"/>
+    <xsd:attribute name="rtlCol" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="fromWordArt" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="anchor" type="ST_TextAnchoringType" use="optional"/>
+    <xsd:attribute name="anchorCtr" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="forceAA" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="upright" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="compatLnSpc" type="xsd:boolean" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TextBody">
+    <xsd:sequence>
+      <xsd:element name="bodyPr" type="CT_TextBodyProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="lstStyle" type="CT_TextListStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="p" type="CT_TextParagraph" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TextBulletStartAtNum">
+    <xsd:restriction base="xsd:int">
+      <xsd:minInclusive value="1"/>
+      <xsd:maxInclusive value="32767"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TextAutonumberScheme">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="alphaLcParenBoth"/>
+      <xsd:enumeration value="alphaUcParenBoth"/>
+      <xsd:enumeration value="alphaLcParenR"/>
+      <xsd:enumeration value="alphaUcParenR"/>
+      <xsd:enumeration value="alphaLcPeriod"/>
+      <xsd:enumeration value="alphaUcPeriod"/>
+      <xsd:enumeration value="arabicParenBoth"/>
+      <xsd:enumeration value="arabicParenR"/>
+      <xsd:enumeration value="arabicPeriod"/>
+      <xsd:enumeration value="arabicPlain"/>
+      <xsd:enumeration value="romanLcParenBoth"/>
+      <xsd:enumeration value="romanUcParenBoth"/>
+      <xsd:enumeration value="romanLcParenR"/>
+      <xsd:enumeration value="romanUcParenR"/>
+      <xsd:enumeration value="romanLcPeriod"/>
+      <xsd:enumeration value="romanUcPeriod"/>
+      <xsd:enumeration value="circleNumDbPlain"/>
+      <xsd:enumeration value="circleNumWdBlackPlain"/>
+      <xsd:enumeration value="circleNumWdWhitePlain"/>
+      <xsd:enumeration value="arabicDbPeriod"/>
+      <xsd:enumeration value="arabicDbPlain"/>
+      <xsd:enumeration value="ea1ChsPeriod"/>
+      <xsd:enumeration value="ea1ChsPlain"/>
+      <xsd:enumeration value="ea1ChtPeriod"/>
+      <xsd:enumeration value="ea1ChtPlain"/>
+      <xsd:enumeration value="ea1JpnChsDbPeriod"/>
+      <xsd:enumeration value="ea1JpnKorPlain"/>
+      <xsd:enumeration value="ea1JpnKorPeriod"/>
+      <xsd:enumeration value="arabic1Minus"/>
+      <xsd:enumeration value="arabic2Minus"/>
+      <xsd:enumeration value="hebrew2Minus"/>
+      <xsd:enumeration value="thaiAlphaPeriod"/>
+      <xsd:enumeration value="thaiAlphaParenR"/>
+      <xsd:enumeration value="thaiAlphaParenBoth"/>
+      <xsd:enumeration value="thaiNumPeriod"/>
+      <xsd:enumeration value="thaiNumParenR"/>
+      <xsd:enumeration value="thaiNumParenBoth"/>
+      <xsd:enumeration value="hindiAlphaPeriod"/>
+      <xsd:enumeration value="hindiNumPeriod"/>
+      <xsd:enumeration value="hindiNumParenR"/>
+      <xsd:enumeration value="hindiAlpha1Period"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TextBulletColorFollowText"/>
+  <xsd:group name="EG_TextBulletColor">
+    <xsd:choice>
+      <xsd:element name="buClrTx" type="CT_TextBulletColorFollowText" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="buClr" type="CT_Color" minOccurs="1" maxOccurs="1"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:simpleType name="ST_TextBulletSize">
+    <xsd:union memberTypes="ST_TextBulletSizePercent ST_TextBulletSizeDecimal"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TextBulletSizePercent">
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="0*((2[5-9])|([3-9][0-9])|([1-3][0-9][0-9])|400)%"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TextBulletSizeDecimal">
+    <xsd:restriction base="ST_PercentageDecimal">
+      <xsd:minInclusive value="25000"/>
+      <xsd:maxInclusive value="400000"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TextBulletSizeFollowText"/>
+  <xsd:complexType name="CT_TextBulletSizePercent">
+    <xsd:attribute name="val" type="ST_TextBulletSizePercent" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TextBulletSizePoint">
+    <xsd:attribute name="val" type="ST_TextFontSize" use="required"/>
+  </xsd:complexType>
+  <xsd:group name="EG_TextBulletSize">
+    <xsd:choice>
+      <xsd:element name="buSzTx" type="CT_TextBulletSizeFollowText"/>
+      <xsd:element name="buSzPct" type="CT_TextBulletSizePercent"/>
+      <xsd:element name="buSzPts" type="CT_TextBulletSizePoint"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:complexType name="CT_TextBulletTypefaceFollowText"/>
+  <xsd:group name="EG_TextBulletTypeface">
+    <xsd:choice>
+      <xsd:element name="buFontTx" type="CT_TextBulletTypefaceFollowText"/>
+      <xsd:element name="buFont" type="CT_TextFont"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:complexType name="CT_TextAutonumberBullet">
+    <xsd:attribute name="type" type="ST_TextAutonumberScheme" use="required"/>
+    <xsd:attribute name="startAt" type="ST_TextBulletStartAtNum" use="optional" default="1"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TextCharBullet">
+    <xsd:attribute name="char" type="xsd:string" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TextBlipBullet">
+    <xsd:sequence>
+      <xsd:element name="blip" type="CT_Blip" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TextNoBullet"/>
+  <xsd:group name="EG_TextBullet">
+    <xsd:choice>
+      <xsd:element name="buNone" type="CT_TextNoBullet"/>
+      <xsd:element name="buAutoNum" type="CT_TextAutonumberBullet"/>
+      <xsd:element name="buChar" type="CT_TextCharBullet"/>
+      <xsd:element name="buBlip" type="CT_TextBlipBullet"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:simpleType name="ST_TextPoint">
+    <xsd:union memberTypes="ST_TextPointUnqualified s:ST_UniversalMeasure"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TextPointUnqualified">
+    <xsd:restriction base="xsd:int">
+      <xsd:minInclusive value="-400000"/>
+      <xsd:maxInclusive value="400000"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TextNonNegativePoint">
+    <xsd:restriction base="xsd:int">
+      <xsd:minInclusive value="0"/>
+      <xsd:maxInclusive value="400000"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TextFontSize">
+    <xsd:restriction base="xsd:int">
+      <xsd:minInclusive value="100"/>
+      <xsd:maxInclusive value="400000"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TextTypeface">
+    <xsd:restriction base="xsd:string"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_PitchFamily">
+   <xsd:restriction base="xsd:byte">
+     <xsd:enumeration value="00"/>
+     <xsd:enumeration value="01"/>
+     <xsd:enumeration value="02"/>
+     <xsd:enumeration value="16"/>
+     <xsd:enumeration value="17"/>
+     <xsd:enumeration value="18"/>
+     <xsd:enumeration value="32"/>
+     <xsd:enumeration value="33"/>
+     <xsd:enumeration value="34"/>
+     <xsd:enumeration value="48"/>
+     <xsd:enumeration value="49"/>
+     <xsd:enumeration value="50"/>
+     <xsd:enumeration value="64"/>
+     <xsd:enumeration value="65"/>
+     <xsd:enumeration value="66"/>
+     <xsd:enumeration value="80"/>
+     <xsd:enumeration value="81"/>
+     <xsd:enumeration value="82"/>
+   </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="CT_TextFont">
+    <xsd:attribute name="typeface" type="ST_TextTypeface" use="required"/>
+    <xsd:attribute name="panose" type="s:ST_Panose" use="optional"/>
+    <xsd:attribute name="pitchFamily" type="ST_PitchFamily" use="optional" default="0"/>
+    <xsd:attribute name="charset" type="xsd:byte" use="optional" default="1"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TextUnderlineType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="words"/>
+      <xsd:enumeration value="sng"/>
+      <xsd:enumeration value="dbl"/>
+      <xsd:enumeration value="heavy"/>
+      <xsd:enumeration value="dotted"/>
+      <xsd:enumeration value="dottedHeavy"/>
+      <xsd:enumeration value="dash"/>
+      <xsd:enumeration value="dashHeavy"/>
+      <xsd:enumeration value="dashLong"/>
+      <xsd:enumeration value="dashLongHeavy"/>
+      <xsd:enumeration value="dotDash"/>
+      <xsd:enumeration value="dotDashHeavy"/>
+      <xsd:enumeration value="dotDotDash"/>
+      <xsd:enumeration value="dotDotDashHeavy"/>
+      <xsd:enumeration value="wavy"/>
+      <xsd:enumeration value="wavyHeavy"/>
+      <xsd:enumeration value="wavyDbl"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TextUnderlineLineFollowText"/>
+  <xsd:complexType name="CT_TextUnderlineFillFollowText"/>
+  <xsd:complexType name="CT_TextUnderlineFillGroupWrapper">
+    <xsd:group ref="EG_FillProperties" minOccurs="1" maxOccurs="1"/>
+  </xsd:complexType>
+  <xsd:group name="EG_TextUnderlineLine">
+    <xsd:choice>
+      <xsd:element name="uLnTx" type="CT_TextUnderlineLineFollowText"/>
+      <xsd:element name="uLn" type="CT_LineProperties" minOccurs="0" maxOccurs="1"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:group name="EG_TextUnderlineFill">
+    <xsd:choice>
+      <xsd:element name="uFillTx" type="CT_TextUnderlineFillFollowText"/>
+      <xsd:element name="uFill" type="CT_TextUnderlineFillGroupWrapper"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:simpleType name="ST_TextStrikeType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="noStrike"/>
+      <xsd:enumeration value="sngStrike"/>
+      <xsd:enumeration value="dblStrike"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TextCapsType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="small"/>
+      <xsd:enumeration value="all"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TextCharacterProperties">
+    <xsd:sequence>
+      <xsd:element name="ln" type="CT_LineProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:group ref="EG_FillProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:group ref="EG_EffectProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="highlight" type="CT_Color" minOccurs="0" maxOccurs="1"/>
+      <xsd:group ref="EG_TextUnderlineLine" minOccurs="0" maxOccurs="1"/>
+      <xsd:group ref="EG_TextUnderlineFill" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="latin" type="CT_TextFont" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="ea" type="CT_TextFont" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="cs" type="CT_TextFont" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="sym" type="CT_TextFont" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="hlinkClick" type="CT_Hyperlink" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="hlinkMouseOver" type="CT_Hyperlink" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="rtl" type="CT_Boolean" minOccurs="0"/>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="kumimoji" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="lang" type="s:ST_Lang" use="optional"/>
+    <xsd:attribute name="altLang" type="s:ST_Lang" use="optional"/>
+    <xsd:attribute name="sz" type="ST_TextFontSize" use="optional"/>
+    <xsd:attribute name="b" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="i" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="u" type="ST_TextUnderlineType" use="optional"/>
+    <xsd:attribute name="strike" type="ST_TextStrikeType" use="optional"/>
+    <xsd:attribute name="kern" type="ST_TextNonNegativePoint" use="optional"/>
+    <xsd:attribute name="cap" type="ST_TextCapsType" use="optional" default="none"/>
+    <xsd:attribute name="spc" type="ST_TextPoint" use="optional"/>
+    <xsd:attribute name="normalizeH" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="baseline" type="ST_Percentage" use="optional"/>
+    <xsd:attribute name="noProof" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="dirty" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="err" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="smtClean" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="smtId" type="xsd:unsignedInt" use="optional" default="0"/>
+    <xsd:attribute name="bmk" type="xsd:string" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Boolean">
+    <xsd:attribute name="val" type="s:ST_OnOff" default="0"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TextSpacingPoint">
+    <xsd:restriction base="xsd:int">
+      <xsd:minInclusive value="0"/>
+      <xsd:maxInclusive value="158400"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TextSpacingPercentOrPercentString">
+    <xsd:union memberTypes="ST_TextSpacingPercent s:ST_Percentage"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TextSpacingPercent">
+    <xsd:restriction base="ST_PercentageDecimal">
+      <xsd:minInclusive value="0"/>
+      <xsd:maxInclusive value="13200000"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TextSpacingPercent">
+    <xsd:attribute name="val" type="ST_TextSpacingPercentOrPercentString" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TextSpacingPoint">
+    <xsd:attribute name="val" type="ST_TextSpacingPoint" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TextMargin">
+    <xsd:restriction base="ST_Coordinate32Unqualified">
+      <xsd:minInclusive value="0"/>
+      <xsd:maxInclusive value="51206400"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TextIndent">
+    <xsd:restriction base="ST_Coordinate32Unqualified">
+      <xsd:minInclusive value="-51206400"/>
+      <xsd:maxInclusive value="51206400"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TextTabAlignType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="l"/>
+      <xsd:enumeration value="ctr"/>
+      <xsd:enumeration value="r"/>
+      <xsd:enumeration value="dec"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TextTabStop">
+    <xsd:attribute name="pos" type="ST_Coordinate32" use="optional"/>
+    <xsd:attribute name="algn" type="ST_TextTabAlignType" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TextTabStopList">
+    <xsd:sequence>
+      <xsd:element name="tab" type="CT_TextTabStop" minOccurs="0" maxOccurs="32"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TextLineBreak">
+    <xsd:sequence>
+      <xsd:element name="rPr" type="CT_TextCharacterProperties" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TextSpacing">
+    <xsd:choice>
+      <xsd:element name="spcPct" type="CT_TextSpacingPercent"/>
+      <xsd:element name="spcPts" type="CT_TextSpacingPoint"/>
+    </xsd:choice>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TextAlignType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="l"/>
+      <xsd:enumeration value="ctr"/>
+      <xsd:enumeration value="r"/>
+      <xsd:enumeration value="just"/>
+      <xsd:enumeration value="justLow"/>
+      <xsd:enumeration value="dist"/>
+      <xsd:enumeration value="thaiDist"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TextFontAlignType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="auto"/>
+      <xsd:enumeration value="t"/>
+      <xsd:enumeration value="ctr"/>
+      <xsd:enumeration value="base"/>
+      <xsd:enumeration value="b"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TextIndentLevelType">
+    <xsd:restriction base="xsd:int">
+      <xsd:minInclusive value="0"/>
+      <xsd:maxInclusive value="8"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TextParagraphProperties">
+    <xsd:sequence>
+      <xsd:element name="lnSpc" type="CT_TextSpacing" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="spcBef" type="CT_TextSpacing" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="spcAft" type="CT_TextSpacing" minOccurs="0" maxOccurs="1"/>
+      <xsd:group ref="EG_TextBulletColor" minOccurs="0" maxOccurs="1"/>
+      <xsd:group ref="EG_TextBulletSize" minOccurs="0" maxOccurs="1"/>
+      <xsd:group ref="EG_TextBulletTypeface" minOccurs="0" maxOccurs="1"/>
+      <xsd:group ref="EG_TextBullet" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tabLst" type="CT_TextTabStopList" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="defRPr" type="CT_TextCharacterProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="marL" type="ST_TextMargin" use="optional"/>
+    <xsd:attribute name="marR" type="ST_TextMargin" use="optional"/>
+    <xsd:attribute name="lvl" type="ST_TextIndentLevelType" use="optional"/>
+    <xsd:attribute name="indent" type="ST_TextIndent" use="optional"/>
+    <xsd:attribute name="algn" type="ST_TextAlignType" use="optional"/>
+    <xsd:attribute name="defTabSz" type="ST_Coordinate32" use="optional"/>
+    <xsd:attribute name="rtl" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="eaLnBrk" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="fontAlgn" type="ST_TextFontAlignType" use="optional"/>
+    <xsd:attribute name="latinLnBrk" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="hangingPunct" type="xsd:boolean" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TextField">
+    <xsd:sequence>
+      <xsd:element name="rPr" type="CT_TextCharacterProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="pPr" type="CT_TextParagraphProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="t" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="s:ST_Guid" use="required"/>
+    <xsd:attribute name="type" type="xsd:string" use="optional"/>
+  </xsd:complexType>
+  <xsd:group name="EG_TextRun">
+    <xsd:choice>
+      <xsd:element name="r" type="CT_RegularTextRun"/>
+      <xsd:element name="br" type="CT_TextLineBreak"/>
+      <xsd:element name="fld" type="CT_TextField"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:complexType name="CT_RegularTextRun">
+    <xsd:sequence>
+      <xsd:element name="rPr" type="CT_TextCharacterProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="t" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+</xsd:schema>

--- a/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-picture.xsd
+++ b/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-picture.xsd
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://schemas.openxmlformats.org/drawingml/2006/picture"
+  xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" elementFormDefault="qualified"
+  targetNamespace="http://schemas.openxmlformats.org/drawingml/2006/picture">
+  <xsd:import namespace="http://schemas.openxmlformats.org/drawingml/2006/main"
+    schemaLocation="dml-main.xsd"/>
+  <xsd:complexType name="CT_PictureNonVisual">
+    <xsd:sequence>
+      <xsd:element name="cNvPr" type="a:CT_NonVisualDrawingProps" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="cNvPicPr" type="a:CT_NonVisualPictureProperties" minOccurs="1"
+        maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Picture">
+    <xsd:sequence minOccurs="1" maxOccurs="1">
+      <xsd:element name="nvPicPr" type="CT_PictureNonVisual" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="blipFill" type="a:CT_BlipFillProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="spPr" type="a:CT_ShapeProperties" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="pic" type="CT_Picture"/>
+</xsd:schema>

--- a/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-spreadsheetDrawing.xsd
+++ b/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-spreadsheetDrawing.xsd
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+  xmlns="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"
+  xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+  targetNamespace="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"
+  elementFormDefault="qualified">
+  <xsd:import namespace="http://schemas.openxmlformats.org/drawingml/2006/main"
+    schemaLocation="dml-main.xsd"/>
+  <xsd:import schemaLocation="shared-relationshipReference.xsd"
+    namespace="http://schemas.openxmlformats.org/officeDocument/2006/relationships"/>
+  <xsd:element name="from" type="CT_Marker"/>
+  <xsd:element name="to" type="CT_Marker"/>
+  <xsd:complexType name="CT_AnchorClientData">
+    <xsd:attribute name="fLocksWithSheet" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="fPrintsWithSheet" type="xsd:boolean" use="optional" default="true"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ShapeNonVisual">
+    <xsd:sequence>
+      <xsd:element name="cNvPr" type="a:CT_NonVisualDrawingProps" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="cNvSpPr" type="a:CT_NonVisualDrawingShapeProps" minOccurs="1" maxOccurs="1"
+      />
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Shape">
+    <xsd:sequence>
+      <xsd:element name="nvSpPr" type="CT_ShapeNonVisual" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="spPr" type="a:CT_ShapeProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="style" type="a:CT_ShapeStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="txBody" type="a:CT_TextBody" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="macro" type="xsd:string" use="optional"/>
+    <xsd:attribute name="textlink" type="xsd:string" use="optional"/>
+    <xsd:attribute name="fLocksText" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="fPublished" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ConnectorNonVisual">
+    <xsd:sequence>
+      <xsd:element name="cNvPr" type="a:CT_NonVisualDrawingProps" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="cNvCxnSpPr" type="a:CT_NonVisualConnectorProperties" minOccurs="1"
+        maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Connector">
+    <xsd:sequence>
+      <xsd:element name="nvCxnSpPr" type="CT_ConnectorNonVisual" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="spPr" type="a:CT_ShapeProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="style" type="a:CT_ShapeStyle" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="macro" type="xsd:string" use="optional"/>
+    <xsd:attribute name="fPublished" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PictureNonVisual">
+    <xsd:sequence>
+      <xsd:element name="cNvPr" type="a:CT_NonVisualDrawingProps" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="cNvPicPr" type="a:CT_NonVisualPictureProperties" minOccurs="1"
+        maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Picture">
+    <xsd:sequence>
+      <xsd:element name="nvPicPr" type="CT_PictureNonVisual" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="blipFill" type="a:CT_BlipFillProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="spPr" type="a:CT_ShapeProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="style" type="a:CT_ShapeStyle" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="macro" type="xsd:string" use="optional" default=""/>
+    <xsd:attribute name="fPublished" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GraphicalObjectFrameNonVisual">
+    <xsd:sequence>
+      <xsd:element name="cNvPr" type="a:CT_NonVisualDrawingProps" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="cNvGraphicFramePr" type="a:CT_NonVisualGraphicFrameProperties"
+        minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GraphicalObjectFrame">
+    <xsd:sequence>
+      <xsd:element name="nvGraphicFramePr" type="CT_GraphicalObjectFrameNonVisual" minOccurs="1"
+        maxOccurs="1"/>
+      <xsd:element name="xfrm" type="a:CT_Transform2D" minOccurs="1" maxOccurs="1"/>
+      <xsd:element ref="a:graphic" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="macro" type="xsd:string" use="optional"/>
+    <xsd:attribute name="fPublished" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GroupShapeNonVisual">
+    <xsd:sequence>
+      <xsd:element name="cNvPr" type="a:CT_NonVisualDrawingProps" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="cNvGrpSpPr" type="a:CT_NonVisualGroupDrawingShapeProps" minOccurs="1"
+        maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GroupShape">
+    <xsd:sequence>
+      <xsd:element name="nvGrpSpPr" type="CT_GroupShapeNonVisual" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="grpSpPr" type="a:CT_GroupShapeProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:choice minOccurs="0" maxOccurs="unbounded">
+        <xsd:element name="sp" type="CT_Shape"/>
+        <xsd:element name="grpSp" type="CT_GroupShape"/>
+        <xsd:element name="graphicFrame" type="CT_GraphicalObjectFrame"/>
+        <xsd:element name="cxnSp" type="CT_Connector"/>
+        <xsd:element name="pic" type="CT_Picture"/>
+      </xsd:choice>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:group name="EG_ObjectChoices">
+    <xsd:sequence>
+      <xsd:choice minOccurs="1" maxOccurs="1">
+        <xsd:element name="sp" type="CT_Shape"/>
+        <xsd:element name="grpSp" type="CT_GroupShape"/>
+        <xsd:element name="graphicFrame" type="CT_GraphicalObjectFrame"/>
+        <xsd:element name="cxnSp" type="CT_Connector"/>
+        <xsd:element name="pic" type="CT_Picture"/>
+        <xsd:element name="contentPart" type="CT_Rel"/>
+      </xsd:choice>
+    </xsd:sequence>
+  </xsd:group>
+  <xsd:complexType name="CT_Rel">
+    <xsd:attribute ref="r:id" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_ColID">
+    <xsd:restriction base="xsd:int">
+      <xsd:minInclusive value="0"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_RowID">
+    <xsd:restriction base="xsd:int">
+      <xsd:minInclusive value="0"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Marker">
+    <xsd:sequence>
+      <xsd:element name="col" type="ST_ColID"/>
+      <xsd:element name="colOff" type="a:ST_Coordinate"/>
+      <xsd:element name="row" type="ST_RowID"/>
+      <xsd:element name="rowOff" type="a:ST_Coordinate"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_EditAs">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="twoCell"/>
+      <xsd:enumeration value="oneCell"/>
+      <xsd:enumeration value="absolute"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TwoCellAnchor">
+    <xsd:sequence>
+      <xsd:element name="from" type="CT_Marker"/>
+      <xsd:element name="to" type="CT_Marker"/>
+      <xsd:group ref="EG_ObjectChoices"/>
+      <xsd:element name="clientData" type="CT_AnchorClientData" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="editAs" type="ST_EditAs" use="optional" default="twoCell"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_OneCellAnchor">
+    <xsd:sequence>
+      <xsd:element name="from" type="CT_Marker"/>
+      <xsd:element name="ext" type="a:CT_PositiveSize2D"/>
+      <xsd:group ref="EG_ObjectChoices"/>
+      <xsd:element name="clientData" type="CT_AnchorClientData" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_AbsoluteAnchor">
+    <xsd:sequence>
+      <xsd:element name="pos" type="a:CT_Point2D"/>
+      <xsd:element name="ext" type="a:CT_PositiveSize2D"/>
+      <xsd:group ref="EG_ObjectChoices"/>
+      <xsd:element name="clientData" type="CT_AnchorClientData" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:group name="EG_Anchor">
+    <xsd:choice>
+      <xsd:element name="twoCellAnchor" type="CT_TwoCellAnchor"/>
+      <xsd:element name="oneCellAnchor" type="CT_OneCellAnchor"/>
+      <xsd:element name="absoluteAnchor" type="CT_AbsoluteAnchor"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:complexType name="CT_Drawing">
+    <xsd:sequence>
+      <xsd:group ref="EG_Anchor" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="wsDr" type="CT_Drawing"/>
+</xsd:schema>

--- a/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-wordprocessingDrawing.xsd
+++ b/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-wordprocessingDrawing.xsd
@@ -1,0 +1,287 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+  xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+  xmlns:dpct="http://schemas.openxmlformats.org/drawingml/2006/picture"
+  xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+  xmlns="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+  targetNamespace="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+  elementFormDefault="qualified">
+  <xsd:import namespace="http://schemas.openxmlformats.org/drawingml/2006/main"
+    schemaLocation="dml-main.xsd"/>
+  <xsd:import schemaLocation="wml.xsd"
+    namespace="http://schemas.openxmlformats.org/wordprocessingml/2006/main"/>
+  <xsd:import namespace="http://schemas.openxmlformats.org/drawingml/2006/picture"
+    schemaLocation="dml-picture.xsd"/>
+  <xsd:import namespace="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+    schemaLocation="shared-relationshipReference.xsd"/>
+  <xsd:complexType name="CT_EffectExtent">
+    <xsd:attribute name="l" type="a:ST_Coordinate" use="required"/>
+    <xsd:attribute name="t" type="a:ST_Coordinate" use="required"/>
+    <xsd:attribute name="r" type="a:ST_Coordinate" use="required"/>
+    <xsd:attribute name="b" type="a:ST_Coordinate" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_WrapDistance">
+    <xsd:restriction base="xsd:unsignedInt"/>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Inline">
+    <xsd:sequence>
+      <xsd:element name="extent" type="a:CT_PositiveSize2D"/>
+      <xsd:element name="effectExtent" type="CT_EffectExtent" minOccurs="0"/>
+      <xsd:element name="docPr" type="a:CT_NonVisualDrawingProps" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="cNvGraphicFramePr" type="a:CT_NonVisualGraphicFrameProperties"
+        minOccurs="0" maxOccurs="1"/>
+      <xsd:element ref="a:graphic" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="distT" type="ST_WrapDistance" use="optional"/>
+    <xsd:attribute name="distB" type="ST_WrapDistance" use="optional"/>
+    <xsd:attribute name="distL" type="ST_WrapDistance" use="optional"/>
+    <xsd:attribute name="distR" type="ST_WrapDistance" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_WrapText">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="bothSides"/>
+      <xsd:enumeration value="left"/>
+      <xsd:enumeration value="right"/>
+      <xsd:enumeration value="largest"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_WrapPath">
+    <xsd:sequence>
+      <xsd:element name="start" type="a:CT_Point2D" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="lineTo" type="a:CT_Point2D" minOccurs="2" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="edited" type="xsd:boolean" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_WrapNone"/>
+  <xsd:complexType name="CT_WrapSquare">
+    <xsd:sequence>
+      <xsd:element name="effectExtent" type="CT_EffectExtent" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="wrapText" type="ST_WrapText" use="required"/>
+    <xsd:attribute name="distT" type="ST_WrapDistance" use="optional"/>
+    <xsd:attribute name="distB" type="ST_WrapDistance" use="optional"/>
+    <xsd:attribute name="distL" type="ST_WrapDistance" use="optional"/>
+    <xsd:attribute name="distR" type="ST_WrapDistance" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_WrapTight">
+    <xsd:sequence>
+      <xsd:element name="wrapPolygon" type="CT_WrapPath" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="wrapText" type="ST_WrapText" use="required"/>
+    <xsd:attribute name="distL" type="ST_WrapDistance" use="optional"/>
+    <xsd:attribute name="distR" type="ST_WrapDistance" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_WrapThrough">
+    <xsd:sequence>
+      <xsd:element name="wrapPolygon" type="CT_WrapPath" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="wrapText" type="ST_WrapText" use="required"/>
+    <xsd:attribute name="distL" type="ST_WrapDistance" use="optional"/>
+    <xsd:attribute name="distR" type="ST_WrapDistance" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_WrapTopBottom">
+    <xsd:sequence>
+      <xsd:element name="effectExtent" type="CT_EffectExtent" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="distT" type="ST_WrapDistance" use="optional"/>
+    <xsd:attribute name="distB" type="ST_WrapDistance" use="optional"/>
+  </xsd:complexType>
+  <xsd:group name="EG_WrapType">
+    <xsd:sequence>
+      <xsd:choice minOccurs="1" maxOccurs="1">
+        <xsd:element name="wrapNone" type="CT_WrapNone" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="wrapSquare" type="CT_WrapSquare" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="wrapTight" type="CT_WrapTight" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="wrapThrough" type="CT_WrapThrough" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="wrapTopAndBottom" type="CT_WrapTopBottom" minOccurs="1" maxOccurs="1"/>
+      </xsd:choice>
+    </xsd:sequence>
+  </xsd:group>
+  <xsd:simpleType name="ST_PositionOffset">
+    <xsd:restriction base="xsd:int"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_AlignH">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="left"/>
+      <xsd:enumeration value="right"/>
+      <xsd:enumeration value="center"/>
+      <xsd:enumeration value="inside"/>
+      <xsd:enumeration value="outside"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_RelFromH">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="margin"/>
+      <xsd:enumeration value="page"/>
+      <xsd:enumeration value="column"/>
+      <xsd:enumeration value="character"/>
+      <xsd:enumeration value="leftMargin"/>
+      <xsd:enumeration value="rightMargin"/>
+      <xsd:enumeration value="insideMargin"/>
+      <xsd:enumeration value="outsideMargin"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_PosH">
+    <xsd:sequence>
+      <xsd:choice minOccurs="1" maxOccurs="1">
+        <xsd:element name="align" type="ST_AlignH" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="posOffset" type="ST_PositionOffset" minOccurs="1" maxOccurs="1"/>
+      </xsd:choice>
+    </xsd:sequence>
+    <xsd:attribute name="relativeFrom" type="ST_RelFromH" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_AlignV">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="top"/>
+      <xsd:enumeration value="bottom"/>
+      <xsd:enumeration value="center"/>
+      <xsd:enumeration value="inside"/>
+      <xsd:enumeration value="outside"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_RelFromV">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="margin"/>
+      <xsd:enumeration value="page"/>
+      <xsd:enumeration value="paragraph"/>
+      <xsd:enumeration value="line"/>
+      <xsd:enumeration value="topMargin"/>
+      <xsd:enumeration value="bottomMargin"/>
+      <xsd:enumeration value="insideMargin"/>
+      <xsd:enumeration value="outsideMargin"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_PosV">
+    <xsd:sequence>
+      <xsd:choice minOccurs="1" maxOccurs="1">
+        <xsd:element name="align" type="ST_AlignV" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="posOffset" type="ST_PositionOffset" minOccurs="1" maxOccurs="1"/>
+      </xsd:choice>
+    </xsd:sequence>
+    <xsd:attribute name="relativeFrom" type="ST_RelFromV" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Anchor">
+    <xsd:sequence>
+      <xsd:element name="simplePos" type="a:CT_Point2D"/>
+      <xsd:element name="positionH" type="CT_PosH"/>
+      <xsd:element name="positionV" type="CT_PosV"/>
+      <xsd:element name="extent" type="a:CT_PositiveSize2D"/>
+      <xsd:element name="effectExtent" type="CT_EffectExtent" minOccurs="0"/>
+      <xsd:group ref="EG_WrapType"/>
+      <xsd:element name="docPr" type="a:CT_NonVisualDrawingProps" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="cNvGraphicFramePr" type="a:CT_NonVisualGraphicFrameProperties"
+        minOccurs="0" maxOccurs="1"/>
+      <xsd:element ref="a:graphic" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="distT" type="ST_WrapDistance" use="optional"/>
+    <xsd:attribute name="distB" type="ST_WrapDistance" use="optional"/>
+    <xsd:attribute name="distL" type="ST_WrapDistance" use="optional"/>
+    <xsd:attribute name="distR" type="ST_WrapDistance" use="optional"/>
+    <xsd:attribute name="simplePos" type="xsd:boolean"/>
+    <xsd:attribute name="relativeHeight" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="behindDoc" type="xsd:boolean" use="required"/>
+    <xsd:attribute name="locked" type="xsd:boolean" use="required"/>
+    <xsd:attribute name="layoutInCell" type="xsd:boolean" use="required"/>
+    <xsd:attribute name="hidden" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="allowOverlap" type="xsd:boolean" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TxbxContent">
+    <xsd:group ref="w:EG_BlockLevelElts" minOccurs="1" maxOccurs="unbounded"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TextboxInfo">
+    <xsd:sequence>
+      <xsd:element name="txbxContent" type="CT_TxbxContent" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="extLst" type="a:CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:unsignedShort" use="optional" default="0"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_LinkedTextboxInformation">
+    <xsd:sequence>
+      <xsd:element name="extLst" type="a:CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:unsignedShort" use="required"/>
+    <xsd:attribute name="seq" type="xsd:unsignedShort" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_WordprocessingShape">
+    <xsd:sequence minOccurs="1" maxOccurs="1">
+      <xsd:element name="cNvPr" type="a:CT_NonVisualDrawingProps" minOccurs="0" maxOccurs="1"/>
+      <xsd:choice minOccurs="1" maxOccurs="1">
+        <xsd:element name="cNvSpPr" type="a:CT_NonVisualDrawingShapeProps" minOccurs="1"
+          maxOccurs="1"/>
+        <xsd:element name="cNvCnPr" type="a:CT_NonVisualConnectorProperties" minOccurs="1"
+          maxOccurs="1"/>
+      </xsd:choice>
+      <xsd:element name="spPr" type="a:CT_ShapeProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="style" type="a:CT_ShapeStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="a:CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+      <xsd:choice minOccurs="0" maxOccurs="1">
+        <xsd:element name="txbx" type="CT_TextboxInfo" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="linkedTxbx" type="CT_LinkedTextboxInformation" minOccurs="1"
+          maxOccurs="1"/>
+      </xsd:choice>
+      <xsd:element name="bodyPr" type="a:CT_TextBodyProperties" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="normalEastAsianFlow" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GraphicFrame">
+    <xsd:sequence>
+      <xsd:element name="cNvPr" type="a:CT_NonVisualDrawingProps" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="cNvFrPr" type="a:CT_NonVisualGraphicFrameProperties" minOccurs="1"
+        maxOccurs="1"/>
+      <xsd:element name="xfrm" type="a:CT_Transform2D" minOccurs="1" maxOccurs="1"/>
+      <xsd:element ref="a:graphic" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="extLst" type="a:CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_WordprocessingContentPartNonVisual">
+    <xsd:sequence>
+      <xsd:element name="cNvPr" type="a:CT_NonVisualDrawingProps" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="cNvContentPartPr" type="a:CT_NonVisualContentPartProperties" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_WordprocessingContentPart">
+    <xsd:sequence>
+      <xsd:element name="nvContentPartPr" type="CT_WordprocessingContentPartNonVisual" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="xfrm" type="a:CT_Transform2D" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="a:CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="bwMode" type="a:ST_BlackWhiteMode" use="optional"/>
+    <xsd:attribute ref="r:id" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_WordprocessingGroup">
+    <xsd:sequence minOccurs="1" maxOccurs="1">
+      <xsd:element name="cNvPr" type="a:CT_NonVisualDrawingProps" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="cNvGrpSpPr" type="a:CT_NonVisualGroupDrawingShapeProps" minOccurs="1"
+        maxOccurs="1"/>
+      <xsd:element name="grpSpPr" type="a:CT_GroupShapeProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:choice minOccurs="0" maxOccurs="unbounded">
+        <xsd:element ref="wsp"/>
+        <xsd:element name="grpSp" type="CT_WordprocessingGroup"/>
+        <xsd:element name="graphicFrame" type="CT_GraphicFrame"/>
+        <xsd:element ref="dpct:pic"/>
+        <xsd:element name="contentPart" type="CT_WordprocessingContentPart"/>
+      </xsd:choice>
+      <xsd:element name="extLst" type="a:CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_WordprocessingCanvas">
+    <xsd:sequence minOccurs="1" maxOccurs="1">
+      <xsd:element name="bg" type="a:CT_BackgroundFormatting" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="whole" type="a:CT_WholeE2oFormatting" minOccurs="0" maxOccurs="1"/>
+      <xsd:choice minOccurs="0" maxOccurs="unbounded">
+        <xsd:element ref="wsp"/>
+        <xsd:element ref="dpct:pic"/>
+        <xsd:element name="contentPart" type="CT_WordprocessingContentPart"/>
+        <xsd:element ref="wgp"/>
+        <xsd:element name="graphicFrame" type="CT_GraphicFrame"/>
+      </xsd:choice>
+      <xsd:element name="extLst" type="a:CT_OfficeArtExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="wpc" type="CT_WordprocessingCanvas"/>
+  <xsd:element name="wgp" type="CT_WordprocessingGroup"/>
+  <xsd:element name="wsp" type="CT_WordprocessingShape"/>
+  <xsd:element name="inline" type="CT_Inline"/>
+  <xsd:element name="anchor" type="CT_Anchor"/>
+</xsd:schema>

--- a/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/pml.xsd
+++ b/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/pml.xsd
@@ -1,0 +1,1676 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://schemas.openxmlformats.org/presentationml/2006/main"
+  xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+  xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+  xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+  xmlns:s="http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"
+  elementFormDefault="qualified"
+  targetNamespace="http://schemas.openxmlformats.org/presentationml/2006/main">
+  <xsd:import namespace="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+    schemaLocation="shared-relationshipReference.xsd"/>
+  <xsd:import namespace="http://schemas.openxmlformats.org/drawingml/2006/main"
+    schemaLocation="dml-main.xsd"/>
+  <xsd:import namespace="http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"
+    schemaLocation="shared-commonSimpleTypes.xsd"/>
+  <xsd:simpleType name="ST_TransitionSideDirectionType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="l"/>
+      <xsd:enumeration value="u"/>
+      <xsd:enumeration value="r"/>
+      <xsd:enumeration value="d"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TransitionCornerDirectionType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="lu"/>
+      <xsd:enumeration value="ru"/>
+      <xsd:enumeration value="ld"/>
+      <xsd:enumeration value="rd"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TransitionInOutDirectionType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="out"/>
+      <xsd:enumeration value="in"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_SideDirectionTransition">
+    <xsd:attribute name="dir" type="ST_TransitionSideDirectionType" use="optional" default="l"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CornerDirectionTransition">
+    <xsd:attribute name="dir" type="ST_TransitionCornerDirectionType" use="optional" default="lu"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TransitionEightDirectionType">
+    <xsd:union memberTypes="ST_TransitionSideDirectionType ST_TransitionCornerDirectionType"/>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_EightDirectionTransition">
+    <xsd:attribute name="dir" type="ST_TransitionEightDirectionType" use="optional" default="l"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_OrientationTransition">
+    <xsd:attribute name="dir" type="ST_Direction" use="optional" default="horz"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_InOutTransition">
+    <xsd:attribute name="dir" type="ST_TransitionInOutDirectionType" use="optional" default="out"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_OptionalBlackTransition">
+    <xsd:attribute name="thruBlk" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SplitTransition">
+    <xsd:attribute name="orient" type="ST_Direction" use="optional" default="horz"/>
+    <xsd:attribute name="dir" type="ST_TransitionInOutDirectionType" use="optional" default="out"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_WheelTransition">
+    <xsd:attribute name="spokes" type="xsd:unsignedInt" use="optional" default="4"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TransitionStartSoundAction">
+    <xsd:sequence>
+      <xsd:element minOccurs="1" maxOccurs="1" name="snd" type="a:CT_EmbeddedWAVAudioFile"/>
+    </xsd:sequence>
+    <xsd:attribute name="loop" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TransitionSoundAction">
+    <xsd:choice minOccurs="1" maxOccurs="1">
+      <xsd:element name="stSnd" type="CT_TransitionStartSoundAction"/>
+      <xsd:element name="endSnd" type="CT_Empty"/>
+    </xsd:choice>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TransitionSpeed">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="slow"/>
+      <xsd:enumeration value="med"/>
+      <xsd:enumeration value="fast"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_SlideTransition">
+    <xsd:sequence>
+      <xsd:choice minOccurs="0" maxOccurs="1">
+        <xsd:element name="blinds" type="CT_OrientationTransition"/>
+        <xsd:element name="checker" type="CT_OrientationTransition"/>
+        <xsd:element name="circle" type="CT_Empty"/>
+        <xsd:element name="dissolve" type="CT_Empty"/>
+        <xsd:element name="comb" type="CT_OrientationTransition"/>
+        <xsd:element name="cover" type="CT_EightDirectionTransition"/>
+        <xsd:element name="cut" type="CT_OptionalBlackTransition"/>
+        <xsd:element name="diamond" type="CT_Empty"/>
+        <xsd:element name="fade" type="CT_OptionalBlackTransition"/>
+        <xsd:element name="newsflash" type="CT_Empty"/>
+        <xsd:element name="plus" type="CT_Empty"/>
+        <xsd:element name="pull" type="CT_EightDirectionTransition"/>
+        <xsd:element name="push" type="CT_SideDirectionTransition"/>
+        <xsd:element name="random" type="CT_Empty"/>
+        <xsd:element name="randomBar" type="CT_OrientationTransition"/>
+        <xsd:element name="split" type="CT_SplitTransition"/>
+        <xsd:element name="strips" type="CT_CornerDirectionTransition"/>
+        <xsd:element name="wedge" type="CT_Empty"/>
+        <xsd:element name="wheel" type="CT_WheelTransition"/>
+        <xsd:element name="wipe" type="CT_SideDirectionTransition"/>
+        <xsd:element name="zoom" type="CT_InOutTransition"/>
+      </xsd:choice>
+      <xsd:element name="sndAc" minOccurs="0" maxOccurs="1" type="CT_TransitionSoundAction"/>
+      <xsd:element name="extLst" type="CT_ExtensionListModify" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="spd" type="ST_TransitionSpeed" use="optional" default="fast"/>
+    <xsd:attribute name="advClick" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="advTm" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TLTimeIndefinite">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="indefinite"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TLTime">
+    <xsd:union memberTypes="xsd:unsignedInt ST_TLTimeIndefinite"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TLTimeNodeID">
+    <xsd:restriction base="xsd:unsignedInt"/>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TLIterateIntervalTime">
+    <xsd:attribute name="val" type="ST_TLTime" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TLIterateIntervalPercentage">
+    <xsd:attribute name="val" type="a:ST_PositivePercentage" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_IterateType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="el"/>
+      <xsd:enumeration value="wd"/>
+      <xsd:enumeration value="lt"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TLIterateData">
+    <xsd:choice minOccurs="1" maxOccurs="1">
+      <xsd:element name="tmAbs" type="CT_TLIterateIntervalTime"/>
+      <xsd:element name="tmPct" type="CT_TLIterateIntervalPercentage"/>
+    </xsd:choice>
+    <xsd:attribute name="type" type="ST_IterateType" use="optional" default="el"/>
+    <xsd:attribute name="backwards" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TLSubShapeId">
+    <xsd:attribute name="spid" type="a:ST_ShapeID" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TLTextTargetElement">
+    <xsd:choice minOccurs="0" maxOccurs="1">
+      <xsd:element name="charRg" type="CT_IndexRange"/>
+      <xsd:element name="pRg" type="CT_IndexRange"/>
+    </xsd:choice>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TLChartSubelementType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="gridLegend"/>
+      <xsd:enumeration value="series"/>
+      <xsd:enumeration value="category"/>
+      <xsd:enumeration value="ptInSeries"/>
+      <xsd:enumeration value="ptInCategory"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TLOleChartTargetElement">
+    <xsd:attribute name="type" type="ST_TLChartSubelementType" use="required"/>
+    <xsd:attribute name="lvl" type="xsd:unsignedInt" use="optional" default="0"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TLShapeTargetElement">
+    <xsd:choice minOccurs="0" maxOccurs="1">
+      <xsd:element name="bg" type="CT_Empty"/>
+      <xsd:element name="subSp" type="CT_TLSubShapeId"/>
+      <xsd:element name="oleChartEl" type="CT_TLOleChartTargetElement"/>
+      <xsd:element name="txEl" type="CT_TLTextTargetElement"/>
+      <xsd:element name="graphicEl" type="a:CT_AnimationElementChoice"/>
+    </xsd:choice>
+    <xsd:attribute name="spid" type="a:ST_DrawingElementId" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TLTimeTargetElement">
+    <xsd:choice minOccurs="1" maxOccurs="1">
+      <xsd:element name="sldTgt" type="CT_Empty"/>
+      <xsd:element name="sndTgt" type="a:CT_EmbeddedWAVAudioFile"/>
+      <xsd:element name="spTgt" type="CT_TLShapeTargetElement"/>
+      <xsd:element name="inkTgt" type="CT_TLSubShapeId"/>
+    </xsd:choice>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TLTriggerTimeNodeID">
+    <xsd:attribute name="val" type="ST_TLTimeNodeID" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TLTriggerRuntimeNode">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="first"/>
+      <xsd:enumeration value="last"/>
+      <xsd:enumeration value="all"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TLTriggerRuntimeNode">
+    <xsd:attribute name="val" type="ST_TLTriggerRuntimeNode" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TLTriggerEvent">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="onBegin"/>
+      <xsd:enumeration value="onEnd"/>
+      <xsd:enumeration value="begin"/>
+      <xsd:enumeration value="end"/>
+      <xsd:enumeration value="onClick"/>
+      <xsd:enumeration value="onDblClick"/>
+      <xsd:enumeration value="onMouseOver"/>
+      <xsd:enumeration value="onMouseOut"/>
+      <xsd:enumeration value="onNext"/>
+      <xsd:enumeration value="onPrev"/>
+      <xsd:enumeration value="onStopAudio"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TLTimeCondition">
+    <xsd:choice minOccurs="0" maxOccurs="1">
+      <xsd:element name="tgtEl" type="CT_TLTimeTargetElement"/>
+      <xsd:element name="tn" type="CT_TLTriggerTimeNodeID"/>
+      <xsd:element name="rtn" type="CT_TLTriggerRuntimeNode"/>
+    </xsd:choice>
+    <xsd:attribute name="evt" use="optional" type="ST_TLTriggerEvent"/>
+    <xsd:attribute name="delay" type="ST_TLTime" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TLTimeConditionList">
+    <xsd:sequence>
+      <xsd:element name="cond" type="CT_TLTimeCondition" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TimeNodeList">
+    <xsd:choice minOccurs="1" maxOccurs="unbounded">
+      <xsd:element name="par" type="CT_TLTimeNodeParallel"/>
+      <xsd:element name="seq" type="CT_TLTimeNodeSequence"/>
+      <xsd:element name="excl" type="CT_TLTimeNodeExclusive"/>
+      <xsd:element name="anim" type="CT_TLAnimateBehavior"/>
+      <xsd:element name="animClr" type="CT_TLAnimateColorBehavior"/>
+      <xsd:element name="animEffect" type="CT_TLAnimateEffectBehavior"/>
+      <xsd:element name="animMotion" type="CT_TLAnimateMotionBehavior"/>
+      <xsd:element name="animRot" type="CT_TLAnimateRotationBehavior"/>
+      <xsd:element name="animScale" type="CT_TLAnimateScaleBehavior"/>
+      <xsd:element name="cmd" type="CT_TLCommandBehavior"/>
+      <xsd:element name="set" type="CT_TLSetBehavior"/>
+      <xsd:element name="audio" type="CT_TLMediaNodeAudio"/>
+      <xsd:element name="video" type="CT_TLMediaNodeVideo"/>
+    </xsd:choice>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TLTimeNodePresetClassType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="entr"/>
+      <xsd:enumeration value="exit"/>
+      <xsd:enumeration value="emph"/>
+      <xsd:enumeration value="path"/>
+      <xsd:enumeration value="verb"/>
+      <xsd:enumeration value="mediacall"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TLTimeNodeRestartType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="always"/>
+      <xsd:enumeration value="whenNotActive"/>
+      <xsd:enumeration value="never"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TLTimeNodeFillType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="remove"/>
+      <xsd:enumeration value="freeze"/>
+      <xsd:enumeration value="hold"/>
+      <xsd:enumeration value="transition"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TLTimeNodeSyncType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="canSlip"/>
+      <xsd:enumeration value="locked"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TLTimeNodeMasterRelation">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="sameClick"/>
+      <xsd:enumeration value="lastClick"/>
+      <xsd:enumeration value="nextClick"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TLTimeNodeType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="clickEffect"/>
+      <xsd:enumeration value="withEffect"/>
+      <xsd:enumeration value="afterEffect"/>
+      <xsd:enumeration value="mainSeq"/>
+      <xsd:enumeration value="interactiveSeq"/>
+      <xsd:enumeration value="clickPar"/>
+      <xsd:enumeration value="withGroup"/>
+      <xsd:enumeration value="afterGroup"/>
+      <xsd:enumeration value="tmRoot"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TLCommonTimeNodeData">
+    <xsd:sequence>
+      <xsd:element name="stCondLst" type="CT_TLTimeConditionList" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="endCondLst" type="CT_TLTimeConditionList" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="endSync" type="CT_TLTimeCondition" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="iterate" type="CT_TLIterateData" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="childTnLst" type="CT_TimeNodeList" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="subTnLst" type="CT_TimeNodeList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="ST_TLTimeNodeID" use="optional"/>
+    <xsd:attribute name="presetID" type="xsd:int" use="optional"/>
+    <xsd:attribute name="presetClass" type="ST_TLTimeNodePresetClassType" use="optional"/>
+    <xsd:attribute name="presetSubtype" type="xsd:int" use="optional"/>
+    <xsd:attribute name="dur" type="ST_TLTime" use="optional"/>
+    <xsd:attribute name="repeatCount" type="ST_TLTime" use="optional" default="1000"/>
+    <xsd:attribute name="repeatDur" type="ST_TLTime" use="optional"/>
+    <xsd:attribute name="spd" type="a:ST_Percentage" use="optional" default="100%"/>
+    <xsd:attribute name="accel" type="a:ST_PositiveFixedPercentage" use="optional" default="0%"/>
+    <xsd:attribute name="decel" type="a:ST_PositiveFixedPercentage" use="optional" default="0%"/>
+    <xsd:attribute name="autoRev" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="restart" type="ST_TLTimeNodeRestartType" use="optional"/>
+    <xsd:attribute name="fill" type="ST_TLTimeNodeFillType" use="optional"/>
+    <xsd:attribute name="syncBehavior" type="ST_TLTimeNodeSyncType" use="optional"/>
+    <xsd:attribute name="tmFilter" type="xsd:string" use="optional"/>
+    <xsd:attribute name="evtFilter" type="xsd:string" use="optional"/>
+    <xsd:attribute name="display" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="masterRel" type="ST_TLTimeNodeMasterRelation" use="optional"/>
+    <xsd:attribute name="bldLvl" type="xsd:int" use="optional"/>
+    <xsd:attribute name="grpId" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="afterEffect" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="nodeType" type="ST_TLTimeNodeType" use="optional"/>
+    <xsd:attribute name="nodePh" type="xsd:boolean" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TLTimeNodeParallel">
+    <xsd:sequence>
+      <xsd:element name="cTn" type="CT_TLCommonTimeNodeData" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TLNextActionType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="seek"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TLPreviousActionType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="skipTimed"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TLTimeNodeSequence">
+    <xsd:sequence>
+      <xsd:element name="cTn" type="CT_TLCommonTimeNodeData" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="prevCondLst" type="CT_TLTimeConditionList" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="nextCondLst" type="CT_TLTimeConditionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="concurrent" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="prevAc" type="ST_TLPreviousActionType" use="optional"/>
+    <xsd:attribute name="nextAc" type="ST_TLNextActionType" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TLTimeNodeExclusive">
+    <xsd:sequence>
+      <xsd:element name="cTn" type="CT_TLCommonTimeNodeData" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TLBehaviorAttributeNameList">
+    <xsd:sequence>
+      <xsd:element name="attrName" type="xsd:string" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TLBehaviorAdditiveType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="base"/>
+      <xsd:enumeration value="sum"/>
+      <xsd:enumeration value="repl"/>
+      <xsd:enumeration value="mult"/>
+      <xsd:enumeration value="none"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TLBehaviorAccumulateType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="always"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TLBehaviorTransformType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="pt"/>
+      <xsd:enumeration value="img"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TLBehaviorOverrideType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="normal"/>
+      <xsd:enumeration value="childStyle"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TLCommonBehaviorData">
+    <xsd:sequence>
+      <xsd:element name="cTn" type="CT_TLCommonTimeNodeData" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="tgtEl" type="CT_TLTimeTargetElement" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="attrNameLst" type="CT_TLBehaviorAttributeNameList" minOccurs="0"
+        maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="additive" type="ST_TLBehaviorAdditiveType" use="optional"/>
+    <xsd:attribute name="accumulate" type="ST_TLBehaviorAccumulateType" use="optional"/>
+    <xsd:attribute name="xfrmType" type="ST_TLBehaviorTransformType" use="optional"/>
+    <xsd:attribute name="from" type="xsd:string" use="optional"/>
+    <xsd:attribute name="to" type="xsd:string" use="optional"/>
+    <xsd:attribute name="by" type="xsd:string" use="optional"/>
+    <xsd:attribute name="rctx" type="xsd:string" use="optional"/>
+    <xsd:attribute name="override" type="ST_TLBehaviorOverrideType" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TLAnimVariantBooleanVal">
+    <xsd:attribute name="val" type="xsd:boolean" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TLAnimVariantIntegerVal">
+    <xsd:attribute name="val" type="xsd:int" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TLAnimVariantFloatVal">
+    <xsd:attribute name="val" type="xsd:float" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TLAnimVariantStringVal">
+    <xsd:attribute name="val" type="xsd:string" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TLAnimVariant">
+    <xsd:choice minOccurs="1" maxOccurs="1">
+      <xsd:element name="boolVal" type="CT_TLAnimVariantBooleanVal"/>
+      <xsd:element name="intVal" type="CT_TLAnimVariantIntegerVal"/>
+      <xsd:element name="fltVal" type="CT_TLAnimVariantFloatVal"/>
+      <xsd:element name="strVal" type="CT_TLAnimVariantStringVal"/>
+      <xsd:element name="clrVal" type="a:CT_Color"/>
+    </xsd:choice>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TLTimeAnimateValueTime">
+    <xsd:union memberTypes="a:ST_PositiveFixedPercentage ST_TLTimeIndefinite"/>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TLTimeAnimateValue">
+    <xsd:sequence>
+      <xsd:element name="val" type="CT_TLAnimVariant" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="tm" type="ST_TLTimeAnimateValueTime" use="optional" default="indefinite"/>
+    <xsd:attribute name="fmla" type="xsd:string" use="optional" default=""/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TLTimeAnimateValueList">
+    <xsd:sequence>
+      <xsd:element name="tav" type="CT_TLTimeAnimateValue" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TLAnimateBehaviorCalcMode">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="discrete"/>
+      <xsd:enumeration value="lin"/>
+      <xsd:enumeration value="fmla"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TLAnimateBehaviorValueType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="str"/>
+      <xsd:enumeration value="num"/>
+      <xsd:enumeration value="clr"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TLAnimateBehavior">
+    <xsd:sequence>
+      <xsd:element name="cBhvr" type="CT_TLCommonBehaviorData" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="tavLst" type="CT_TLTimeAnimateValueList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="by" type="xsd:string" use="optional"/>
+    <xsd:attribute name="from" type="xsd:string" use="optional"/>
+    <xsd:attribute name="to" type="xsd:string" use="optional"/>
+    <xsd:attribute name="calcmode" type="ST_TLAnimateBehaviorCalcMode" use="optional"/>
+    <xsd:attribute name="valueType" type="ST_TLAnimateBehaviorValueType" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TLByRgbColorTransform">
+    <xsd:attribute name="r" type="a:ST_FixedPercentage" use="required"/>
+    <xsd:attribute name="g" type="a:ST_FixedPercentage" use="required"/>
+    <xsd:attribute name="b" type="a:ST_FixedPercentage" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TLByHslColorTransform">
+    <xsd:attribute name="h" type="a:ST_Angle" use="required"/>
+    <xsd:attribute name="s" type="a:ST_FixedPercentage" use="required"/>
+    <xsd:attribute name="l" type="a:ST_FixedPercentage" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TLByAnimateColorTransform">
+    <xsd:choice minOccurs="1" maxOccurs="1">
+      <xsd:element name="rgb" type="CT_TLByRgbColorTransform"/>
+      <xsd:element name="hsl" type="CT_TLByHslColorTransform"/>
+    </xsd:choice>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TLAnimateColorSpace">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="rgb"/>
+      <xsd:enumeration value="hsl"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TLAnimateColorDirection">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="cw"/>
+      <xsd:enumeration value="ccw"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TLAnimateColorBehavior">
+    <xsd:sequence>
+      <xsd:element name="cBhvr" type="CT_TLCommonBehaviorData" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="by" type="CT_TLByAnimateColorTransform" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="from" type="a:CT_Color" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="to" type="a:CT_Color" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="clrSpc" type="ST_TLAnimateColorSpace" use="optional"/>
+    <xsd:attribute name="dir" type="ST_TLAnimateColorDirection" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TLAnimateEffectTransition">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="in"/>
+      <xsd:enumeration value="out"/>
+      <xsd:enumeration value="none"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TLAnimateEffectBehavior">
+    <xsd:sequence>
+      <xsd:element name="cBhvr" type="CT_TLCommonBehaviorData" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="progress" type="CT_TLAnimVariant" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="transition" type="ST_TLAnimateEffectTransition" default="in" use="optional"/>
+    <xsd:attribute name="filter" type="xsd:string" use="optional"/>
+    <xsd:attribute name="prLst" type="xsd:string" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TLAnimateMotionBehaviorOrigin">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="parent"/>
+      <xsd:enumeration value="layout"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TLAnimateMotionPathEditMode">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="relative"/>
+      <xsd:enumeration value="fixed"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TLPoint">
+    <xsd:attribute name="x" type="a:ST_Percentage" use="required"/>
+    <xsd:attribute name="y" type="a:ST_Percentage" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TLAnimateMotionBehavior">
+    <xsd:sequence>
+      <xsd:element name="cBhvr" type="CT_TLCommonBehaviorData" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="by" type="CT_TLPoint" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="from" type="CT_TLPoint" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="to" type="CT_TLPoint" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="rCtr" type="CT_TLPoint" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="origin" type="ST_TLAnimateMotionBehaviorOrigin" use="optional"/>
+    <xsd:attribute name="path" type="xsd:string" use="optional"/>
+    <xsd:attribute name="pathEditMode" type="ST_TLAnimateMotionPathEditMode" use="optional"/>
+    <xsd:attribute name="rAng" type="a:ST_Angle" use="optional"/>
+    <xsd:attribute name="ptsTypes" type="xsd:string" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TLAnimateRotationBehavior">
+    <xsd:sequence>
+      <xsd:element name="cBhvr" type="CT_TLCommonBehaviorData" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="by" type="a:ST_Angle" use="optional"/>
+    <xsd:attribute name="from" type="a:ST_Angle" use="optional"/>
+    <xsd:attribute name="to" type="a:ST_Angle" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TLAnimateScaleBehavior">
+    <xsd:sequence>
+      <xsd:element name="cBhvr" type="CT_TLCommonBehaviorData" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="by" type="CT_TLPoint" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="from" type="CT_TLPoint" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="to" type="CT_TLPoint" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="zoomContents" type="xsd:boolean" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TLCommandType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="evt"/>
+      <xsd:enumeration value="call"/>
+      <xsd:enumeration value="verb"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TLCommandBehavior">
+    <xsd:sequence>
+      <xsd:element name="cBhvr" type="CT_TLCommonBehaviorData" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute type="ST_TLCommandType" name="type" use="optional"/>
+    <xsd:attribute name="cmd" type="xsd:string" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TLSetBehavior">
+    <xsd:sequence>
+      <xsd:element name="cBhvr" type="CT_TLCommonBehaviorData" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="to" type="CT_TLAnimVariant" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TLCommonMediaNodeData">
+    <xsd:sequence>
+      <xsd:element name="cTn" type="CT_TLCommonTimeNodeData" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="tgtEl" type="CT_TLTimeTargetElement" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="vol" type="a:ST_PositiveFixedPercentage" default="50%" use="optional"/>
+    <xsd:attribute name="mute" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="numSld" type="xsd:unsignedInt" use="optional" default="1"/>
+    <xsd:attribute name="showWhenStopped" type="xsd:boolean" use="optional" default="true"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TLMediaNodeAudio">
+    <xsd:sequence>
+      <xsd:element name="cMediaNode" type="CT_TLCommonMediaNodeData" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="isNarration" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TLMediaNodeVideo">
+    <xsd:sequence>
+      <xsd:element name="cMediaNode" type="CT_TLCommonMediaNodeData" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="fullScrn" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:attributeGroup name="AG_TLBuild">
+    <xsd:attribute name="spid" type="a:ST_DrawingElementId" use="required"/>
+    <xsd:attribute name="grpId" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="uiExpand" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:attributeGroup>
+  <xsd:complexType name="CT_TLTemplate">
+    <xsd:sequence>
+      <xsd:element name="tnLst" type="CT_TimeNodeList" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="lvl" type="xsd:unsignedInt" use="optional" default="0"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TLTemplateList">
+    <xsd:sequence>
+      <xsd:element name="tmpl" type="CT_TLTemplate" minOccurs="0" maxOccurs="9"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TLParaBuildType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="allAtOnce"/>
+      <xsd:enumeration value="p"/>
+      <xsd:enumeration value="cust"/>
+      <xsd:enumeration value="whole"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TLBuildParagraph">
+    <xsd:sequence>
+      <xsd:element name="tmplLst" type="CT_TLTemplateList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attributeGroup ref="AG_TLBuild"/>
+    <xsd:attribute name="build" type="ST_TLParaBuildType" use="optional" default="whole"/>
+    <xsd:attribute name="bldLvl" type="xsd:unsignedInt" use="optional" default="1"/>
+    <xsd:attribute name="animBg" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="autoUpdateAnimBg" type="xsd:boolean" default="true" use="optional"/>
+    <xsd:attribute name="rev" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="advAuto" type="ST_TLTime" use="optional" default="indefinite"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TLDiagramBuildType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="whole"/>
+      <xsd:enumeration value="depthByNode"/>
+      <xsd:enumeration value="depthByBranch"/>
+      <xsd:enumeration value="breadthByNode"/>
+      <xsd:enumeration value="breadthByLvl"/>
+      <xsd:enumeration value="cw"/>
+      <xsd:enumeration value="cwIn"/>
+      <xsd:enumeration value="cwOut"/>
+      <xsd:enumeration value="ccw"/>
+      <xsd:enumeration value="ccwIn"/>
+      <xsd:enumeration value="ccwOut"/>
+      <xsd:enumeration value="inByRing"/>
+      <xsd:enumeration value="outByRing"/>
+      <xsd:enumeration value="up"/>
+      <xsd:enumeration value="down"/>
+      <xsd:enumeration value="allAtOnce"/>
+      <xsd:enumeration value="cust"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TLBuildDiagram">
+    <xsd:attributeGroup ref="AG_TLBuild"/>
+    <xsd:attribute name="bld" type="ST_TLDiagramBuildType" use="optional" default="whole"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TLOleChartBuildType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="allAtOnce"/>
+      <xsd:enumeration value="series"/>
+      <xsd:enumeration value="category"/>
+      <xsd:enumeration value="seriesEl"/>
+      <xsd:enumeration value="categoryEl"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TLOleBuildChart">
+    <xsd:attributeGroup ref="AG_TLBuild"/>
+    <xsd:attribute name="bld" type="ST_TLOleChartBuildType" use="optional" default="allAtOnce"/>
+    <xsd:attribute name="animBg" type="xsd:boolean" use="optional" default="true"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TLGraphicalObjectBuild">
+    <xsd:choice minOccurs="1" maxOccurs="1">
+      <xsd:element name="bldAsOne" type="CT_Empty"/>
+      <xsd:element name="bldSub" type="a:CT_AnimationGraphicalObjectBuildProperties"/>
+    </xsd:choice>
+    <xsd:attributeGroup ref="AG_TLBuild"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_BuildList">
+    <xsd:choice minOccurs="1" maxOccurs="unbounded">
+      <xsd:element name="bldP" type="CT_TLBuildParagraph"/>
+      <xsd:element name="bldDgm" type="CT_TLBuildDiagram"/>
+      <xsd:element name="bldOleChart" type="CT_TLOleBuildChart"/>
+      <xsd:element name="bldGraphic" type="CT_TLGraphicalObjectBuild"/>
+    </xsd:choice>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SlideTiming">
+    <xsd:sequence>
+      <xsd:element name="tnLst" type="CT_TimeNodeList" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="bldLst" type="CT_BuildList" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionListModify" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Empty"/>
+  <xsd:simpleType name="ST_Name">
+    <xsd:restriction base="xsd:string"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_Direction">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="horz"/>
+      <xsd:enumeration value="vert"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_Index">
+    <xsd:restriction base="xsd:unsignedInt"/>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_IndexRange">
+    <xsd:attribute name="st" type="ST_Index" use="required"/>
+    <xsd:attribute name="end" type="ST_Index" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SlideRelationshipListEntry">
+    <xsd:attribute ref="r:id" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SlideRelationshipList">
+    <xsd:sequence>
+      <xsd:element name="sld" type="CT_SlideRelationshipListEntry" minOccurs="0"
+        maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CustomShowId">
+    <xsd:attribute name="id" type="xsd:unsignedInt" use="required"/>
+  </xsd:complexType>
+  <xsd:group name="EG_SlideListChoice">
+    <xsd:choice>
+      <xsd:element name="sldAll" type="CT_Empty"/>
+      <xsd:element name="sldRg" type="CT_IndexRange"/>
+      <xsd:element name="custShow" type="CT_CustomShowId"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:complexType name="CT_CustomerData">
+    <xsd:attribute ref="r:id" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TagsData">
+    <xsd:attribute ref="r:id" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CustomerDataList">
+    <xsd:sequence minOccurs="0" maxOccurs="1">
+      <xsd:element name="custData" type="CT_CustomerData" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="tags" type="CT_TagsData" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Extension">
+    <xsd:sequence>
+      <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="uri" type="xsd:token" use="required"/>
+  </xsd:complexType>
+  <xsd:group name="EG_ExtensionList">
+    <xsd:sequence>
+      <xsd:element name="ext" type="CT_Extension" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:group>
+  <xsd:complexType name="CT_ExtensionList">
+    <xsd:sequence>
+      <xsd:group ref="EG_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ExtensionListModify">
+    <xsd:sequence>
+      <xsd:group ref="EG_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="mod" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CommentAuthor">
+    <xsd:sequence>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="name" type="ST_Name" use="required"/>
+    <xsd:attribute name="initials" type="ST_Name" use="required"/>
+    <xsd:attribute name="lastIdx" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="clrIdx" type="xsd:unsignedInt" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CommentAuthorList">
+    <xsd:sequence>
+      <xsd:element name="cmAuthor" type="CT_CommentAuthor" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="cmAuthorLst" type="CT_CommentAuthorList"/>
+  <xsd:complexType name="CT_Comment">
+    <xsd:sequence>
+      <xsd:element name="pos" type="a:CT_Point2D" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="text" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionListModify" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="authorId" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="dt" type="xsd:dateTime" use="optional"/>
+    <xsd:attribute name="idx" type="ST_Index" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CommentList">
+    <xsd:sequence>
+      <xsd:element name="cm" type="CT_Comment" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="cmLst" type="CT_CommentList"/>
+  <xsd:attributeGroup name="AG_Ole">
+    <xsd:attribute name="spid" type="a:ST_ShapeID" use="optional"/>
+    <xsd:attribute name="name" type="xsd:string" use="optional" default=""/>
+    <xsd:attribute name="showAsIcon" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute ref="r:id" use="optional"/>
+    <xsd:attribute name="imgW" type="a:ST_PositiveCoordinate32" use="optional"/>
+    <xsd:attribute name="imgH" type="a:ST_PositiveCoordinate32" use="optional"/>
+  </xsd:attributeGroup>
+  <xsd:simpleType name="ST_OleObjectFollowColorScheme">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="full"/>
+      <xsd:enumeration value="textAndBackground"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_OleObjectEmbed">
+    <xsd:sequence>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="followColorScheme" type="ST_OleObjectFollowColorScheme" use="optional"
+      default="none"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_OleObjectLink">
+    <xsd:sequence>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="updateAutomatic" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_OleObject">
+    <xsd:sequence>
+      <xsd:choice minOccurs="1" maxOccurs="1">
+        <xsd:element name="embed" type="CT_OleObjectEmbed"/>
+        <xsd:element name="link" type="CT_OleObjectLink"/>
+      </xsd:choice>
+      <xsd:element name="pic" type="CT_Picture" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attributeGroup ref="AG_Ole"/>
+    <xsd:attribute name="progId" type="xsd:string" use="optional"/>
+  </xsd:complexType>
+  <xsd:element name="oleObj" type="CT_OleObject"/>
+  <xsd:complexType name="CT_Control">
+    <xsd:sequence>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="pic" type="CT_Picture" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attributeGroup ref="AG_Ole"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ControlList">
+    <xsd:sequence>
+      <xsd:element name="control" type="CT_Control" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_SlideId">
+    <xsd:restriction base="xsd:unsignedInt">
+      <xsd:minInclusive value="256"/>
+      <xsd:maxExclusive value="2147483648"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_SlideIdListEntry">
+    <xsd:sequence>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="ST_SlideId" use="required"/>
+    <xsd:attribute ref="r:id" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SlideIdList">
+    <xsd:sequence>
+      <xsd:element name="sldId" type="CT_SlideIdListEntry" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_SlideMasterId">
+    <xsd:restriction base="xsd:unsignedInt">
+      <xsd:minInclusive value="2147483648"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_SlideMasterIdListEntry">
+    <xsd:sequence>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="ST_SlideMasterId" use="optional"/>
+    <xsd:attribute ref="r:id" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SlideMasterIdList">
+    <xsd:sequence>
+      <xsd:element name="sldMasterId" type="CT_SlideMasterIdListEntry" minOccurs="0"
+        maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_NotesMasterIdListEntry">
+    <xsd:sequence>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute ref="r:id" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_NotesMasterIdList">
+    <xsd:sequence>
+      <xsd:element name="notesMasterId" type="CT_NotesMasterIdListEntry" minOccurs="0" maxOccurs="1"
+      />
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_HandoutMasterIdListEntry">
+    <xsd:sequence>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute ref="r:id" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_HandoutMasterIdList">
+    <xsd:sequence>
+      <xsd:element name="handoutMasterId" type="CT_HandoutMasterIdListEntry" minOccurs="0"
+        maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_EmbeddedFontDataId">
+    <xsd:attribute ref="r:id" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_EmbeddedFontListEntry">
+    <xsd:sequence>
+      <xsd:element name="font" type="a:CT_TextFont" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="regular" type="CT_EmbeddedFontDataId" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="bold" type="CT_EmbeddedFontDataId" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="italic" type="CT_EmbeddedFontDataId" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="boldItalic" type="CT_EmbeddedFontDataId" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_EmbeddedFontList">
+    <xsd:sequence>
+      <xsd:element name="embeddedFont" type="CT_EmbeddedFontListEntry" minOccurs="0"
+        maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SmartTags">
+    <xsd:attribute ref="r:id" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CustomShow">
+    <xsd:sequence>
+      <xsd:element name="sldLst" type="CT_SlideRelationshipList" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="ST_Name" use="required"/>
+    <xsd:attribute name="id" type="xsd:unsignedInt" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CustomShowList">
+    <xsd:sequence>
+      <xsd:element name="custShow" type="CT_CustomShow" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_PhotoAlbumLayout">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="fitToSlide"/>
+      <xsd:enumeration value="1pic"/>
+      <xsd:enumeration value="2pic"/>
+      <xsd:enumeration value="4pic"/>
+      <xsd:enumeration value="1picTitle"/>
+      <xsd:enumeration value="2picTitle"/>
+      <xsd:enumeration value="4picTitle"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_PhotoAlbumFrameShape">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="frameStyle1"/>
+      <xsd:enumeration value="frameStyle2"/>
+      <xsd:enumeration value="frameStyle3"/>
+      <xsd:enumeration value="frameStyle4"/>
+      <xsd:enumeration value="frameStyle5"/>
+      <xsd:enumeration value="frameStyle6"/>
+      <xsd:enumeration value="frameStyle7"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_PhotoAlbum">
+    <xsd:sequence>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="bw" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="showCaptions" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="layout" type="ST_PhotoAlbumLayout" use="optional" default="fitToSlide"/>
+    <xsd:attribute name="frame" type="ST_PhotoAlbumFrameShape" use="optional" default="frameStyle1"
+    />
+  </xsd:complexType>
+  <xsd:simpleType name="ST_SlideSizeCoordinate">
+    <xsd:restriction base="a:ST_PositiveCoordinate32">
+      <xsd:minInclusive value="914400"/>
+      <xsd:maxInclusive value="51206400"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_SlideSizeType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="screen4x3"/>
+      <xsd:enumeration value="letter"/>
+      <xsd:enumeration value="A4"/>
+      <xsd:enumeration value="35mm"/>
+      <xsd:enumeration value="overhead"/>
+      <xsd:enumeration value="banner"/>
+      <xsd:enumeration value="custom"/>
+      <xsd:enumeration value="ledger"/>
+      <xsd:enumeration value="A3"/>
+      <xsd:enumeration value="B4ISO"/>
+      <xsd:enumeration value="B5ISO"/>
+      <xsd:enumeration value="B4JIS"/>
+      <xsd:enumeration value="B5JIS"/>
+      <xsd:enumeration value="hagakiCard"/>
+      <xsd:enumeration value="screen16x9"/>
+      <xsd:enumeration value="screen16x10"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_SlideSize">
+    <xsd:attribute name="cx" type="ST_SlideSizeCoordinate" use="required"/>
+    <xsd:attribute name="cy" type="ST_SlideSizeCoordinate" use="required"/>
+    <xsd:attribute name="type" type="ST_SlideSizeType" use="optional" default="custom"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Kinsoku">
+    <xsd:attribute name="lang" type="xsd:string" use="optional"/>
+    <xsd:attribute name="invalStChars" type="xsd:string" use="required"/>
+    <xsd:attribute name="invalEndChars" type="xsd:string" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_BookmarkIdSeed">
+    <xsd:restriction base="xsd:unsignedInt">
+      <xsd:minInclusive value="1"/>
+      <xsd:maxExclusive value="2147483648"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_ModifyVerifier">
+    <xsd:attribute name="algorithmName" type="xsd:string" use="optional"/>
+    <xsd:attribute name="hashValue" type="xsd:base64Binary" use="optional"/>
+    <xsd:attribute name="saltValue" type="xsd:base64Binary" use="optional"/>
+    <xsd:attribute name="spinValue" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="cryptProviderType" type="s:ST_CryptProv" use="optional"/>
+    <xsd:attribute name="cryptAlgorithmClass" type="s:ST_AlgClass" use="optional"/>
+    <xsd:attribute name="cryptAlgorithmType" type="s:ST_AlgType" use="optional"/>
+    <xsd:attribute name="cryptAlgorithmSid" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="spinCount" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="saltData" type="xsd:base64Binary" use="optional"/>
+    <xsd:attribute name="hashData" type="xsd:base64Binary" use="optional"/>
+    <xsd:attribute name="cryptProvider" type="xsd:string" use="optional"/>
+    <xsd:attribute name="algIdExt" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="algIdExtSource" type="xsd:string" use="optional"/>
+    <xsd:attribute name="cryptProviderTypeExt" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="cryptProviderTypeExtSource" type="xsd:string" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Presentation">
+    <xsd:sequence>
+      <xsd:element name="sldMasterIdLst" type="CT_SlideMasterIdList" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="notesMasterIdLst" type="CT_NotesMasterIdList" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="handoutMasterIdLst" type="CT_HandoutMasterIdList" minOccurs="0"
+        maxOccurs="1"/>
+      <xsd:element name="sldIdLst" type="CT_SlideIdList" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="sldSz" type="CT_SlideSize" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="notesSz" type="a:CT_PositiveSize2D" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="smartTags" type="CT_SmartTags" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="embeddedFontLst" type="CT_EmbeddedFontList" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="custShowLst" type="CT_CustomShowList" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="photoAlbum" type="CT_PhotoAlbum" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="custDataLst" type="CT_CustomerDataList" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="kinsoku" type="CT_Kinsoku" minOccurs="0"/>
+      <xsd:element name="defaultTextStyle" type="a:CT_TextListStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="modifyVerifier" type="CT_ModifyVerifier" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="serverZoom" type="a:ST_Percentage" use="optional" default="50%"/>
+    <xsd:attribute name="firstSlideNum" type="xsd:int" use="optional" default="1"/>
+    <xsd:attribute name="showSpecialPlsOnTitleSld" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="rtl" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="removePersonalInfoOnSave" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="compatMode" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="strictFirstAndLastChars" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="embedTrueTypeFonts" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="saveSubsetFonts" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="autoCompressPictures" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="bookmarkIdSeed" type="ST_BookmarkIdSeed" use="optional" default="1"/>
+    <xsd:attribute name="conformance" type="s:ST_ConformanceClass"/>
+  </xsd:complexType>
+  <xsd:element name="presentation" type="CT_Presentation"/>
+  <xsd:complexType name="CT_HtmlPublishProperties">
+    <xsd:sequence>
+      <xsd:group ref="EG_SlideListChoice" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="showSpeakerNotes" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="target" type="xsd:string" use="optional"/>
+    <xsd:attribute name="title" type="xsd:string" use="optional" default=""/>
+    <xsd:attribute ref="r:id" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_WebColorType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="browser"/>
+      <xsd:enumeration value="presentationText"/>
+      <xsd:enumeration value="presentationAccent"/>
+      <xsd:enumeration value="whiteTextOnBlack"/>
+      <xsd:enumeration value="blackTextOnWhite"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_WebScreenSize">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="544x376"/>
+      <xsd:enumeration value="640x480"/>
+      <xsd:enumeration value="720x512"/>
+      <xsd:enumeration value="800x600"/>
+      <xsd:enumeration value="1024x768"/>
+      <xsd:enumeration value="1152x882"/>
+      <xsd:enumeration value="1152x900"/>
+      <xsd:enumeration value="1280x1024"/>
+      <xsd:enumeration value="1600x1200"/>
+      <xsd:enumeration value="1800x1400"/>
+      <xsd:enumeration value="1920x1200"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_WebEncoding">
+    <xsd:restriction base="xsd:string"/>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_WebProperties">
+    <xsd:sequence>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="showAnimation" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="resizeGraphics" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="allowPng" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="relyOnVml" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="organizeInFolders" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="useLongFilenames" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="imgSz" type="ST_WebScreenSize" use="optional" default="800x600"/>
+    <xsd:attribute name="encoding" type="ST_WebEncoding" use="optional" default=""/>
+    <xsd:attribute name="clr" type="ST_WebColorType" use="optional" default="whiteTextOnBlack"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_PrintWhat">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="slides"/>
+      <xsd:enumeration value="handouts1"/>
+      <xsd:enumeration value="handouts2"/>
+      <xsd:enumeration value="handouts3"/>
+      <xsd:enumeration value="handouts4"/>
+      <xsd:enumeration value="handouts6"/>
+      <xsd:enumeration value="handouts9"/>
+      <xsd:enumeration value="notes"/>
+      <xsd:enumeration value="outline"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_PrintColorMode">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="bw"/>
+      <xsd:enumeration value="gray"/>
+      <xsd:enumeration value="clr"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_PrintProperties">
+    <xsd:sequence>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="prnWhat" type="ST_PrintWhat" use="optional" default="slides"/>
+    <xsd:attribute name="clrMode" type="ST_PrintColorMode" use="optional" default="clr"/>
+    <xsd:attribute name="hiddenSlides" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="scaleToFitPaper" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="frameSlides" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ShowInfoBrowse">
+    <xsd:attribute name="showScrollbar" type="xsd:boolean" use="optional" default="true"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ShowInfoKiosk">
+    <xsd:attribute name="restart" type="xsd:unsignedInt" use="optional" default="300000"/>
+  </xsd:complexType>
+  <xsd:group name="EG_ShowType">
+    <xsd:choice>
+      <xsd:element name="present" type="CT_Empty"/>
+      <xsd:element name="browse" type="CT_ShowInfoBrowse"/>
+      <xsd:element name="kiosk" type="CT_ShowInfoKiosk"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:complexType name="CT_ShowProperties">
+    <xsd:sequence minOccurs="0" maxOccurs="1">
+      <xsd:group ref="EG_ShowType" minOccurs="0" maxOccurs="1"/>
+      <xsd:group ref="EG_SlideListChoice" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="penClr" type="a:CT_Color" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="loop" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="showNarration" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="showAnimation" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="useTimings" type="xsd:boolean" use="optional" default="true"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PresentationProperties">
+    <xsd:sequence>
+      <xsd:element name="htmlPubPr" type="CT_HtmlPublishProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="webPr" type="CT_WebProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="prnPr" type="CT_PrintProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="showPr" type="CT_ShowProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="clrMru" type="a:CT_ColorMRU" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="presentationPr" type="CT_PresentationProperties"/>
+  <xsd:complexType name="CT_HeaderFooter">
+    <xsd:sequence>
+      <xsd:element name="extLst" type="CT_ExtensionListModify" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="sldNum" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="hdr" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="ftr" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="dt" type="xsd:boolean" use="optional" default="true"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_PlaceholderType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="title"/>
+      <xsd:enumeration value="body"/>
+      <xsd:enumeration value="ctrTitle"/>
+      <xsd:enumeration value="subTitle"/>
+      <xsd:enumeration value="dt"/>
+      <xsd:enumeration value="sldNum"/>
+      <xsd:enumeration value="ftr"/>
+      <xsd:enumeration value="hdr"/>
+      <xsd:enumeration value="obj"/>
+      <xsd:enumeration value="chart"/>
+      <xsd:enumeration value="tbl"/>
+      <xsd:enumeration value="clipArt"/>
+      <xsd:enumeration value="dgm"/>
+      <xsd:enumeration value="media"/>
+      <xsd:enumeration value="sldImg"/>
+      <xsd:enumeration value="pic"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_PlaceholderSize">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="full"/>
+      <xsd:enumeration value="half"/>
+      <xsd:enumeration value="quarter"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Placeholder">
+    <xsd:sequence>
+      <xsd:element name="extLst" type="CT_ExtensionListModify" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="type" type="ST_PlaceholderType" use="optional" default="obj"/>
+    <xsd:attribute name="orient" type="ST_Direction" use="optional" default="horz"/>
+    <xsd:attribute name="sz" type="ST_PlaceholderSize" use="optional" default="full"/>
+    <xsd:attribute name="idx" type="xsd:unsignedInt" use="optional" default="0"/>
+    <xsd:attribute name="hasCustomPrompt" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ApplicationNonVisualDrawingProps">
+    <xsd:sequence>
+      <xsd:element name="ph" type="CT_Placeholder" minOccurs="0" maxOccurs="1"/>
+      <xsd:group ref="a:EG_Media" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="custDataLst" type="CT_CustomerDataList" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="isPhoto" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="userDrawn" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ShapeNonVisual">
+    <xsd:sequence>
+      <xsd:element name="cNvPr" type="a:CT_NonVisualDrawingProps" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="cNvSpPr" type="a:CT_NonVisualDrawingShapeProps" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="nvPr" type="CT_ApplicationNonVisualDrawingProps" minOccurs="1"
+        maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Shape">
+    <xsd:sequence>
+      <xsd:element name="nvSpPr" type="CT_ShapeNonVisual" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="spPr" type="a:CT_ShapeProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="style" type="a:CT_ShapeStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="txBody" type="a:CT_TextBody" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionListModify" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="useBgFill" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ConnectorNonVisual">
+    <xsd:sequence>
+      <xsd:element name="cNvPr" type="a:CT_NonVisualDrawingProps" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="cNvCxnSpPr" type="a:CT_NonVisualConnectorProperties" minOccurs="1"
+        maxOccurs="1"/>
+      <xsd:element name="nvPr" type="CT_ApplicationNonVisualDrawingProps" minOccurs="1"
+        maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Connector">
+    <xsd:sequence>
+      <xsd:element name="nvCxnSpPr" type="CT_ConnectorNonVisual" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="spPr" type="a:CT_ShapeProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="style" type="a:CT_ShapeStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionListModify" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PictureNonVisual">
+    <xsd:sequence>
+      <xsd:element name="cNvPr" type="a:CT_NonVisualDrawingProps" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="cNvPicPr" type="a:CT_NonVisualPictureProperties" minOccurs="1"
+        maxOccurs="1"/>
+      <xsd:element name="nvPr" type="CT_ApplicationNonVisualDrawingProps" minOccurs="1"
+        maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Picture">
+    <xsd:sequence>
+      <xsd:element name="nvPicPr" type="CT_PictureNonVisual" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="blipFill" type="a:CT_BlipFillProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="spPr" type="a:CT_ShapeProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="style" type="a:CT_ShapeStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionListModify" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GraphicalObjectFrameNonVisual">
+    <xsd:sequence>
+      <xsd:element name="cNvPr" type="a:CT_NonVisualDrawingProps" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="cNvGraphicFramePr" type="a:CT_NonVisualGraphicFrameProperties"
+        minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="nvPr" type="CT_ApplicationNonVisualDrawingProps" minOccurs="1"
+        maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GraphicalObjectFrame">
+    <xsd:sequence>
+      <xsd:element name="nvGraphicFramePr" type="CT_GraphicalObjectFrameNonVisual" minOccurs="1"
+        maxOccurs="1"/>
+      <xsd:element name="xfrm" type="a:CT_Transform2D" minOccurs="1" maxOccurs="1"/>
+      <xsd:element ref="a:graphic" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionListModify" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="bwMode" type="a:ST_BlackWhiteMode" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GroupShapeNonVisual">
+    <xsd:sequence>
+      <xsd:element name="cNvPr" type="a:CT_NonVisualDrawingProps" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="cNvGrpSpPr" type="a:CT_NonVisualGroupDrawingShapeProps" minOccurs="1"
+        maxOccurs="1"/>
+      <xsd:element name="nvPr" type="CT_ApplicationNonVisualDrawingProps" minOccurs="1"
+        maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GroupShape">
+    <xsd:sequence>
+      <xsd:element name="nvGrpSpPr" type="CT_GroupShapeNonVisual" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="grpSpPr" type="a:CT_GroupShapeProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:choice minOccurs="0" maxOccurs="unbounded">
+        <xsd:element name="sp" type="CT_Shape"/>
+        <xsd:element name="grpSp" type="CT_GroupShape"/>
+        <xsd:element name="graphicFrame" type="CT_GraphicalObjectFrame"/>
+        <xsd:element name="cxnSp" type="CT_Connector"/>
+        <xsd:element name="pic" type="CT_Picture"/>
+        <xsd:element name="contentPart" type="CT_Rel"/>
+      </xsd:choice>
+      <xsd:element name="extLst" type="CT_ExtensionListModify" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Rel">
+    <xsd:attribute ref="r:id" use="required"/>
+  </xsd:complexType>
+  <xsd:group name="EG_TopLevelSlide">
+    <xsd:sequence>
+      <xsd:element name="clrMap" type="a:CT_ColorMapping" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:group>
+  <xsd:group name="EG_ChildSlide">
+    <xsd:sequence>
+      <xsd:element name="clrMapOvr" type="a:CT_ColorMappingOverride" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:group>
+  <xsd:attributeGroup name="AG_ChildSlide">
+    <xsd:attribute name="showMasterSp" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="showMasterPhAnim" type="xsd:boolean" use="optional" default="true"/>
+  </xsd:attributeGroup>
+  <xsd:complexType name="CT_BackgroundProperties">
+    <xsd:sequence>
+      <xsd:group ref="a:EG_FillProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:group ref="a:EG_EffectProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="shadeToTitle" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:group name="EG_Background">
+    <xsd:choice>
+      <xsd:element name="bgPr" type="CT_BackgroundProperties"/>
+      <xsd:element name="bgRef" type="a:CT_StyleMatrixReference"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:complexType name="CT_Background">
+    <xsd:sequence>
+      <xsd:group ref="EG_Background"/>
+    </xsd:sequence>
+    <xsd:attribute name="bwMode" type="a:ST_BlackWhiteMode" use="optional" default="white"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CommonSlideData">
+    <xsd:sequence>
+      <xsd:element name="bg" type="CT_Background" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="spTree" type="CT_GroupShape" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="custDataLst" type="CT_CustomerDataList" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="controls" type="CT_ControlList" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="optional" default=""/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Slide">
+    <xsd:sequence minOccurs="1" maxOccurs="1">
+      <xsd:element name="cSld" type="CT_CommonSlideData" minOccurs="1" maxOccurs="1"/>
+      <xsd:group ref="EG_ChildSlide" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="transition" type="CT_SlideTransition" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="timing" type="CT_SlideTiming" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionListModify" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attributeGroup ref="AG_ChildSlide"/>
+    <xsd:attribute name="show" type="xsd:boolean" use="optional" default="true"/>
+  </xsd:complexType>
+  <xsd:element name="sld" type="CT_Slide"/>
+  <xsd:simpleType name="ST_SlideLayoutType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="title"/>
+      <xsd:enumeration value="tx"/>
+      <xsd:enumeration value="twoColTx"/>
+      <xsd:enumeration value="tbl"/>
+      <xsd:enumeration value="txAndChart"/>
+      <xsd:enumeration value="chartAndTx"/>
+      <xsd:enumeration value="dgm"/>
+      <xsd:enumeration value="chart"/>
+      <xsd:enumeration value="txAndClipArt"/>
+      <xsd:enumeration value="clipArtAndTx"/>
+      <xsd:enumeration value="titleOnly"/>
+      <xsd:enumeration value="blank"/>
+      <xsd:enumeration value="txAndObj"/>
+      <xsd:enumeration value="objAndTx"/>
+      <xsd:enumeration value="objOnly"/>
+      <xsd:enumeration value="obj"/>
+      <xsd:enumeration value="txAndMedia"/>
+      <xsd:enumeration value="mediaAndTx"/>
+      <xsd:enumeration value="objOverTx"/>
+      <xsd:enumeration value="txOverObj"/>
+      <xsd:enumeration value="txAndTwoObj"/>
+      <xsd:enumeration value="twoObjAndTx"/>
+      <xsd:enumeration value="twoObjOverTx"/>
+      <xsd:enumeration value="fourObj"/>
+      <xsd:enumeration value="vertTx"/>
+      <xsd:enumeration value="clipArtAndVertTx"/>
+      <xsd:enumeration value="vertTitleAndTx"/>
+      <xsd:enumeration value="vertTitleAndTxOverChart"/>
+      <xsd:enumeration value="twoObj"/>
+      <xsd:enumeration value="objAndTwoObj"/>
+      <xsd:enumeration value="twoObjAndObj"/>
+      <xsd:enumeration value="cust"/>
+      <xsd:enumeration value="secHead"/>
+      <xsd:enumeration value="twoTxTwoObj"/>
+      <xsd:enumeration value="objTx"/>
+      <xsd:enumeration value="picTx"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_SlideLayout">
+    <xsd:sequence minOccurs="1" maxOccurs="1">
+      <xsd:element name="cSld" type="CT_CommonSlideData" minOccurs="1" maxOccurs="1"/>
+      <xsd:group ref="EG_ChildSlide" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="transition" type="CT_SlideTransition" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="timing" type="CT_SlideTiming" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="hf" type="CT_HeaderFooter" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionListModify" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attributeGroup ref="AG_ChildSlide"/>
+    <xsd:attribute name="matchingName" type="xsd:string" use="optional" default=""/>
+    <xsd:attribute name="type" type="ST_SlideLayoutType" use="optional" default="cust"/>
+    <xsd:attribute name="preserve" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="userDrawn" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:element name="sldLayout" type="CT_SlideLayout"/>
+  <xsd:complexType name="CT_SlideMasterTextStyles">
+    <xsd:sequence>
+      <xsd:element name="titleStyle" type="a:CT_TextListStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="bodyStyle" type="a:CT_TextListStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="otherStyle" type="a:CT_TextListStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_SlideLayoutId">
+    <xsd:restriction base="xsd:unsignedInt">
+      <xsd:minInclusive value="2147483648"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_SlideLayoutIdListEntry">
+    <xsd:sequence>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="ST_SlideLayoutId" use="optional"/>
+    <xsd:attribute ref="r:id" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SlideLayoutIdList">
+    <xsd:sequence>
+      <xsd:element name="sldLayoutId" type="CT_SlideLayoutIdListEntry" minOccurs="0"
+        maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SlideMaster">
+    <xsd:sequence minOccurs="1" maxOccurs="1">
+      <xsd:element name="cSld" type="CT_CommonSlideData" minOccurs="1" maxOccurs="1"/>
+      <xsd:group ref="EG_TopLevelSlide" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="sldLayoutIdLst" type="CT_SlideLayoutIdList" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="transition" type="CT_SlideTransition" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="timing" type="CT_SlideTiming" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="hf" type="CT_HeaderFooter" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="txStyles" type="CT_SlideMasterTextStyles" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionListModify" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="preserve" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:element name="sldMaster" type="CT_SlideMaster"/>
+  <xsd:complexType name="CT_HandoutMaster">
+    <xsd:sequence>
+      <xsd:element name="cSld" type="CT_CommonSlideData" minOccurs="1" maxOccurs="1"/>
+      <xsd:group ref="EG_TopLevelSlide" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="hf" type="CT_HeaderFooter" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionListModify" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="handoutMaster" type="CT_HandoutMaster"/>
+  <xsd:complexType name="CT_NotesMaster">
+    <xsd:sequence>
+      <xsd:element name="cSld" type="CT_CommonSlideData" minOccurs="1" maxOccurs="1"/>
+      <xsd:group ref="EG_TopLevelSlide" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="hf" type="CT_HeaderFooter" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="notesStyle" type="a:CT_TextListStyle" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionListModify" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="notesMaster" type="CT_NotesMaster"/>
+  <xsd:complexType name="CT_NotesSlide">
+    <xsd:sequence minOccurs="1" maxOccurs="1">
+      <xsd:element name="cSld" type="CT_CommonSlideData" minOccurs="1" maxOccurs="1"/>
+      <xsd:group ref="EG_ChildSlide" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionListModify" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attributeGroup ref="AG_ChildSlide"/>
+  </xsd:complexType>
+  <xsd:element name="notes" type="CT_NotesSlide"/>
+  <xsd:complexType name="CT_SlideSyncProperties">
+    <xsd:sequence>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="serverSldId" type="xsd:string" use="required"/>
+    <xsd:attribute name="serverSldModifiedTime" type="xsd:dateTime" use="required"/>
+    <xsd:attribute name="clientInsertedTime" type="xsd:dateTime" use="required"/>
+  </xsd:complexType>
+  <xsd:element name="sldSyncPr" type="CT_SlideSyncProperties"/>
+  <xsd:complexType name="CT_StringTag">
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="val" type="xsd:string" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TagList">
+    <xsd:sequence>
+      <xsd:element name="tag" type="CT_StringTag" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="tagLst" type="CT_TagList"/>
+  <xsd:simpleType name="ST_SplitterBarState">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="minimized"/>
+      <xsd:enumeration value="restored"/>
+      <xsd:enumeration value="maximized"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_ViewType">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="sldView"/>
+      <xsd:enumeration value="sldMasterView"/>
+      <xsd:enumeration value="notesView"/>
+      <xsd:enumeration value="handoutView"/>
+      <xsd:enumeration value="notesMasterView"/>
+      <xsd:enumeration value="outlineView"/>
+      <xsd:enumeration value="sldSorterView"/>
+      <xsd:enumeration value="sldThumbnailView"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_NormalViewPortion">
+    <xsd:attribute name="sz" type="a:ST_PositiveFixedPercentage" use="required"/>
+    <xsd:attribute name="autoAdjust" type="xsd:boolean" use="optional" default="true"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_NormalViewProperties">
+    <xsd:sequence>
+      <xsd:element name="restoredLeft" type="CT_NormalViewPortion" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="restoredTop" type="CT_NormalViewPortion" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="showOutlineIcons" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="snapVertSplitter" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="vertBarState" type="ST_SplitterBarState" use="optional" default="restored"/>
+    <xsd:attribute name="horzBarState" type="ST_SplitterBarState" use="optional" default="restored"/>
+    <xsd:attribute name="preferSingleView" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CommonViewProperties">
+    <xsd:sequence>
+      <xsd:element name="scale" type="a:CT_Scale2D" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="origin" type="a:CT_Point2D" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="varScale" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_NotesTextViewProperties">
+    <xsd:sequence minOccurs="1" maxOccurs="1">
+      <xsd:element name="cViewPr" type="CT_CommonViewProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_OutlineViewSlideEntry">
+    <xsd:attribute ref="r:id" use="required"/>
+    <xsd:attribute name="collapse" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_OutlineViewSlideList">
+    <xsd:sequence>
+      <xsd:element name="sld" type="CT_OutlineViewSlideEntry" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_OutlineViewProperties">
+    <xsd:sequence minOccurs="1" maxOccurs="1">
+      <xsd:element name="cViewPr" type="CT_CommonViewProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="sldLst" type="CT_OutlineViewSlideList" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SlideSorterViewProperties">
+    <xsd:sequence minOccurs="1" maxOccurs="1">
+      <xsd:element name="cViewPr" type="CT_CommonViewProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="showFormatting" type="xsd:boolean" use="optional" default="true"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Guide">
+    <xsd:attribute name="orient" type="ST_Direction" use="optional" default="vert"/>
+    <xsd:attribute name="pos" type="a:ST_Coordinate32" use="optional" default="0"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GuideList">
+    <xsd:sequence minOccurs="0" maxOccurs="1">
+      <xsd:element name="guide" type="CT_Guide" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CommonSlideViewProperties">
+    <xsd:sequence>
+      <xsd:element name="cViewPr" type="CT_CommonViewProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="guideLst" type="CT_GuideList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="snapToGrid" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="snapToObjects" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="showGuides" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SlideViewProperties">
+    <xsd:sequence>
+      <xsd:element name="cSldViewPr" type="CT_CommonSlideViewProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_NotesViewProperties">
+    <xsd:sequence>
+      <xsd:element name="cSldViewPr" type="CT_CommonSlideViewProperties" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ViewProperties">
+    <xsd:sequence minOccurs="0" maxOccurs="1">
+      <xsd:element name="normalViewPr" type="CT_NormalViewProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="slideViewPr" type="CT_SlideViewProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="outlineViewPr" type="CT_OutlineViewProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="notesTextViewPr" type="CT_NotesTextViewProperties" minOccurs="0"
+        maxOccurs="1"/>
+      <xsd:element name="sorterViewPr" type="CT_SlideSorterViewProperties" minOccurs="0"
+        maxOccurs="1"/>
+      <xsd:element name="notesViewPr" type="CT_NotesViewProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="gridSpacing" type="a:CT_PositiveSize2D" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="lastView" type="ST_ViewType" use="optional" default="sldView"/>
+    <xsd:attribute name="showComments" type="xsd:boolean" use="optional" default="true"/>
+  </xsd:complexType>
+  <xsd:element name="viewPr" type="CT_ViewProperties"/>
+</xsd:schema>

--- a/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-additionalCharacteristics.xsd
+++ b/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-additionalCharacteristics.xsd
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://schemas.openxmlformats.org/officeDocument/2006/characteristics"
+  targetNamespace="http://schemas.openxmlformats.org/officeDocument/2006/characteristics"
+  elementFormDefault="qualified">
+  <xsd:complexType name="CT_AdditionalCharacteristics">
+    <xsd:sequence>
+      <xsd:element name="characteristic" type="CT_Characteristic" minOccurs="0"
+        maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Characteristic">
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="relation" type="ST_Relation" use="required"/>
+    <xsd:attribute name="val" type="xsd:string" use="required"/>
+    <xsd:attribute name="vocabulary" type="xsd:anyURI" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_Relation">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="ge"/>
+      <xsd:enumeration value="le"/>
+      <xsd:enumeration value="gt"/>
+      <xsd:enumeration value="lt"/>
+      <xsd:enumeration value="eq"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:element name="additionalCharacteristics" type="CT_AdditionalCharacteristics"/>
+</xsd:schema>

--- a/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-bibliography.xsd
+++ b/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-bibliography.xsd
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://schemas.openxmlformats.org/officeDocument/2006/bibliography"
+  xmlns:s="http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"
+  targetNamespace="http://schemas.openxmlformats.org/officeDocument/2006/bibliography"
+  elementFormDefault="qualified">
+  <xsd:import namespace="http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"
+    schemaLocation="shared-commonSimpleTypes.xsd"/>
+  <xsd:simpleType name="ST_SourceType">
+    <xsd:restriction base="s:ST_String">
+      <xsd:enumeration value="ArticleInAPeriodical"/>
+      <xsd:enumeration value="Book"/>
+      <xsd:enumeration value="BookSection"/>
+      <xsd:enumeration value="JournalArticle"/>
+      <xsd:enumeration value="ConferenceProceedings"/>
+      <xsd:enumeration value="Report"/>
+      <xsd:enumeration value="SoundRecording"/>
+      <xsd:enumeration value="Performance"/>
+      <xsd:enumeration value="Art"/>
+      <xsd:enumeration value="DocumentFromInternetSite"/>
+      <xsd:enumeration value="InternetSite"/>
+      <xsd:enumeration value="Film"/>
+      <xsd:enumeration value="Interview"/>
+      <xsd:enumeration value="Patent"/>
+      <xsd:enumeration value="ElectronicSource"/>
+      <xsd:enumeration value="Case"/>
+      <xsd:enumeration value="Misc"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_NameListType">
+    <xsd:sequence>
+      <xsd:element name="Person" type="CT_PersonType" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PersonType">
+    <xsd:sequence>
+      <xsd:element name="Last" type="s:ST_String" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="First" type="s:ST_String" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="Middle" type="s:ST_String" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_NameType">
+    <xsd:sequence>
+      <xsd:element name="NameList" type="CT_NameListType" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_NameOrCorporateType">
+    <xsd:sequence>
+      <xsd:choice minOccurs="0" maxOccurs="1">
+        <xsd:element name="NameList" type="CT_NameListType" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="Corporate" minOccurs="1" maxOccurs="1" type="s:ST_String"/>
+      </xsd:choice>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_AuthorType">
+    <xsd:sequence>
+      <xsd:choice minOccurs="0" maxOccurs="unbounded">
+        <xsd:element name="Artist" type="CT_NameType"/>
+        <xsd:element name="Author" type="CT_NameOrCorporateType"/>
+        <xsd:element name="BookAuthor" type="CT_NameType"/>
+        <xsd:element name="Compiler" type="CT_NameType"/>
+        <xsd:element name="Composer" type="CT_NameType"/>
+        <xsd:element name="Conductor" type="CT_NameType"/>
+        <xsd:element name="Counsel" type="CT_NameType"/>
+        <xsd:element name="Director" type="CT_NameType"/>
+        <xsd:element name="Editor" type="CT_NameType"/>
+        <xsd:element name="Interviewee" type="CT_NameType"/>
+        <xsd:element name="Interviewer" type="CT_NameType"/>
+        <xsd:element name="Inventor" type="CT_NameType"/>
+        <xsd:element name="Performer" type="CT_NameOrCorporateType"/>
+        <xsd:element name="ProducerName" type="CT_NameType"/>
+        <xsd:element name="Translator" type="CT_NameType"/>
+        <xsd:element name="Writer" type="CT_NameType"/>
+      </xsd:choice>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SourceType">
+    <xsd:sequence>
+      <xsd:choice minOccurs="0" maxOccurs="unbounded">
+        <xsd:element name="AbbreviatedCaseNumber" type="s:ST_String"/>
+        <xsd:element name="AlbumTitle" type="s:ST_String"/>
+        <xsd:element name="Author" type="CT_AuthorType"/>
+        <xsd:element name="BookTitle" type="s:ST_String"/>
+        <xsd:element name="Broadcaster" type="s:ST_String"/>
+        <xsd:element name="BroadcastTitle" type="s:ST_String"/>
+        <xsd:element name="CaseNumber" type="s:ST_String"/>
+        <xsd:element name="ChapterNumber" type="s:ST_String"/>
+        <xsd:element name="City" type="s:ST_String"/>
+        <xsd:element name="Comments" type="s:ST_String"/>
+        <xsd:element name="ConferenceName" type="s:ST_String"/>
+        <xsd:element name="CountryRegion" type="s:ST_String"/>
+        <xsd:element name="Court" type="s:ST_String"/>
+        <xsd:element name="Day" type="s:ST_String"/>
+        <xsd:element name="DayAccessed" type="s:ST_String"/>
+        <xsd:element name="Department" type="s:ST_String"/>
+        <xsd:element name="Distributor" type="s:ST_String"/>
+        <xsd:element name="Edition" type="s:ST_String"/>
+        <xsd:element name="Guid" type="s:ST_String"/>
+        <xsd:element name="Institution" type="s:ST_String"/>
+        <xsd:element name="InternetSiteTitle" type="s:ST_String"/>
+        <xsd:element name="Issue" type="s:ST_String"/>
+        <xsd:element name="JournalName" type="s:ST_String"/>
+        <xsd:element name="LCID" type="s:ST_Lang"/>
+        <xsd:element name="Medium" type="s:ST_String"/>
+        <xsd:element name="Month" type="s:ST_String"/>
+        <xsd:element name="MonthAccessed" type="s:ST_String"/>
+        <xsd:element name="NumberVolumes" type="s:ST_String"/>
+        <xsd:element name="Pages" type="s:ST_String"/>
+        <xsd:element name="PatentNumber" type="s:ST_String"/>
+        <xsd:element name="PeriodicalTitle" type="s:ST_String"/>
+        <xsd:element name="ProductionCompany" type="s:ST_String"/>
+        <xsd:element name="PublicationTitle" type="s:ST_String"/>
+        <xsd:element name="Publisher" type="s:ST_String"/>
+        <xsd:element name="RecordingNumber" type="s:ST_String"/>
+        <xsd:element name="RefOrder" type="s:ST_String"/>
+        <xsd:element name="Reporter" type="s:ST_String"/>
+        <xsd:element name="SourceType" type="ST_SourceType"/>
+        <xsd:element name="ShortTitle" type="s:ST_String"/>
+        <xsd:element name="StandardNumber" type="s:ST_String"/>
+        <xsd:element name="StateProvince" type="s:ST_String"/>
+        <xsd:element name="Station" type="s:ST_String"/>
+        <xsd:element name="Tag" type="s:ST_String"/>
+        <xsd:element name="Theater" type="s:ST_String"/>
+        <xsd:element name="ThesisType" type="s:ST_String"/>
+        <xsd:element name="Title" type="s:ST_String"/>
+        <xsd:element name="Type" type="s:ST_String"/>
+        <xsd:element name="URL" type="s:ST_String"/>
+        <xsd:element name="Version" type="s:ST_String"/>
+        <xsd:element name="Volume" type="s:ST_String"/>
+        <xsd:element name="Year" type="s:ST_String"/>
+        <xsd:element name="YearAccessed" type="s:ST_String"/>
+      </xsd:choice>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="Sources" type="CT_Sources"/>
+  <xsd:complexType name="CT_Sources">
+    <xsd:sequence>
+      <xsd:element name="Source" type="CT_SourceType" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="SelectedStyle" type="s:ST_String"/>
+    <xsd:attribute name="StyleName" type="s:ST_String"/>
+    <xsd:attribute name="URI" type="s:ST_String"/>
+  </xsd:complexType>
+</xsd:schema>

--- a/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-commonSimpleTypes.xsd
+++ b/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-commonSimpleTypes.xsd
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"
+  targetNamespace="http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"
+  elementFormDefault="qualified">
+  <xsd:simpleType name="ST_Lang">
+    <xsd:restriction base="xsd:string"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_HexColorRGB">
+    <xsd:restriction base="xsd:hexBinary">
+      <xsd:length value="3" fixed="true"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_Panose">
+    <xsd:restriction base="xsd:hexBinary">
+      <xsd:length value="10"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_CalendarType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="gregorian"/>
+      <xsd:enumeration value="gregorianUs"/>
+      <xsd:enumeration value="gregorianMeFrench"/>
+      <xsd:enumeration value="gregorianArabic"/>
+      <xsd:enumeration value="hijri"/>
+      <xsd:enumeration value="hebrew"/>
+      <xsd:enumeration value="taiwan"/>
+      <xsd:enumeration value="japan"/>
+      <xsd:enumeration value="thai"/>
+      <xsd:enumeration value="korea"/>
+      <xsd:enumeration value="saka"/>
+      <xsd:enumeration value="gregorianXlitEnglish"/>
+      <xsd:enumeration value="gregorianXlitFrench"/>
+      <xsd:enumeration value="none"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_AlgClass">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="hash"/>
+      <xsd:enumeration value="custom"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_CryptProv">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="rsaAES"/>
+      <xsd:enumeration value="rsaFull"/>
+      <xsd:enumeration value="custom"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_AlgType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="typeAny"/>
+      <xsd:enumeration value="custom"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_ColorType">
+    <xsd:restriction base="xsd:string"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_Guid">
+    <xsd:restriction base="xsd:token">
+      <xsd:pattern value="\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\}"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_OnOff">
+    <xsd:union memberTypes="xsd:boolean ST_OnOff1"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_OnOff1">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="on"/>
+      <xsd:enumeration value="off"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_String">
+    <xsd:restriction base="xsd:string"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_XmlName">
+    <xsd:restriction base="xsd:NCName">
+      <xsd:minLength value="1"/>
+      <xsd:maxLength value="255"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TrueFalse">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="t"/>
+      <xsd:enumeration value="f"/>
+      <xsd:enumeration value="true"/>
+      <xsd:enumeration value="false"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TrueFalseBlank">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="t"/>
+      <xsd:enumeration value="f"/>
+      <xsd:enumeration value="true"/>
+      <xsd:enumeration value="false"/>
+      <xsd:enumeration value=""/>
+      <xsd:enumeration value="True"/>
+      <xsd:enumeration value="False"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_UnsignedDecimalNumber">
+    <xsd:restriction base="xsd:decimal">
+      <xsd:minInclusive value="0"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TwipsMeasure">
+    <xsd:union memberTypes="ST_UnsignedDecimalNumber ST_PositiveUniversalMeasure"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_VerticalAlignRun">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="baseline"/>
+      <xsd:enumeration value="superscript"/>
+      <xsd:enumeration value="subscript"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_Xstring">
+    <xsd:restriction base="xsd:string"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_XAlign">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="left"/>
+      <xsd:enumeration value="center"/>
+      <xsd:enumeration value="right"/>
+      <xsd:enumeration value="inside"/>
+      <xsd:enumeration value="outside"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_YAlign">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="inline"/>
+      <xsd:enumeration value="top"/>
+      <xsd:enumeration value="center"/>
+      <xsd:enumeration value="bottom"/>
+      <xsd:enumeration value="inside"/>
+      <xsd:enumeration value="outside"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_ConformanceClass">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="strict"/>
+      <xsd:enumeration value="transitional"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_UniversalMeasure">
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="-?[0-9]+(\.[0-9]+)?(mm|cm|in|pt|pc|pi)"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_PositiveUniversalMeasure">
+    <xsd:restriction base="ST_UniversalMeasure">
+      <xsd:pattern value="[0-9]+(\.[0-9]+)?(mm|cm|in|pt|pc|pi)"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_Percentage">
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="-?[0-9]+(\.[0-9]+)?%"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_FixedPercentage">
+    <xsd:restriction base="ST_Percentage">
+      <xsd:pattern value="-?((100)|([0-9][0-9]?))(\.[0-9][0-9]?)?%"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_PositivePercentage">
+    <xsd:restriction base="ST_Percentage">
+      <xsd:pattern value="[0-9]+(\.[0-9]+)?%"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_PositiveFixedPercentage">
+    <xsd:restriction base="ST_Percentage">
+      <xsd:pattern value="((100)|([0-9][0-9]?))(\.[0-9][0-9]?)?%"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+</xsd:schema>

--- a/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-customXmlDataProperties.xsd
+++ b/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-customXmlDataProperties.xsd
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://schemas.openxmlformats.org/officeDocument/2006/customXml"
+  xmlns:s="http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"
+  targetNamespace="http://schemas.openxmlformats.org/officeDocument/2006/customXml"
+  elementFormDefault="qualified" attributeFormDefault="qualified" blockDefault="#all">
+  <xsd:import namespace="http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"
+    schemaLocation="shared-commonSimpleTypes.xsd"/>
+  <xsd:complexType name="CT_DatastoreSchemaRef">
+    <xsd:attribute name="uri" type="xsd:string" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DatastoreSchemaRefs">
+    <xsd:sequence>
+      <xsd:element name="schemaRef" type="CT_DatastoreSchemaRef" minOccurs="0" maxOccurs="unbounded"
+      />
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DatastoreItem">
+    <xsd:sequence>
+      <xsd:element name="schemaRefs" type="CT_DatastoreSchemaRefs" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="itemID" type="s:ST_Guid" use="required"/>
+  </xsd:complexType>
+  <xsd:element name="datastoreItem" type="CT_DatastoreItem"/>
+</xsd:schema>

--- a/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-customXmlSchemaProperties.xsd
+++ b/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-customXmlSchemaProperties.xsd
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://schemas.openxmlformats.org/schemaLibrary/2006/main"
+  targetNamespace="http://schemas.openxmlformats.org/schemaLibrary/2006/main"
+  attributeFormDefault="qualified" elementFormDefault="qualified">
+  <xsd:complexType name="CT_Schema">
+    <xsd:attribute name="uri" type="xsd:string" default=""/>
+    <xsd:attribute name="manifestLocation" type="xsd:string"/>
+    <xsd:attribute name="schemaLocation" type="xsd:string"/>
+    <xsd:attribute name="schemaLanguage" type="xsd:token"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SchemaLibrary">
+    <xsd:sequence>
+      <xsd:element name="schema" type="CT_Schema" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="schemaLibrary" type="CT_SchemaLibrary"/>
+</xsd:schema>

--- a/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-documentPropertiesCustom.xsd
+++ b/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-documentPropertiesCustom.xsd
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://schemas.openxmlformats.org/officeDocument/2006/custom-properties"
+  xmlns:vt="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes"
+  xmlns:s="http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"
+  targetNamespace="http://schemas.openxmlformats.org/officeDocument/2006/custom-properties"
+  blockDefault="#all" elementFormDefault="qualified">
+  <xsd:import namespace="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes"
+    schemaLocation="shared-documentPropertiesVariantTypes.xsd"/>
+  <xsd:import namespace="http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"
+    schemaLocation="shared-commonSimpleTypes.xsd"/>
+  <xsd:element name="Properties" type="CT_Properties"/>
+  <xsd:complexType name="CT_Properties">
+    <xsd:sequence>
+      <xsd:element name="property" minOccurs="0" maxOccurs="unbounded" type="CT_Property"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Property">
+    <xsd:choice minOccurs="1" maxOccurs="1">
+      <xsd:element ref="vt:vector"/>
+      <xsd:element ref="vt:array"/>
+      <xsd:element ref="vt:blob"/>
+      <xsd:element ref="vt:oblob"/>
+      <xsd:element ref="vt:empty"/>
+      <xsd:element ref="vt:null"/>
+      <xsd:element ref="vt:i1"/>
+      <xsd:element ref="vt:i2"/>
+      <xsd:element ref="vt:i4"/>
+      <xsd:element ref="vt:i8"/>
+      <xsd:element ref="vt:int"/>
+      <xsd:element ref="vt:ui1"/>
+      <xsd:element ref="vt:ui2"/>
+      <xsd:element ref="vt:ui4"/>
+      <xsd:element ref="vt:ui8"/>
+      <xsd:element ref="vt:uint"/>
+      <xsd:element ref="vt:r4"/>
+      <xsd:element ref="vt:r8"/>
+      <xsd:element ref="vt:decimal"/>
+      <xsd:element ref="vt:lpstr"/>
+      <xsd:element ref="vt:lpwstr"/>
+      <xsd:element ref="vt:bstr"/>
+      <xsd:element ref="vt:date"/>
+      <xsd:element ref="vt:filetime"/>
+      <xsd:element ref="vt:bool"/>
+      <xsd:element ref="vt:cy"/>
+      <xsd:element ref="vt:error"/>
+      <xsd:element ref="vt:stream"/>
+      <xsd:element ref="vt:ostream"/>
+      <xsd:element ref="vt:storage"/>
+      <xsd:element ref="vt:ostorage"/>
+      <xsd:element ref="vt:vstream"/>
+      <xsd:element ref="vt:clsid"/>
+    </xsd:choice>
+    <xsd:attribute name="fmtid" use="required" type="s:ST_Guid"/>
+    <xsd:attribute name="pid" use="required" type="xsd:int"/>
+    <xsd:attribute name="name" use="optional" type="xsd:string"/>
+    <xsd:attribute name="linkTarget" use="optional" type="xsd:string"/>
+  </xsd:complexType>
+</xsd:schema>

--- a/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-documentPropertiesExtended.xsd
+++ b/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-documentPropertiesExtended.xsd
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties"
+  xmlns:vt="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes"
+  targetNamespace="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties"
+  elementFormDefault="qualified" blockDefault="#all">
+  <xsd:import namespace="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes"
+    schemaLocation="shared-documentPropertiesVariantTypes.xsd"/>
+  <xsd:element name="Properties" type="CT_Properties"/>
+  <xsd:complexType name="CT_Properties">
+    <xsd:all>
+      <xsd:element name="Template" minOccurs="0" maxOccurs="1" type="xsd:string"/>
+      <xsd:element name="Manager" minOccurs="0" maxOccurs="1" type="xsd:string"/>
+      <xsd:element name="Company" minOccurs="0" maxOccurs="1" type="xsd:string"/>
+      <xsd:element name="Pages" minOccurs="0" maxOccurs="1" type="xsd:int"/>
+      <xsd:element name="Words" minOccurs="0" maxOccurs="1" type="xsd:int"/>
+      <xsd:element name="Characters" minOccurs="0" maxOccurs="1" type="xsd:int"/>
+      <xsd:element name="PresentationFormat" minOccurs="0" maxOccurs="1" type="xsd:string"/>
+      <xsd:element name="Lines" minOccurs="0" maxOccurs="1" type="xsd:int"/>
+      <xsd:element name="Paragraphs" minOccurs="0" maxOccurs="1" type="xsd:int"/>
+      <xsd:element name="Slides" minOccurs="0" maxOccurs="1" type="xsd:int"/>
+      <xsd:element name="Notes" minOccurs="0" maxOccurs="1" type="xsd:int"/>
+      <xsd:element name="TotalTime" minOccurs="0" maxOccurs="1" type="xsd:int"/>
+      <xsd:element name="HiddenSlides" minOccurs="0" maxOccurs="1" type="xsd:int"/>
+      <xsd:element name="MMClips" minOccurs="0" maxOccurs="1" type="xsd:int"/>
+      <xsd:element name="ScaleCrop" minOccurs="0" maxOccurs="1" type="xsd:boolean"/>
+      <xsd:element name="HeadingPairs" minOccurs="0" maxOccurs="1" type="CT_VectorVariant"/>
+      <xsd:element name="TitlesOfParts" minOccurs="0" maxOccurs="1" type="CT_VectorLpstr"/>
+      <xsd:element name="LinksUpToDate" minOccurs="0" maxOccurs="1" type="xsd:boolean"/>
+      <xsd:element name="CharactersWithSpaces" minOccurs="0" maxOccurs="1" type="xsd:int"/>
+      <xsd:element name="SharedDoc" minOccurs="0" maxOccurs="1" type="xsd:boolean"/>
+      <xsd:element name="HyperlinkBase" minOccurs="0" maxOccurs="1" type="xsd:string"/>
+      <xsd:element name="HLinks" minOccurs="0" maxOccurs="1" type="CT_VectorVariant"/>
+      <xsd:element name="HyperlinksChanged" minOccurs="0" maxOccurs="1" type="xsd:boolean"/>
+      <xsd:element name="DigSig" minOccurs="0" maxOccurs="1" type="CT_DigSigBlob"/>
+      <xsd:element name="Application" minOccurs="0" maxOccurs="1" type="xsd:string"/>
+      <xsd:element name="AppVersion" minOccurs="0" maxOccurs="1" type="xsd:string"/>
+      <xsd:element name="DocSecurity" minOccurs="0" maxOccurs="1" type="xsd:int"/>
+    </xsd:all>
+  </xsd:complexType>
+  <xsd:complexType name="CT_VectorVariant">
+    <xsd:sequence minOccurs="1" maxOccurs="1">
+      <xsd:element ref="vt:vector"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_VectorLpstr">
+    <xsd:sequence minOccurs="1" maxOccurs="1">
+      <xsd:element ref="vt:vector"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DigSigBlob">
+    <xsd:sequence minOccurs="1" maxOccurs="1">
+      <xsd:element ref="vt:blob"/>
+    </xsd:sequence>
+  </xsd:complexType>
+</xsd:schema>

--- a/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-documentPropertiesVariantTypes.xsd
+++ b/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-documentPropertiesVariantTypes.xsd
@@ -1,0 +1,195 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes"
+  xmlns:s="http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"
+  targetNamespace="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes"
+  blockDefault="#all" elementFormDefault="qualified">
+  <xsd:import namespace="http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"
+    schemaLocation="shared-commonSimpleTypes.xsd"/>
+  <xsd:simpleType name="ST_VectorBaseType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="variant"/>
+      <xsd:enumeration value="i1"/>
+      <xsd:enumeration value="i2"/>
+      <xsd:enumeration value="i4"/>
+      <xsd:enumeration value="i8"/>
+      <xsd:enumeration value="ui1"/>
+      <xsd:enumeration value="ui2"/>
+      <xsd:enumeration value="ui4"/>
+      <xsd:enumeration value="ui8"/>
+      <xsd:enumeration value="r4"/>
+      <xsd:enumeration value="r8"/>
+      <xsd:enumeration value="lpstr"/>
+      <xsd:enumeration value="lpwstr"/>
+      <xsd:enumeration value="bstr"/>
+      <xsd:enumeration value="date"/>
+      <xsd:enumeration value="filetime"/>
+      <xsd:enumeration value="bool"/>
+      <xsd:enumeration value="cy"/>
+      <xsd:enumeration value="error"/>
+      <xsd:enumeration value="clsid"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_ArrayBaseType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="variant"/>
+      <xsd:enumeration value="i1"/>
+      <xsd:enumeration value="i2"/>
+      <xsd:enumeration value="i4"/>
+      <xsd:enumeration value="int"/>
+      <xsd:enumeration value="ui1"/>
+      <xsd:enumeration value="ui2"/>
+      <xsd:enumeration value="ui4"/>
+      <xsd:enumeration value="uint"/>
+      <xsd:enumeration value="r4"/>
+      <xsd:enumeration value="r8"/>
+      <xsd:enumeration value="decimal"/>
+      <xsd:enumeration value="bstr"/>
+      <xsd:enumeration value="date"/>
+      <xsd:enumeration value="bool"/>
+      <xsd:enumeration value="cy"/>
+      <xsd:enumeration value="error"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_Cy">
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="\s*[0-9]*\.[0-9]{4}\s*"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_Error">
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="\s*0x[0-9A-Za-z]{8}\s*"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Empty"/>
+  <xsd:complexType name="CT_Null"/>
+  <xsd:complexType name="CT_Vector">
+    <xsd:choice minOccurs="1" maxOccurs="unbounded">
+      <xsd:element ref="variant"/>
+      <xsd:element ref="i1"/>
+      <xsd:element ref="i2"/>
+      <xsd:element ref="i4"/>
+      <xsd:element ref="i8"/>
+      <xsd:element ref="ui1"/>
+      <xsd:element ref="ui2"/>
+      <xsd:element ref="ui4"/>
+      <xsd:element ref="ui8"/>
+      <xsd:element ref="r4"/>
+      <xsd:element ref="r8"/>
+      <xsd:element ref="lpstr"/>
+      <xsd:element ref="lpwstr"/>
+      <xsd:element ref="bstr"/>
+      <xsd:element ref="date"/>
+      <xsd:element ref="filetime"/>
+      <xsd:element ref="bool"/>
+      <xsd:element ref="cy"/>
+      <xsd:element ref="error"/>
+      <xsd:element ref="clsid"/>
+    </xsd:choice>
+    <xsd:attribute name="baseType" type="ST_VectorBaseType" use="required"/>
+    <xsd:attribute name="size" type="xsd:unsignedInt" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Array">
+    <xsd:choice minOccurs="1" maxOccurs="unbounded">
+      <xsd:element ref="variant"/>
+      <xsd:element ref="i1"/>
+      <xsd:element ref="i2"/>
+      <xsd:element ref="i4"/>
+      <xsd:element ref="int"/>
+      <xsd:element ref="ui1"/>
+      <xsd:element ref="ui2"/>
+      <xsd:element ref="ui4"/>
+      <xsd:element ref="uint"/>
+      <xsd:element ref="r4"/>
+      <xsd:element ref="r8"/>
+      <xsd:element ref="decimal"/>
+      <xsd:element ref="bstr"/>
+      <xsd:element ref="date"/>
+      <xsd:element ref="bool"/>
+      <xsd:element ref="error"/>
+      <xsd:element ref="cy"/>
+    </xsd:choice>
+    <xsd:attribute name="lBounds" type="xsd:int" use="required"/>
+    <xsd:attribute name="uBounds" type="xsd:int" use="required"/>
+    <xsd:attribute name="baseType" type="ST_ArrayBaseType" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Variant">
+    <xsd:choice minOccurs="1" maxOccurs="1">
+      <xsd:element ref="variant"/>
+      <xsd:element ref="vector"/>
+      <xsd:element ref="array"/>
+      <xsd:element ref="blob"/>
+      <xsd:element ref="oblob"/>
+      <xsd:element ref="empty"/>
+      <xsd:element ref="null"/>
+      <xsd:element ref="i1"/>
+      <xsd:element ref="i2"/>
+      <xsd:element ref="i4"/>
+      <xsd:element ref="i8"/>
+      <xsd:element ref="int"/>
+      <xsd:element ref="ui1"/>
+      <xsd:element ref="ui2"/>
+      <xsd:element ref="ui4"/>
+      <xsd:element ref="ui8"/>
+      <xsd:element ref="uint"/>
+      <xsd:element ref="r4"/>
+      <xsd:element ref="r8"/>
+      <xsd:element ref="decimal"/>
+      <xsd:element ref="lpstr"/>
+      <xsd:element ref="lpwstr"/>
+      <xsd:element ref="bstr"/>
+      <xsd:element ref="date"/>
+      <xsd:element ref="filetime"/>
+      <xsd:element ref="bool"/>
+      <xsd:element ref="cy"/>
+      <xsd:element ref="error"/>
+      <xsd:element ref="stream"/>
+      <xsd:element ref="ostream"/>
+      <xsd:element ref="storage"/>
+      <xsd:element ref="ostorage"/>
+      <xsd:element ref="vstream"/>
+      <xsd:element ref="clsid"/>
+    </xsd:choice>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Vstream">
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:base64Binary">
+        <xsd:attribute name="version" type="s:ST_Guid"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:element name="variant" type="CT_Variant"/>
+  <xsd:element name="vector" type="CT_Vector"/>
+  <xsd:element name="array" type="CT_Array"/>
+  <xsd:element name="blob" type="xsd:base64Binary"/>
+  <xsd:element name="oblob" type="xsd:base64Binary"/>
+  <xsd:element name="empty" type="CT_Empty"/>
+  <xsd:element name="null" type="CT_Null"/>
+  <xsd:element name="i1" type="xsd:byte"/>
+  <xsd:element name="i2" type="xsd:short"/>
+  <xsd:element name="i4" type="xsd:int"/>
+  <xsd:element name="i8" type="xsd:long"/>
+  <xsd:element name="int" type="xsd:int"/>
+  <xsd:element name="ui1" type="xsd:unsignedByte"/>
+  <xsd:element name="ui2" type="xsd:unsignedShort"/>
+  <xsd:element name="ui4" type="xsd:unsignedInt"/>
+  <xsd:element name="ui8" type="xsd:unsignedLong"/>
+  <xsd:element name="uint" type="xsd:unsignedInt"/>
+  <xsd:element name="r4" type="xsd:float"/>
+  <xsd:element name="r8" type="xsd:double"/>
+  <xsd:element name="decimal" type="xsd:decimal"/>
+  <xsd:element name="lpstr" type="xsd:string"/>
+  <xsd:element name="lpwstr" type="xsd:string"/>
+  <xsd:element name="bstr" type="xsd:string"/>
+  <xsd:element name="date" type="xsd:dateTime"/>
+  <xsd:element name="filetime" type="xsd:dateTime"/>
+  <xsd:element name="bool" type="xsd:boolean"/>
+  <xsd:element name="cy" type="ST_Cy"/>
+  <xsd:element name="error" type="ST_Error"/>
+  <xsd:element name="stream" type="xsd:base64Binary"/>
+  <xsd:element name="ostream" type="xsd:base64Binary"/>
+  <xsd:element name="storage" type="xsd:base64Binary"/>
+  <xsd:element name="ostorage" type="xsd:base64Binary"/>
+  <xsd:element name="vstream" type="CT_Vstream"/>
+  <xsd:element name="clsid" type="s:ST_Guid"/>
+</xsd:schema>

--- a/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-math.xsd
+++ b/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-math.xsd
@@ -1,0 +1,582 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://schemas.openxmlformats.org/officeDocument/2006/math"
+  xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math"
+  xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+  xmlns:s="http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"
+  elementFormDefault="qualified" attributeFormDefault="qualified" blockDefault="#all"
+  targetNamespace="http://schemas.openxmlformats.org/officeDocument/2006/math">
+  <xsd:import namespace="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+    schemaLocation="wml.xsd"/>
+  <xsd:import namespace="http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"
+    schemaLocation="shared-commonSimpleTypes.xsd"/>
+  <xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd"/>
+  <xsd:simpleType name="ST_Integer255">
+    <xsd:restriction base="xsd:integer">
+      <xsd:minInclusive value="1"/>
+      <xsd:maxInclusive value="255"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Integer255">
+    <xsd:attribute name="val" type="ST_Integer255" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_Integer2">
+    <xsd:restriction base="xsd:integer">
+      <xsd:minInclusive value="-2"/>
+      <xsd:maxInclusive value="2"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Integer2">
+    <xsd:attribute name="val" type="ST_Integer2" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_SpacingRule">
+    <xsd:restriction base="xsd:integer">
+      <xsd:minInclusive value="0"/>
+      <xsd:maxInclusive value="4"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_SpacingRule">
+    <xsd:attribute name="val" type="ST_SpacingRule" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_UnSignedInteger">
+    <xsd:restriction base="xsd:unsignedInt"/>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_UnSignedInteger">
+    <xsd:attribute name="val" type="ST_UnSignedInteger" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_Char">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Char">
+    <xsd:attribute name="val" type="ST_Char" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_OnOff">
+    <xsd:attribute name="val" type="s:ST_OnOff"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_String">
+    <xsd:attribute name="val" type="s:ST_String"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_XAlign">
+    <xsd:attribute name="val" type="s:ST_XAlign" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_YAlign">
+    <xsd:attribute name="val" type="s:ST_YAlign" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_Shp">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="centered"/>
+      <xsd:enumeration value="match"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Shp">
+    <xsd:attribute name="val" type="ST_Shp" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_FType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="bar"/>
+      <xsd:enumeration value="skw"/>
+      <xsd:enumeration value="lin"/>
+      <xsd:enumeration value="noBar"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_FType">
+    <xsd:attribute name="val" type="ST_FType" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_LimLoc">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="undOvr"/>
+      <xsd:enumeration value="subSup"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_LimLoc">
+    <xsd:attribute name="val" type="ST_LimLoc" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TopBot">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="top"/>
+      <xsd:enumeration value="bot"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TopBot">
+    <xsd:attribute name="val" type="ST_TopBot" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_Script">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="roman"/>
+      <xsd:enumeration value="script"/>
+      <xsd:enumeration value="fraktur"/>
+      <xsd:enumeration value="double-struck"/>
+      <xsd:enumeration value="sans-serif"/>
+      <xsd:enumeration value="monospace"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Script">
+    <xsd:attribute name="val" type="ST_Script"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_Style">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="p"/>
+      <xsd:enumeration value="b"/>
+      <xsd:enumeration value="i"/>
+      <xsd:enumeration value="bi"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Style">
+    <xsd:attribute name="val" type="ST_Style"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ManualBreak">
+    <xsd:attribute name="alnAt" type="ST_Integer255"/>
+  </xsd:complexType>
+  <xsd:group name="EG_ScriptStyle">
+    <xsd:sequence>
+      <xsd:element name="scr" minOccurs="0" type="CT_Script"/>
+      <xsd:element name="sty" minOccurs="0" type="CT_Style"/>
+    </xsd:sequence>
+  </xsd:group>
+  <xsd:complexType name="CT_RPR">
+    <xsd:sequence>
+      <xsd:element name="lit" minOccurs="0" type="CT_OnOff"/>
+      <xsd:choice>
+        <xsd:element name="nor" minOccurs="0" type="CT_OnOff"/>
+        <xsd:sequence>
+          <xsd:group ref="EG_ScriptStyle"/>
+        </xsd:sequence>
+      </xsd:choice>
+      <xsd:element name="brk" minOccurs="0" type="CT_ManualBreak"/>
+      <xsd:element name="aln" minOccurs="0" type="CT_OnOff"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Text">
+    <xsd:simpleContent>
+      <xsd:extension base="s:ST_String">
+        <xsd:attribute ref="xml:space" use="optional"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType name="CT_R">
+    <xsd:sequence>
+      <xsd:element name="rPr" type="CT_RPR" minOccurs="0"/>
+      <xsd:group ref="w:EG_RPr" minOccurs="0"/>
+      <xsd:choice minOccurs="0" maxOccurs="unbounded">
+        <xsd:group ref="w:EG_RunInnerContent"/>
+        <xsd:element name="t" type="CT_Text" minOccurs="0"/>
+      </xsd:choice>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CtrlPr">
+    <xsd:sequence>
+      <xsd:group ref="w:EG_RPrMath" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_AccPr">
+    <xsd:sequence>
+      <xsd:element name="chr" type="CT_Char" minOccurs="0"/>
+      <xsd:element name="ctrlPr" type="CT_CtrlPr" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Acc">
+    <xsd:sequence>
+      <xsd:element name="accPr" type="CT_AccPr" minOccurs="0"/>
+      <xsd:element name="e" type="CT_OMathArg"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_BarPr">
+    <xsd:sequence>
+      <xsd:element name="pos" type="CT_TopBot" minOccurs="0"/>
+      <xsd:element name="ctrlPr" type="CT_CtrlPr" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Bar">
+    <xsd:sequence>
+      <xsd:element name="barPr" type="CT_BarPr" minOccurs="0"/>
+      <xsd:element name="e" type="CT_OMathArg"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_BoxPr">
+    <xsd:sequence>
+      <xsd:element name="opEmu" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="noBreak" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="diff" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="brk" type="CT_ManualBreak" minOccurs="0"/>
+      <xsd:element name="aln" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="ctrlPr" type="CT_CtrlPr" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Box">
+    <xsd:sequence>
+      <xsd:element name="boxPr" type="CT_BoxPr" minOccurs="0"/>
+      <xsd:element name="e" type="CT_OMathArg"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_BorderBoxPr">
+    <xsd:sequence>
+      <xsd:element name="hideTop" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="hideBot" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="hideLeft" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="hideRight" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="strikeH" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="strikeV" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="strikeBLTR" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="strikeTLBR" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="ctrlPr" type="CT_CtrlPr" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_BorderBox">
+    <xsd:sequence>
+      <xsd:element name="borderBoxPr" type="CT_BorderBoxPr" minOccurs="0"/>
+      <xsd:element name="e" type="CT_OMathArg"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DPr">
+    <xsd:sequence>
+      <xsd:element name="begChr" type="CT_Char" minOccurs="0"/>
+      <xsd:element name="sepChr" type="CT_Char" minOccurs="0"/>
+      <xsd:element name="endChr" type="CT_Char" minOccurs="0"/>
+      <xsd:element name="grow" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="shp" type="CT_Shp" minOccurs="0"/>
+      <xsd:element name="ctrlPr" type="CT_CtrlPr" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_D">
+    <xsd:sequence>
+      <xsd:element name="dPr" type="CT_DPr" minOccurs="0"/>
+      <xsd:element name="e" type="CT_OMathArg" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_EqArrPr">
+    <xsd:sequence>
+      <xsd:element name="baseJc" type="CT_YAlign" minOccurs="0"/>
+      <xsd:element name="maxDist" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="objDist" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="rSpRule" type="CT_SpacingRule" minOccurs="0"/>
+      <xsd:element name="rSp" type="CT_UnSignedInteger" minOccurs="0"/>
+      <xsd:element name="ctrlPr" type="CT_CtrlPr" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_EqArr">
+    <xsd:sequence>
+      <xsd:element name="eqArrPr" type="CT_EqArrPr" minOccurs="0"/>
+      <xsd:element name="e" type="CT_OMathArg" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_FPr">
+    <xsd:sequence>
+      <xsd:element name="type" type="CT_FType" minOccurs="0"/>
+      <xsd:element name="ctrlPr" type="CT_CtrlPr" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_F">
+    <xsd:sequence>
+      <xsd:element name="fPr" type="CT_FPr" minOccurs="0"/>
+      <xsd:element name="num" type="CT_OMathArg"/>
+      <xsd:element name="den" type="CT_OMathArg"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_FuncPr">
+    <xsd:sequence>
+      <xsd:element name="ctrlPr" type="CT_CtrlPr" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Func">
+    <xsd:sequence>
+      <xsd:element name="funcPr" type="CT_FuncPr" minOccurs="0"/>
+      <xsd:element name="fName" type="CT_OMathArg"/>
+      <xsd:element name="e" type="CT_OMathArg"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GroupChrPr">
+    <xsd:sequence>
+      <xsd:element name="chr" type="CT_Char" minOccurs="0"/>
+      <xsd:element name="pos" type="CT_TopBot" minOccurs="0"/>
+      <xsd:element name="vertJc" type="CT_TopBot" minOccurs="0"/>
+      <xsd:element name="ctrlPr" type="CT_CtrlPr" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GroupChr">
+    <xsd:sequence>
+      <xsd:element name="groupChrPr" type="CT_GroupChrPr" minOccurs="0"/>
+      <xsd:element name="e" type="CT_OMathArg"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_LimLowPr">
+    <xsd:sequence>
+      <xsd:element name="ctrlPr" type="CT_CtrlPr" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_LimLow">
+    <xsd:sequence>
+      <xsd:element name="limLowPr" type="CT_LimLowPr" minOccurs="0"/>
+      <xsd:element name="e" type="CT_OMathArg"/>
+      <xsd:element name="lim" type="CT_OMathArg"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_LimUppPr">
+    <xsd:sequence>
+      <xsd:element name="ctrlPr" type="CT_CtrlPr" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_LimUpp">
+    <xsd:sequence>
+      <xsd:element name="limUppPr" type="CT_LimUppPr" minOccurs="0"/>
+      <xsd:element name="e" type="CT_OMathArg"/>
+      <xsd:element name="lim" type="CT_OMathArg"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_MCPr">
+    <xsd:sequence>
+      <xsd:element name="count" type="CT_Integer255" minOccurs="0"/>
+      <xsd:element name="mcJc" type="CT_XAlign" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_MC">
+    <xsd:sequence>
+      <xsd:element name="mcPr" type="CT_MCPr" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_MCS">
+    <xsd:sequence>
+      <xsd:element name="mc" type="CT_MC" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_MPr">
+    <xsd:sequence>
+      <xsd:element name="baseJc" type="CT_YAlign" minOccurs="0"/>
+      <xsd:element name="plcHide" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="rSpRule" type="CT_SpacingRule" minOccurs="0"/>
+      <xsd:element name="cGpRule" type="CT_SpacingRule" minOccurs="0"/>
+      <xsd:element name="rSp" type="CT_UnSignedInteger" minOccurs="0"/>
+      <xsd:element name="cSp" type="CT_UnSignedInteger" minOccurs="0"/>
+      <xsd:element name="cGp" type="CT_UnSignedInteger" minOccurs="0"/>
+      <xsd:element name="mcs" type="CT_MCS" minOccurs="0"/>
+      <xsd:element name="ctrlPr" type="CT_CtrlPr" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_MR">
+    <xsd:sequence>
+      <xsd:element name="e" type="CT_OMathArg" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_M">
+    <xsd:sequence>
+      <xsd:element name="mPr" type="CT_MPr" minOccurs="0"/>
+      <xsd:element name="mr" type="CT_MR" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_NaryPr">
+    <xsd:sequence>
+      <xsd:element name="chr" type="CT_Char" minOccurs="0"/>
+      <xsd:element name="limLoc" type="CT_LimLoc" minOccurs="0"/>
+      <xsd:element name="grow" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="subHide" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="supHide" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="ctrlPr" type="CT_CtrlPr" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Nary">
+    <xsd:sequence>
+      <xsd:element name="naryPr" type="CT_NaryPr" minOccurs="0"/>
+      <xsd:element name="sub" type="CT_OMathArg"/>
+      <xsd:element name="sup" type="CT_OMathArg"/>
+      <xsd:element name="e" type="CT_OMathArg"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PhantPr">
+    <xsd:sequence>
+      <xsd:element name="show" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="zeroWid" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="zeroAsc" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="zeroDesc" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="transp" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="ctrlPr" type="CT_CtrlPr" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Phant">
+    <xsd:sequence>
+      <xsd:element name="phantPr" type="CT_PhantPr" minOccurs="0"/>
+      <xsd:element name="e" type="CT_OMathArg"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_RadPr">
+    <xsd:sequence>
+      <xsd:element name="degHide" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="ctrlPr" type="CT_CtrlPr" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Rad">
+    <xsd:sequence>
+      <xsd:element name="radPr" type="CT_RadPr" minOccurs="0"/>
+      <xsd:element name="deg" type="CT_OMathArg"/>
+      <xsd:element name="e" type="CT_OMathArg"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SPrePr">
+    <xsd:sequence>
+      <xsd:element name="ctrlPr" type="CT_CtrlPr" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SPre">
+    <xsd:sequence>
+      <xsd:element name="sPrePr" type="CT_SPrePr" minOccurs="0"/>
+      <xsd:element name="sub" type="CT_OMathArg"/>
+      <xsd:element name="sup" type="CT_OMathArg"/>
+      <xsd:element name="e" type="CT_OMathArg"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SSubPr">
+    <xsd:sequence>
+      <xsd:element name="ctrlPr" type="CT_CtrlPr" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SSub">
+    <xsd:sequence>
+      <xsd:element name="sSubPr" type="CT_SSubPr" minOccurs="0"/>
+      <xsd:element name="e" type="CT_OMathArg"/>
+      <xsd:element name="sub" type="CT_OMathArg"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SSubSupPr">
+    <xsd:sequence>
+      <xsd:element name="alnScr" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="ctrlPr" type="CT_CtrlPr" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SSubSup">
+    <xsd:sequence>
+      <xsd:element name="sSubSupPr" type="CT_SSubSupPr" minOccurs="0"/>
+      <xsd:element name="e" type="CT_OMathArg"/>
+      <xsd:element name="sub" type="CT_OMathArg"/>
+      <xsd:element name="sup" type="CT_OMathArg"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SSupPr">
+    <xsd:sequence>
+      <xsd:element name="ctrlPr" type="CT_CtrlPr" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SSup">
+    <xsd:sequence>
+      <xsd:element name="sSupPr" type="CT_SSupPr" minOccurs="0"/>
+      <xsd:element name="e" type="CT_OMathArg"/>
+      <xsd:element name="sup" type="CT_OMathArg"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:group name="EG_OMathMathElements">
+    <xsd:choice>
+      <xsd:element name="acc" type="CT_Acc"/>
+      <xsd:element name="bar" type="CT_Bar"/>
+      <xsd:element name="box" type="CT_Box"/>
+      <xsd:element name="borderBox" type="CT_BorderBox"/>
+      <xsd:element name="d" type="CT_D"/>
+      <xsd:element name="eqArr" type="CT_EqArr"/>
+      <xsd:element name="f" type="CT_F"/>
+      <xsd:element name="func" type="CT_Func"/>
+      <xsd:element name="groupChr" type="CT_GroupChr"/>
+      <xsd:element name="limLow" type="CT_LimLow"/>
+      <xsd:element name="limUpp" type="CT_LimUpp"/>
+      <xsd:element name="m" type="CT_M"/>
+      <xsd:element name="nary" type="CT_Nary"/>
+      <xsd:element name="phant" type="CT_Phant"/>
+      <xsd:element name="rad" type="CT_Rad"/>
+      <xsd:element name="sPre" type="CT_SPre"/>
+      <xsd:element name="sSub" type="CT_SSub"/>
+      <xsd:element name="sSubSup" type="CT_SSubSup"/>
+      <xsd:element name="sSup" type="CT_SSup"/>
+      <xsd:element name="r" type="CT_R"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:group name="EG_OMathElements">
+    <xsd:choice>
+      <xsd:group ref="EG_OMathMathElements"/>
+      <xsd:group ref="w:EG_PContentMath"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:complexType name="CT_OMathArgPr">
+    <xsd:sequence>
+      <xsd:element name="argSz" type="CT_Integer2" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_OMathArg">
+    <xsd:sequence>
+      <xsd:element name="argPr" type="CT_OMathArgPr" minOccurs="0"/>
+      <xsd:group ref="EG_OMathElements" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="ctrlPr" type="CT_CtrlPr" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_Jc">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="left"/>
+      <xsd:enumeration value="right"/>
+      <xsd:enumeration value="center"/>
+      <xsd:enumeration value="centerGroup"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_OMathJc">
+    <xsd:attribute name="val" type="ST_Jc"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_OMathParaPr">
+    <xsd:sequence>
+      <xsd:element name="jc" type="CT_OMathJc" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TwipsMeasure">
+    <xsd:attribute name="val" type="s:ST_TwipsMeasure" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_BreakBin">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="before"/>
+      <xsd:enumeration value="after"/>
+      <xsd:enumeration value="repeat"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_BreakBin">
+    <xsd:attribute name="val" type="ST_BreakBin"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_BreakBinSub">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="--"/>
+      <xsd:enumeration value="-+"/>
+      <xsd:enumeration value="+-"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_BreakBinSub">
+    <xsd:attribute name="val" type="ST_BreakBinSub"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_MathPr">
+    <xsd:sequence>
+      <xsd:element name="mathFont" type="CT_String" minOccurs="0"/>
+      <xsd:element name="brkBin" type="CT_BreakBin" minOccurs="0"/>
+      <xsd:element name="brkBinSub" type="CT_BreakBinSub" minOccurs="0"/>
+      <xsd:element name="smallFrac" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="dispDef" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="lMargin" type="CT_TwipsMeasure" minOccurs="0"/>
+      <xsd:element name="rMargin" type="CT_TwipsMeasure" minOccurs="0"/>
+      <xsd:element name="defJc" type="CT_OMathJc" minOccurs="0"/>
+      <xsd:element name="preSp" type="CT_TwipsMeasure" minOccurs="0"/>
+      <xsd:element name="postSp" type="CT_TwipsMeasure" minOccurs="0"/>
+      <xsd:element name="interSp" type="CT_TwipsMeasure" minOccurs="0"/>
+      <xsd:element name="intraSp" type="CT_TwipsMeasure" minOccurs="0"/>
+      <xsd:choice minOccurs="0">
+        <xsd:element name="wrapIndent" type="CT_TwipsMeasure"/>
+        <xsd:element name="wrapRight" type="CT_OnOff"/>
+      </xsd:choice>
+      <xsd:element name="intLim" type="CT_LimLoc" minOccurs="0"/>
+      <xsd:element name="naryLim" type="CT_LimLoc" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="mathPr" type="CT_MathPr"/>
+  <xsd:complexType name="CT_OMathPara">
+    <xsd:sequence>
+      <xsd:element name="oMathParaPr" type="CT_OMathParaPr" minOccurs="0"/>
+      <xsd:element name="oMath" type="CT_OMath" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_OMath">
+    <xsd:sequence>
+      <xsd:group ref="EG_OMathElements" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="oMathPara" type="CT_OMathPara"/>
+  <xsd:element name="oMath" type="CT_OMath"/>
+</xsd:schema>

--- a/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-relationshipReference.xsd
+++ b/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-relationshipReference.xsd
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+  xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+  elementFormDefault="qualified"
+  targetNamespace="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+  blockDefault="#all">
+  <xsd:simpleType name="ST_RelationshipId">
+    <xsd:restriction base="xsd:string"/>
+  </xsd:simpleType>
+  <xsd:attribute name="id" type="ST_RelationshipId"/>
+  <xsd:attribute name="embed" type="ST_RelationshipId"/>
+  <xsd:attribute name="link" type="ST_RelationshipId"/>
+  <xsd:attribute name="dm" type="ST_RelationshipId" default=""/>
+  <xsd:attribute name="lo" type="ST_RelationshipId" default=""/>
+  <xsd:attribute name="qs" type="ST_RelationshipId" default=""/>
+  <xsd:attribute name="cs" type="ST_RelationshipId" default=""/>
+  <xsd:attribute name="blip" type="ST_RelationshipId" default=""/>
+  <xsd:attribute name="pict" type="ST_RelationshipId"/>
+  <xsd:attribute name="href" type="ST_RelationshipId"/>
+  <xsd:attribute name="topLeft" type="ST_RelationshipId"/>
+  <xsd:attribute name="topRight" type="ST_RelationshipId"/>
+  <xsd:attribute name="bottomLeft" type="ST_RelationshipId"/>
+  <xsd:attribute name="bottomRight" type="ST_RelationshipId"/>
+</xsd:schema>

--- a/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/sml.xsd
+++ b/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/sml.xsd
@@ -1,0 +1,4439 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+  xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+  xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"
+  xmlns:s="http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"
+  targetNamespace="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+  elementFormDefault="qualified">
+  <xsd:import namespace="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+    schemaLocation="shared-relationshipReference.xsd"/>
+  <xsd:import namespace="http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"
+    schemaLocation="shared-commonSimpleTypes.xsd"/>
+  <xsd:import 
+    namespace="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"
+    schemaLocation="dml-spreadsheetDrawing.xsd"/>
+  <xsd:complexType name="CT_AutoFilter">
+    <xsd:sequence>
+      <xsd:element name="filterColumn" minOccurs="0" maxOccurs="unbounded" type="CT_FilterColumn"/>
+      <xsd:element name="sortState" minOccurs="0" maxOccurs="1" type="CT_SortState"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="ref" type="ST_Ref"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_FilterColumn">
+    <xsd:choice minOccurs="0" maxOccurs="1">
+      <xsd:element name="filters" type="CT_Filters" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="top10" type="CT_Top10" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="customFilters" type="CT_CustomFilters" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="dynamicFilter" type="CT_DynamicFilter" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="colorFilter" type="CT_ColorFilter" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="iconFilter" minOccurs="0" maxOccurs="1" type="CT_IconFilter"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:choice>
+    <xsd:attribute name="colId" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="hiddenButton" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="showButton" type="xsd:boolean" use="optional" default="true"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Filters">
+    <xsd:sequence>
+      <xsd:element name="filter" type="CT_Filter" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="dateGroupItem" type="CT_DateGroupItem" minOccurs="0" maxOccurs="unbounded"
+      />
+    </xsd:sequence>
+    <xsd:attribute name="blank" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="calendarType" type="s:ST_CalendarType" use="optional" default="none"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Filter">
+    <xsd:attribute name="val" type="s:ST_Xstring"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CustomFilters">
+    <xsd:sequence>
+      <xsd:element name="customFilter" type="CT_CustomFilter" minOccurs="1" maxOccurs="2"/>
+    </xsd:sequence>
+    <xsd:attribute name="and" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CustomFilter">
+    <xsd:attribute name="operator" type="ST_FilterOperator" default="equal" use="optional"/>
+    <xsd:attribute name="val" type="s:ST_Xstring"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Top10">
+    <xsd:attribute name="top" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="percent" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="val" type="xsd:double" use="required"/>
+    <xsd:attribute name="filterVal" type="xsd:double" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ColorFilter">
+    <xsd:attribute name="dxfId" type="ST_DxfId" use="optional"/>
+    <xsd:attribute name="cellColor" type="xsd:boolean" use="optional" default="true"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_IconFilter">
+    <xsd:attribute name="iconSet" type="ST_IconSetType" use="required"/>
+    <xsd:attribute name="iconId" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_FilterOperator">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="equal"/>
+      <xsd:enumeration value="lessThan"/>
+      <xsd:enumeration value="lessThanOrEqual"/>
+      <xsd:enumeration value="notEqual"/>
+      <xsd:enumeration value="greaterThanOrEqual"/>
+      <xsd:enumeration value="greaterThan"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_DynamicFilter">
+    <xsd:attribute name="type" type="ST_DynamicFilterType" use="required"/>
+    <xsd:attribute name="val" type="xsd:double" use="optional"/>
+    <xsd:attribute name="valIso" type="xsd:dateTime" use="optional"/>
+    <xsd:attribute name="maxVal" type="xsd:double" use="optional"/>
+    <xsd:attribute name="maxValIso" type="xsd:dateTime" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_DynamicFilterType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="null"/>
+      <xsd:enumeration value="aboveAverage"/>
+      <xsd:enumeration value="belowAverage"/>
+      <xsd:enumeration value="tomorrow"/>
+      <xsd:enumeration value="today"/>
+      <xsd:enumeration value="yesterday"/>
+      <xsd:enumeration value="nextWeek"/>
+      <xsd:enumeration value="thisWeek"/>
+      <xsd:enumeration value="lastWeek"/>
+      <xsd:enumeration value="nextMonth"/>
+      <xsd:enumeration value="thisMonth"/>
+      <xsd:enumeration value="lastMonth"/>
+      <xsd:enumeration value="nextQuarter"/>
+      <xsd:enumeration value="thisQuarter"/>
+      <xsd:enumeration value="lastQuarter"/>
+      <xsd:enumeration value="nextYear"/>
+      <xsd:enumeration value="thisYear"/>
+      <xsd:enumeration value="lastYear"/>
+      <xsd:enumeration value="yearToDate"/>
+      <xsd:enumeration value="Q1"/>
+      <xsd:enumeration value="Q2"/>
+      <xsd:enumeration value="Q3"/>
+      <xsd:enumeration value="Q4"/>
+      <xsd:enumeration value="M1"/>
+      <xsd:enumeration value="M2"/>
+      <xsd:enumeration value="M3"/>
+      <xsd:enumeration value="M4"/>
+      <xsd:enumeration value="M5"/>
+      <xsd:enumeration value="M6"/>
+      <xsd:enumeration value="M7"/>
+      <xsd:enumeration value="M8"/>
+      <xsd:enumeration value="M9"/>
+      <xsd:enumeration value="M10"/>
+      <xsd:enumeration value="M11"/>
+      <xsd:enumeration value="M12"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_IconSetType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="3Arrows"/>
+      <xsd:enumeration value="3ArrowsGray"/>
+      <xsd:enumeration value="3Flags"/>
+      <xsd:enumeration value="3TrafficLights1"/>
+      <xsd:enumeration value="3TrafficLights2"/>
+      <xsd:enumeration value="3Signs"/>
+      <xsd:enumeration value="3Symbols"/>
+      <xsd:enumeration value="3Symbols2"/>
+      <xsd:enumeration value="4Arrows"/>
+      <xsd:enumeration value="4ArrowsGray"/>
+      <xsd:enumeration value="4RedToBlack"/>
+      <xsd:enumeration value="4Rating"/>
+      <xsd:enumeration value="4TrafficLights"/>
+      <xsd:enumeration value="5Arrows"/>
+      <xsd:enumeration value="5ArrowsGray"/>
+      <xsd:enumeration value="5Rating"/>
+      <xsd:enumeration value="5Quarters"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_SortState">
+    <xsd:sequence>
+      <xsd:element name="sortCondition" minOccurs="0" maxOccurs="64" type="CT_SortCondition"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="columnSort" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="caseSensitive" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="sortMethod" type="ST_SortMethod" use="optional" default="none"/>
+    <xsd:attribute name="ref" type="ST_Ref" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SortCondition">
+    <xsd:attribute name="descending" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="sortBy" type="ST_SortBy" use="optional" default="value"/>
+    <xsd:attribute name="ref" type="ST_Ref" use="required"/>
+    <xsd:attribute name="customList" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="dxfId" type="ST_DxfId" use="optional"/>
+    <xsd:attribute name="iconSet" type="ST_IconSetType" use="optional" default="3Arrows"/>
+    <xsd:attribute name="iconId" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_SortBy">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="value"/>
+      <xsd:enumeration value="cellColor"/>
+      <xsd:enumeration value="fontColor"/>
+      <xsd:enumeration value="icon"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_SortMethod">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="stroke"/>
+      <xsd:enumeration value="pinYin"/>
+      <xsd:enumeration value="none"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_DateGroupItem">
+    <xsd:attribute name="year" type="xsd:unsignedShort" use="required"/>
+    <xsd:attribute name="month" type="xsd:unsignedShort" use="optional"/>
+    <xsd:attribute name="day" type="xsd:unsignedShort" use="optional"/>
+    <xsd:attribute name="hour" type="xsd:unsignedShort" use="optional"/>
+    <xsd:attribute name="minute" type="xsd:unsignedShort" use="optional"/>
+    <xsd:attribute name="second" type="xsd:unsignedShort" use="optional"/>
+    <xsd:attribute name="dateTimeGrouping" type="ST_DateTimeGrouping" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_DateTimeGrouping">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="year"/>
+      <xsd:enumeration value="month"/>
+      <xsd:enumeration value="day"/>
+      <xsd:enumeration value="hour"/>
+      <xsd:enumeration value="minute"/>
+      <xsd:enumeration value="second"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_CellRef">
+    <xsd:restriction base="xsd:string"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_Ref">
+    <xsd:restriction base="xsd:string"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_RefA">
+    <xsd:restriction base="xsd:string"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_Sqref">
+    <xsd:list itemType="ST_Ref"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_Formula">
+    <xsd:restriction base="s:ST_Xstring"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_UnsignedIntHex">
+    <xsd:restriction base="xsd:hexBinary">
+      <xsd:length value="4"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_UnsignedShortHex">
+    <xsd:restriction base="xsd:hexBinary">
+      <xsd:length value="2"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_XStringElement">
+    <xsd:attribute name="v" type="s:ST_Xstring" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Extension">
+    <xsd:sequence>
+      <xsd:any processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="uri" type="xsd:token"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ObjectAnchor">
+    <xsd:sequence>
+      <xsd:element ref="xdr:from" minOccurs="1" maxOccurs="1"/>
+      <xsd:element ref="xdr:to" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="moveWithCells" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="sizeWithCells" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:group name="EG_ExtensionList">
+    <xsd:sequence>
+      <xsd:element name="ext" type="CT_Extension" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:group>
+  <xsd:complexType name="CT_ExtensionList">
+    <xsd:sequence>
+      <xsd:group ref="EG_ExtensionList" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="calcChain" type="CT_CalcChain"/>
+  <xsd:complexType name="CT_CalcChain">
+    <xsd:sequence>
+      <xsd:element name="c" type="CT_CalcCell" minOccurs="1" maxOccurs="unbounded"/>
+      <xsd:element name="extLst" minOccurs="0" type="CT_ExtensionList"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CalcCell">
+    <xsd:attribute name="r" type="ST_CellRef" use="optional"/>
+    <xsd:attribute name="ref" type="ST_CellRef" use="optional"/>
+    <xsd:attribute name="i" type="xsd:int" use="optional" default="0"/>
+    <xsd:attribute name="s" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="l" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="t" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="a" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:element name="comments" type="CT_Comments"/>
+  <xsd:complexType name="CT_Comments">
+    <xsd:sequence>
+      <xsd:element name="authors" type="CT_Authors" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="commentList" type="CT_CommentList" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="extLst" minOccurs="0" type="CT_ExtensionList"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Authors">
+    <xsd:sequence>
+      <xsd:element name="author" type="s:ST_Xstring" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CommentList">
+    <xsd:sequence>
+      <xsd:element name="comment" type="CT_Comment" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Comment">
+    <xsd:sequence>
+      <xsd:element name="text" type="CT_Rst" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="commentPr" type="CT_CommentPr" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="ref" type="ST_Ref" use="required"/>
+    <xsd:attribute name="authorId" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="guid" type="s:ST_Guid" use="optional"/>
+    <xsd:attribute name="shapeId" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CommentPr">
+    <xsd:sequence>
+      <xsd:element name="anchor" type="CT_ObjectAnchor" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="locked" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="defaultSize" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="print" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="disabled" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="autoFill" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="autoLine" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="altText" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="textHAlign" type="ST_TextHAlign" use="optional" default="left"/>
+    <xsd:attribute name="textVAlign" type="ST_TextVAlign" use="optional" default="top"/>
+    <xsd:attribute name="lockText" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="justLastX" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="autoScale" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TextHAlign">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="left"/>
+      <xsd:enumeration value="center"/>
+      <xsd:enumeration value="right"/>
+      <xsd:enumeration value="justify"/>
+      <xsd:enumeration value="distributed"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TextVAlign">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="top"/>
+      <xsd:enumeration value="center"/>
+      <xsd:enumeration value="bottom"/>
+      <xsd:enumeration value="justify"/>
+      <xsd:enumeration value="distributed"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:element name="MapInfo" type="CT_MapInfo"/>
+  <xsd:complexType name="CT_MapInfo">
+    <xsd:sequence>
+      <xsd:element name="Schema" type="CT_Schema" minOccurs="1" maxOccurs="unbounded"/>
+      <xsd:element name="Map" type="CT_Map" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="SelectionNamespaces" type="xsd:string" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Schema" mixed="true">
+    <xsd:sequence>
+      <xsd:any/>
+    </xsd:sequence>
+    <xsd:attribute name="ID" type="xsd:string" use="required"/>
+    <xsd:attribute name="SchemaRef" type="xsd:string" use="optional"/>
+    <xsd:attribute name="Namespace" type="xsd:string" use="optional"/>
+    <xsd:attribute name="SchemaLanguage" type="xsd:token" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Map">
+    <xsd:sequence>
+      <xsd:element name="DataBinding" type="CT_DataBinding" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="ID" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="Name" type="xsd:string" use="required"/>
+    <xsd:attribute name="RootElement" type="xsd:string" use="required"/>
+    <xsd:attribute name="SchemaID" type="xsd:string" use="required"/>
+    <xsd:attribute name="ShowImportExportValidationErrors" type="xsd:boolean" use="required"/>
+    <xsd:attribute name="AutoFit" type="xsd:boolean" use="required"/>
+    <xsd:attribute name="Append" type="xsd:boolean" use="required"/>
+    <xsd:attribute name="PreserveSortAFLayout" type="xsd:boolean" use="required"/>
+    <xsd:attribute name="PreserveFormat" type="xsd:boolean" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DataBinding">
+    <xsd:sequence>
+      <xsd:any/>
+    </xsd:sequence>
+    <xsd:attribute name="DataBindingName" type="xsd:string" use="optional"/>
+    <xsd:attribute name="FileBinding" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="ConnectionID" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="FileBindingName" type="xsd:string" use="optional"/>
+    <xsd:attribute name="DataBindingLoadMode" type="xsd:unsignedInt" use="required"/>
+  </xsd:complexType>
+  <xsd:element name="connections" type="CT_Connections"/>
+  <xsd:complexType name="CT_Connections">
+    <xsd:sequence>
+      <xsd:element name="connection" minOccurs="1" maxOccurs="unbounded" type="CT_Connection"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Connection">
+    <xsd:sequence>
+      <xsd:element name="dbPr" minOccurs="0" maxOccurs="1" type="CT_DbPr"/>
+      <xsd:element name="olapPr" minOccurs="0" maxOccurs="1" type="CT_OlapPr"/>
+      <xsd:element name="webPr" minOccurs="0" maxOccurs="1" type="CT_WebPr"/>
+      <xsd:element name="textPr" minOccurs="0" maxOccurs="1" type="CT_TextPr"/>
+      <xsd:element name="parameters" minOccurs="0" maxOccurs="1" type="CT_Parameters"/>
+      <xsd:element name="extLst" minOccurs="0" maxOccurs="1" type="CT_ExtensionList"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" use="required" type="xsd:unsignedInt"/>
+    <xsd:attribute name="sourceFile" use="optional" type="s:ST_Xstring"/>
+    <xsd:attribute name="odcFile" use="optional" type="s:ST_Xstring"/>
+    <xsd:attribute name="keepAlive" use="optional" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="interval" use="optional" type="xsd:unsignedInt" default="0"/>
+    <xsd:attribute name="name" use="optional" type="s:ST_Xstring"/>
+    <xsd:attribute name="description" use="optional" type="s:ST_Xstring"/>
+    <xsd:attribute name="type" use="optional" type="xsd:unsignedInt"/>
+    <xsd:attribute name="reconnectionMethod" use="optional" type="xsd:unsignedInt" default="1"/>
+    <xsd:attribute name="refreshedVersion" use="required" type="xsd:unsignedByte"/>
+    <xsd:attribute name="minRefreshableVersion" use="optional" type="xsd:unsignedByte" default="0"/>
+    <xsd:attribute name="savePassword" use="optional" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="new" use="optional" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="deleted" use="optional" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="onlyUseConnectionFile" use="optional" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="background" use="optional" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="refreshOnLoad" use="optional" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="saveData" use="optional" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="credentials" use="optional" type="ST_CredMethod" default="integrated"/>
+    <xsd:attribute name="singleSignOnId" use="optional" type="s:ST_Xstring"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_CredMethod">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="integrated"/>
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="stored"/>
+      <xsd:enumeration value="prompt"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_DbPr">
+    <xsd:attribute name="connection" use="required" type="s:ST_Xstring"/>
+    <xsd:attribute name="command" use="optional" type="s:ST_Xstring"/>
+    <xsd:attribute name="serverCommand" use="optional" type="s:ST_Xstring"/>
+    <xsd:attribute name="commandType" use="optional" type="xsd:unsignedInt" default="2"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_OlapPr">
+    <xsd:attribute name="local" use="optional" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="localConnection" use="optional" type="s:ST_Xstring"/>
+    <xsd:attribute name="localRefresh" use="optional" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="sendLocale" use="optional" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="rowDrillCount" use="optional" type="xsd:unsignedInt"/>
+    <xsd:attribute name="serverFill" use="optional" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="serverNumberFormat" use="optional" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="serverFont" use="optional" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="serverFontColor" use="optional" type="xsd:boolean" default="true"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_WebPr">
+    <xsd:sequence>
+      <xsd:element name="tables" minOccurs="0" maxOccurs="1" type="CT_Tables"/>
+    </xsd:sequence>
+    <xsd:attribute name="xml" use="optional" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="sourceData" use="optional" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="parsePre" use="optional" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="consecutive" use="optional" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="firstRow" use="optional" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="xl97" use="optional" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="textDates" use="optional" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="xl2000" use="optional" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="url" use="optional" type="s:ST_Xstring"/>
+    <xsd:attribute name="post" use="optional" type="s:ST_Xstring"/>
+    <xsd:attribute name="htmlTables" use="optional" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="htmlFormat" use="optional" type="ST_HtmlFmt" default="none"/>
+    <xsd:attribute name="editPage" use="optional" type="s:ST_Xstring"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_HtmlFmt">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="rtf"/>
+      <xsd:enumeration value="all"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Parameters">
+    <xsd:sequence>
+      <xsd:element name="parameter" minOccurs="1" maxOccurs="unbounded" type="CT_Parameter"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" use="optional" type="xsd:unsignedInt"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Parameter">
+    <xsd:attribute name="name" use="optional" type="s:ST_Xstring"/>
+    <xsd:attribute name="sqlType" use="optional" type="xsd:int" default="0"/>
+    <xsd:attribute name="parameterType" use="optional" type="ST_ParameterType" default="prompt"/>
+    <xsd:attribute name="refreshOnChange" use="optional" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="prompt" use="optional" type="s:ST_Xstring"/>
+    <xsd:attribute name="boolean" use="optional" type="xsd:boolean"/>
+    <xsd:attribute name="double" use="optional" type="xsd:double"/>
+    <xsd:attribute name="integer" use="optional" type="xsd:int"/>
+    <xsd:attribute name="string" use="optional" type="s:ST_Xstring"/>
+    <xsd:attribute name="cell" use="optional" type="s:ST_Xstring"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_ParameterType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="prompt"/>
+      <xsd:enumeration value="value"/>
+      <xsd:enumeration value="cell"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Tables">
+    <xsd:choice minOccurs="1" maxOccurs="unbounded">
+      <xsd:element name="m" type="CT_TableMissing"/>
+      <xsd:element name="s" type="CT_XStringElement"/>
+      <xsd:element name="x" type="CT_Index"/>
+    </xsd:choice>
+    <xsd:attribute name="count" use="optional" type="xsd:unsignedInt"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TableMissing"/>
+  <xsd:complexType name="CT_TextPr">
+    <xsd:sequence>
+      <xsd:element name="textFields" minOccurs="0" maxOccurs="1" type="CT_TextFields"/>
+    </xsd:sequence>
+    <xsd:attribute name="prompt" use="optional" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="fileType" use="optional" type="ST_FileType" default="win"/>
+    <xsd:attribute name="codePage" use="optional" type="xsd:unsignedInt" default="1252"/>
+    <xsd:attribute name="characterSet" use="optional" type="xsd:string"/>
+    <xsd:attribute name="firstRow" use="optional" type="xsd:unsignedInt" default="1"/>
+    <xsd:attribute name="sourceFile" use="optional" type="s:ST_Xstring" default=""/>
+    <xsd:attribute name="delimited" use="optional" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="decimal" use="optional" type="s:ST_Xstring" default="."/>
+    <xsd:attribute name="thousands" use="optional" type="s:ST_Xstring" default=","/>
+    <xsd:attribute name="tab" use="optional" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="space" use="optional" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="comma" use="optional" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="semicolon" use="optional" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="consecutive" use="optional" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="qualifier" use="optional" type="ST_Qualifier" default="doubleQuote"/>
+    <xsd:attribute name="delimiter" use="optional" type="s:ST_Xstring"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_FileType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="mac"/>
+      <xsd:enumeration value="win"/>
+      <xsd:enumeration value="dos"/>
+      <xsd:enumeration value="lin"/>
+      <xsd:enumeration value="other"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_Qualifier">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="doubleQuote"/>
+      <xsd:enumeration value="singleQuote"/>
+      <xsd:enumeration value="none"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TextFields">
+    <xsd:sequence>
+      <xsd:element name="textField" minOccurs="1" maxOccurs="unbounded" type="CT_TextField"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" use="optional" type="xsd:unsignedInt" default="1"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TextField">
+    <xsd:attribute name="type" use="optional" type="ST_ExternalConnectionType" default="general"/>
+    <xsd:attribute name="position" use="optional" type="xsd:unsignedInt" default="0"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_ExternalConnectionType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="general"/>
+      <xsd:enumeration value="text"/>
+      <xsd:enumeration value="MDY"/>
+      <xsd:enumeration value="DMY"/>
+      <xsd:enumeration value="YMD"/>
+      <xsd:enumeration value="MYD"/>
+      <xsd:enumeration value="DYM"/>
+      <xsd:enumeration value="YDM"/>
+      <xsd:enumeration value="skip"/>
+      <xsd:enumeration value="EMD"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:element name="pivotCacheDefinition" type="CT_PivotCacheDefinition"/>
+  <xsd:element name="pivotCacheRecords" type="CT_PivotCacheRecords"/>
+  <xsd:element name="pivotTableDefinition" type="CT_pivotTableDefinition"/>
+  <xsd:complexType name="CT_PivotCacheDefinition">
+    <xsd:sequence>
+      <xsd:element name="cacheSource" type="CT_CacheSource" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="cacheFields" type="CT_CacheFields" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="cacheHierarchies" minOccurs="0" type="CT_CacheHierarchies"/>
+      <xsd:element name="kpis" minOccurs="0" type="CT_PCDKPIs"/>
+      <xsd:element name="tupleCache" minOccurs="0" type="CT_TupleCache"/>
+      <xsd:element name="calculatedItems" minOccurs="0" type="CT_CalculatedItems"/>
+      <xsd:element name="calculatedMembers" type="CT_CalculatedMembers" minOccurs="0"/>
+      <xsd:element name="dimensions" type="CT_Dimensions" minOccurs="0"/>
+      <xsd:element name="measureGroups" type="CT_MeasureGroups" minOccurs="0"/>
+      <xsd:element name="maps" type="CT_MeasureDimensionMaps" minOccurs="0"/>
+      <xsd:element name="extLst" minOccurs="0" type="CT_ExtensionList"/>
+    </xsd:sequence>
+    <xsd:attribute ref="r:id" use="optional"/>
+    <xsd:attribute name="invalid" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="saveData" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="refreshOnLoad" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="optimizeMemory" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="enableRefresh" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="refreshedBy" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="refreshedDate" type="xsd:double" use="optional"/>
+    <xsd:attribute name="refreshedDateIso" type="xsd:dateTime" use="optional"/>
+    <xsd:attribute name="backgroundQuery" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="missingItemsLimit" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="createdVersion" type="xsd:unsignedByte" use="optional" default="0"/>
+    <xsd:attribute name="refreshedVersion" type="xsd:unsignedByte" use="optional" default="0"/>
+    <xsd:attribute name="minRefreshableVersion" type="xsd:unsignedByte" use="optional" default="0"/>
+    <xsd:attribute name="recordCount" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="upgradeOnRefresh" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="tupleCache" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="supportSubquery" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="supportAdvancedDrill" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CacheFields">
+    <xsd:sequence>
+      <xsd:element name="cacheField" type="CT_CacheField" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CacheField">
+    <xsd:sequence>
+      <xsd:element name="sharedItems" type="CT_SharedItems" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="fieldGroup" minOccurs="0" type="CT_FieldGroup"/>
+      <xsd:element name="mpMap" minOccurs="0" maxOccurs="unbounded" type="CT_X"/>
+      <xsd:element name="extLst" minOccurs="0" type="CT_ExtensionList"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="s:ST_Xstring" use="required"/>
+    <xsd:attribute name="caption" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="propertyName" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="serverField" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="uniqueList" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="numFmtId" type="ST_NumFmtId" use="optional"/>
+    <xsd:attribute name="formula" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="sqlType" type="xsd:int" use="optional" default="0"/>
+    <xsd:attribute name="hierarchy" type="xsd:int" use="optional" default="0"/>
+    <xsd:attribute name="level" type="xsd:unsignedInt" use="optional" default="0"/>
+    <xsd:attribute name="databaseField" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="mappingCount" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="memberPropertyField" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CacheSource">
+    <xsd:choice minOccurs="0" maxOccurs="1">
+      <xsd:element name="worksheetSource" type="CT_WorksheetSource" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="consolidation" type="CT_Consolidation" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0"/>
+    </xsd:choice>
+    <xsd:attribute name="type" type="ST_SourceType" use="required"/>
+    <xsd:attribute name="connectionId" type="xsd:unsignedInt" default="0" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_SourceType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="worksheet"/>
+      <xsd:enumeration value="external"/>
+      <xsd:enumeration value="consolidation"/>
+      <xsd:enumeration value="scenario"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_WorksheetSource">
+    <xsd:attribute name="ref" type="ST_Ref" use="optional"/>
+    <xsd:attribute name="name" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="sheet" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute ref="r:id" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Consolidation">
+    <xsd:sequence>
+      <xsd:element name="pages" type="CT_Pages" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="rangeSets" type="CT_RangeSets" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="autoPage" type="xsd:boolean" default="true" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Pages">
+    <xsd:sequence>
+      <xsd:element name="page" type="CT_PCDSCPage" minOccurs="1" maxOccurs="4"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PCDSCPage">
+    <xsd:sequence>
+      <xsd:element name="pageItem" type="CT_PageItem" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PageItem">
+    <xsd:attribute name="name" type="s:ST_Xstring" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_RangeSets">
+    <xsd:sequence>
+      <xsd:element name="rangeSet" type="CT_RangeSet" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_RangeSet">
+    <xsd:attribute name="i1" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="i2" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="i3" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="i4" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="ref" type="ST_Ref" use="optional"/>
+    <xsd:attribute name="name" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="sheet" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute ref="r:id" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SharedItems">
+    <xsd:choice minOccurs="0" maxOccurs="unbounded">
+      <xsd:element name="m" type="CT_Missing" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="n" type="CT_Number" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="b" type="CT_Boolean" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="e" type="CT_Error" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="s" type="CT_String" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="d" type="CT_DateTime" minOccurs="1" maxOccurs="1"/>
+    </xsd:choice>
+    <xsd:attribute name="containsSemiMixedTypes" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="containsNonDate" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="containsDate" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="containsString" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="containsBlank" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="containsMixedTypes" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="containsNumber" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="containsInteger" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="minValue" type="xsd:double" use="optional"/>
+    <xsd:attribute name="maxValue" type="xsd:double" use="optional"/>
+    <xsd:attribute name="minDate" type="xsd:dateTime" use="optional"/>
+    <xsd:attribute name="maxDate" type="xsd:dateTime" use="optional"/>
+    <xsd:attribute name="count" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="longText" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Missing">
+    <xsd:sequence>
+      <xsd:element name="tpls" minOccurs="0" maxOccurs="unbounded" type="CT_Tuples"/>
+      <xsd:element name="x" minOccurs="0" maxOccurs="unbounded" type="CT_X"/>
+    </xsd:sequence>
+    <xsd:attribute name="u" type="xsd:boolean"/>
+    <xsd:attribute name="f" type="xsd:boolean"/>
+    <xsd:attribute name="c" type="s:ST_Xstring"/>
+    <xsd:attribute name="cp" type="xsd:unsignedInt"/>
+    <xsd:attribute name="in" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="bc" type="ST_UnsignedIntHex" use="optional"/>
+    <xsd:attribute name="fc" type="ST_UnsignedIntHex" use="optional"/>
+    <xsd:attribute name="i" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="un" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="st" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="b" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Number">
+    <xsd:sequence>
+      <xsd:element name="tpls" minOccurs="0" maxOccurs="unbounded" type="CT_Tuples"/>
+      <xsd:element name="x" minOccurs="0" maxOccurs="unbounded" type="CT_X"/>
+    </xsd:sequence>
+    <xsd:attribute name="v" use="required" type="xsd:double"/>
+    <xsd:attribute name="u" type="xsd:boolean"/>
+    <xsd:attribute name="f" type="xsd:boolean"/>
+    <xsd:attribute name="c" type="s:ST_Xstring"/>
+    <xsd:attribute name="cp" type="xsd:unsignedInt"/>
+    <xsd:attribute name="in" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="bc" type="ST_UnsignedIntHex" use="optional"/>
+    <xsd:attribute name="fc" type="ST_UnsignedIntHex" use="optional"/>
+    <xsd:attribute name="i" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="un" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="st" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="b" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Boolean">
+    <xsd:sequence>
+      <xsd:element name="x" minOccurs="0" maxOccurs="unbounded" type="CT_X"/>
+    </xsd:sequence>
+    <xsd:attribute name="v" use="required" type="xsd:boolean"/>
+    <xsd:attribute name="u" type="xsd:boolean"/>
+    <xsd:attribute name="f" type="xsd:boolean"/>
+    <xsd:attribute name="c" type="s:ST_Xstring"/>
+    <xsd:attribute name="cp" type="xsd:unsignedInt"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Error">
+    <xsd:sequence>
+      <xsd:element name="tpls" minOccurs="0" type="CT_Tuples"/>
+      <xsd:element name="x" minOccurs="0" maxOccurs="unbounded" type="CT_X"/>
+    </xsd:sequence>
+    <xsd:attribute name="v" use="required" type="s:ST_Xstring"/>
+    <xsd:attribute name="u" type="xsd:boolean"/>
+    <xsd:attribute name="f" type="xsd:boolean"/>
+    <xsd:attribute name="c" type="s:ST_Xstring"/>
+    <xsd:attribute name="cp" type="xsd:unsignedInt"/>
+    <xsd:attribute name="in" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="bc" type="ST_UnsignedIntHex" use="optional"/>
+    <xsd:attribute name="fc" type="ST_UnsignedIntHex" use="optional"/>
+    <xsd:attribute name="i" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="un" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="st" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="b" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_String">
+    <xsd:sequence>
+      <xsd:element name="tpls" minOccurs="0" maxOccurs="unbounded" type="CT_Tuples"/>
+      <xsd:element name="x" minOccurs="0" maxOccurs="unbounded" type="CT_X"/>
+    </xsd:sequence>
+    <xsd:attribute name="v" use="required" type="s:ST_Xstring"/>
+    <xsd:attribute name="u" type="xsd:boolean"/>
+    <xsd:attribute name="f" type="xsd:boolean"/>
+    <xsd:attribute name="c" type="s:ST_Xstring"/>
+    <xsd:attribute name="cp" type="xsd:unsignedInt"/>
+    <xsd:attribute name="in" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="bc" type="ST_UnsignedIntHex" use="optional"/>
+    <xsd:attribute name="fc" type="ST_UnsignedIntHex" use="optional"/>
+    <xsd:attribute name="i" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="un" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="st" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="b" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DateTime">
+    <xsd:sequence>
+      <xsd:element name="x" minOccurs="0" maxOccurs="unbounded" type="CT_X"/>
+    </xsd:sequence>
+    <xsd:attribute name="v" use="required" type="xsd:dateTime"/>
+    <xsd:attribute name="u" type="xsd:boolean"/>
+    <xsd:attribute name="f" type="xsd:boolean"/>
+    <xsd:attribute name="c" type="s:ST_Xstring"/>
+    <xsd:attribute name="cp" type="xsd:unsignedInt"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_FieldGroup">
+    <xsd:sequence>
+      <xsd:element name="rangePr" minOccurs="0" type="CT_RangePr"/>
+      <xsd:element name="discretePr" minOccurs="0" type="CT_DiscretePr"/>
+      <xsd:element name="groupItems" minOccurs="0" type="CT_GroupItems"/>
+    </xsd:sequence>
+    <xsd:attribute name="par" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="base" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_RangePr">
+    <xsd:attribute name="autoStart" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="autoEnd" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="groupBy" type="ST_GroupBy" default="range"/>
+    <xsd:attribute name="startNum" type="xsd:double"/>
+    <xsd:attribute name="endNum" type="xsd:double"/>
+    <xsd:attribute name="startDate" type="xsd:dateTime"/>
+    <xsd:attribute name="endDate" type="xsd:dateTime"/>
+    <xsd:attribute name="groupInterval" type="xsd:double" default="1"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_GroupBy">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="range"/>
+      <xsd:enumeration value="seconds"/>
+      <xsd:enumeration value="minutes"/>
+      <xsd:enumeration value="hours"/>
+      <xsd:enumeration value="days"/>
+      <xsd:enumeration value="months"/>
+      <xsd:enumeration value="quarters"/>
+      <xsd:enumeration value="years"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_DiscretePr">
+    <xsd:sequence>
+      <xsd:element name="x" maxOccurs="unbounded" type="CT_Index"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GroupItems">
+    <xsd:choice maxOccurs="unbounded">
+      <xsd:element name="m" type="CT_Missing"/>
+      <xsd:element name="n" type="CT_Number"/>
+      <xsd:element name="b" type="CT_Boolean"/>
+      <xsd:element name="e" type="CT_Error"/>
+      <xsd:element name="s" type="CT_String"/>
+      <xsd:element name="d" type="CT_DateTime"/>
+    </xsd:choice>
+    <xsd:attribute name="count" type="xsd:unsignedInt"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PivotCacheRecords">
+    <xsd:sequence>
+      <xsd:element name="r" minOccurs="0" maxOccurs="unbounded" type="CT_Record"/>
+      <xsd:element name="extLst" minOccurs="0" type="CT_ExtensionList"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Record">
+    <xsd:choice maxOccurs="unbounded">
+      <xsd:element name="m" type="CT_Missing"/>
+      <xsd:element name="n" type="CT_Number"/>
+      <xsd:element name="b" type="CT_Boolean"/>
+      <xsd:element name="e" type="CT_Error"/>
+      <xsd:element name="s" type="CT_String"/>
+      <xsd:element name="d" type="CT_DateTime"/>
+      <xsd:element name="x" type="CT_Index"/>
+    </xsd:choice>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PCDKPIs">
+    <xsd:sequence>
+      <xsd:element name="kpi" minOccurs="0" maxOccurs="unbounded" type="CT_PCDKPI"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PCDKPI">
+    <xsd:attribute name="uniqueName" use="required" type="s:ST_Xstring"/>
+    <xsd:attribute name="caption" use="optional" type="s:ST_Xstring"/>
+    <xsd:attribute name="displayFolder" type="s:ST_Xstring"/>
+    <xsd:attribute name="measureGroup" type="s:ST_Xstring"/>
+    <xsd:attribute name="parent" type="s:ST_Xstring"/>
+    <xsd:attribute name="value" use="required" type="s:ST_Xstring"/>
+    <xsd:attribute name="goal" type="s:ST_Xstring"/>
+    <xsd:attribute name="status" type="s:ST_Xstring"/>
+    <xsd:attribute name="trend" type="s:ST_Xstring"/>
+    <xsd:attribute name="weight" type="s:ST_Xstring"/>
+    <xsd:attribute name="time" type="s:ST_Xstring"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CacheHierarchies">
+    <xsd:sequence>
+      <xsd:element name="cacheHierarchy" minOccurs="0" maxOccurs="unbounded"
+        type="CT_CacheHierarchy"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CacheHierarchy">
+    <xsd:sequence>
+      <xsd:element name="fieldsUsage" minOccurs="0" type="CT_FieldsUsage"/>
+      <xsd:element name="groupLevels" minOccurs="0" type="CT_GroupLevels"/>
+      <xsd:element name="extLst" minOccurs="0" type="CT_ExtensionList"/>
+    </xsd:sequence>
+    <xsd:attribute name="uniqueName" use="required" type="s:ST_Xstring"/>
+    <xsd:attribute name="caption" use="optional" type="s:ST_Xstring"/>
+    <xsd:attribute name="measure" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="set" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="parentSet" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="iconSet" type="xsd:int" default="0"/>
+    <xsd:attribute name="attribute" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="time" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="keyAttribute" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="defaultMemberUniqueName" type="s:ST_Xstring"/>
+    <xsd:attribute name="allUniqueName" type="s:ST_Xstring"/>
+    <xsd:attribute name="allCaption" type="s:ST_Xstring"/>
+    <xsd:attribute name="dimensionUniqueName" type="s:ST_Xstring"/>
+    <xsd:attribute name="displayFolder" type="s:ST_Xstring"/>
+    <xsd:attribute name="measureGroup" type="s:ST_Xstring"/>
+    <xsd:attribute name="measures" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="count" use="required" type="xsd:unsignedInt"/>
+    <xsd:attribute name="oneField" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="memberValueDatatype" use="optional" type="xsd:unsignedShort"/>
+    <xsd:attribute name="unbalanced" use="optional" type="xsd:boolean"/>
+    <xsd:attribute name="unbalancedGroup" use="optional" type="xsd:boolean"/>
+    <xsd:attribute name="hidden" type="xsd:boolean" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_FieldsUsage">
+    <xsd:sequence>
+      <xsd:element name="fieldUsage" minOccurs="0" maxOccurs="unbounded" type="CT_FieldUsage"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_FieldUsage">
+    <xsd:attribute name="x" use="required" type="xsd:int"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GroupLevels">
+    <xsd:sequence>
+      <xsd:element name="groupLevel" maxOccurs="unbounded" type="CT_GroupLevel"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GroupLevel">
+    <xsd:sequence>
+      <xsd:element name="groups" minOccurs="0" type="CT_Groups"/>
+      <xsd:element name="extLst" minOccurs="0" type="CT_ExtensionList"/>
+    </xsd:sequence>
+    <xsd:attribute name="uniqueName" use="required" type="s:ST_Xstring"/>
+    <xsd:attribute name="caption" use="required" type="s:ST_Xstring"/>
+    <xsd:attribute name="user" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="customRollUp" type="xsd:boolean" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Groups">
+    <xsd:sequence>
+      <xsd:element name="group" maxOccurs="unbounded" type="CT_LevelGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_LevelGroup">
+    <xsd:sequence>
+      <xsd:element name="groupMembers" type="CT_GroupMembers"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" use="required" type="s:ST_Xstring"/>
+    <xsd:attribute name="uniqueName" use="required" type="s:ST_Xstring"/>
+    <xsd:attribute name="caption" use="required" type="s:ST_Xstring"/>
+    <xsd:attribute name="uniqueParent" type="s:ST_Xstring"/>
+    <xsd:attribute name="id" type="xsd:int"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GroupMembers">
+    <xsd:sequence>
+      <xsd:element name="groupMember" maxOccurs="unbounded" type="CT_GroupMember"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GroupMember">
+    <xsd:attribute name="uniqueName" use="required" type="s:ST_Xstring"/>
+    <xsd:attribute name="group" type="xsd:boolean" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TupleCache">
+    <xsd:sequence>
+      <xsd:element name="entries" minOccurs="0" type="CT_PCDSDTCEntries"/>
+      <xsd:element name="sets" minOccurs="0" type="CT_Sets"/>
+      <xsd:element name="queryCache" minOccurs="0" type="CT_QueryCache"/>
+      <xsd:element name="serverFormats" minOccurs="0" maxOccurs="1" type="CT_ServerFormats"/>
+      <xsd:element name="extLst" minOccurs="0" type="CT_ExtensionList"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ServerFormat">
+    <xsd:attribute name="culture" use="optional" type="s:ST_Xstring"/>
+    <xsd:attribute name="format" use="optional" type="s:ST_Xstring"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ServerFormats">
+    <xsd:sequence>
+      <xsd:element name="serverFormat" type="CT_ServerFormat" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PCDSDTCEntries">
+    <xsd:choice maxOccurs="unbounded">
+      <xsd:element name="m" type="CT_Missing"/>
+      <xsd:element name="n" type="CT_Number"/>
+      <xsd:element name="e" type="CT_Error"/>
+      <xsd:element name="s" type="CT_String"/>
+    </xsd:choice>
+    <xsd:attribute name="count" type="xsd:unsignedInt"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Tuples">
+    <xsd:sequence>
+      <xsd:element name="tpl" type="CT_Tuple" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="c" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Tuple">
+    <xsd:attribute name="fld" type="xsd:unsignedInt"/>
+    <xsd:attribute name="hier" type="xsd:unsignedInt"/>
+    <xsd:attribute name="item" type="xsd:unsignedInt" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Sets">
+    <xsd:sequence>
+      <xsd:element name="set" maxOccurs="unbounded" type="CT_Set"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Set">
+    <xsd:sequence>
+      <xsd:element name="tpls" minOccurs="0" maxOccurs="unbounded" type="CT_Tuples"/>
+      <xsd:element name="sortByTuple" minOccurs="0" type="CT_Tuples"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt"/>
+    <xsd:attribute name="maxRank" use="required" type="xsd:int"/>
+    <xsd:attribute name="setDefinition" use="required" type="s:ST_Xstring"/>
+    <xsd:attribute name="sortType" type="ST_SortType" default="none"/>
+    <xsd:attribute name="queryFailed" type="xsd:boolean" default="false"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_SortType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="ascending"/>
+      <xsd:enumeration value="descending"/>
+      <xsd:enumeration value="ascendingAlpha"/>
+      <xsd:enumeration value="descendingAlpha"/>
+      <xsd:enumeration value="ascendingNatural"/>
+      <xsd:enumeration value="descendingNatural"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_QueryCache">
+    <xsd:sequence>
+      <xsd:element name="query" maxOccurs="unbounded" type="CT_Query"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Query">
+    <xsd:sequence>
+      <xsd:element name="tpls" minOccurs="0" type="CT_Tuples"/>
+    </xsd:sequence>
+    <xsd:attribute name="mdx" use="required" type="s:ST_Xstring"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CalculatedItems">
+    <xsd:sequence>
+      <xsd:element name="calculatedItem" maxOccurs="unbounded" type="CT_CalculatedItem"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CalculatedItem">
+    <xsd:sequence>
+      <xsd:element name="pivotArea" type="CT_PivotArea"/>
+      <xsd:element name="extLst" minOccurs="0" type="CT_ExtensionList"/>
+    </xsd:sequence>
+    <xsd:attribute name="field" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="formula" type="s:ST_Xstring"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CalculatedMembers">
+    <xsd:sequence>
+      <xsd:element name="calculatedMember" maxOccurs="unbounded" type="CT_CalculatedMember"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CalculatedMember">
+    <xsd:sequence minOccurs="0">
+      <xsd:element name="extLst" minOccurs="0" type="CT_ExtensionList"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" use="required" type="s:ST_Xstring"/>
+    <xsd:attribute name="mdx" use="required" type="s:ST_Xstring"/>
+    <xsd:attribute name="memberName" type="s:ST_Xstring"/>
+    <xsd:attribute name="hierarchy" type="s:ST_Xstring"/>
+    <xsd:attribute name="parent" type="s:ST_Xstring"/>
+    <xsd:attribute name="solveOrder" type="xsd:int" default="0"/>
+    <xsd:attribute name="set" type="xsd:boolean" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_pivotTableDefinition">
+    <xsd:sequence>
+      <xsd:element name="location" type="CT_Location"/>
+      <xsd:element name="pivotFields" type="CT_PivotFields" minOccurs="0"/>
+      <xsd:element name="rowFields" type="CT_RowFields" minOccurs="0"/>
+      <xsd:element name="rowItems" type="CT_rowItems" minOccurs="0"/>
+      <xsd:element name="colFields" type="CT_ColFields" minOccurs="0"/>
+      <xsd:element name="colItems" type="CT_colItems" minOccurs="0"/>
+      <xsd:element name="pageFields" type="CT_PageFields" minOccurs="0"/>
+      <xsd:element name="dataFields" type="CT_DataFields" minOccurs="0"/>
+      <xsd:element name="formats" type="CT_Formats" minOccurs="0"/>
+      <xsd:element name="conditionalFormats" type="CT_ConditionalFormats" minOccurs="0"/>
+      <xsd:element name="chartFormats" type="CT_ChartFormats" minOccurs="0"/>
+      <xsd:element name="pivotHierarchies" type="CT_PivotHierarchies" minOccurs="0"/>
+      <xsd:element name="pivotTableStyleInfo" minOccurs="0" maxOccurs="1" type="CT_PivotTableStyle"/>
+      <xsd:element name="filters" minOccurs="0" maxOccurs="1" type="CT_PivotFilters"/>
+      <xsd:element name="rowHierarchiesUsage" type="CT_RowHierarchiesUsage" minOccurs="0"
+        maxOccurs="1"/>
+      <xsd:element name="colHierarchiesUsage" type="CT_ColHierarchiesUsage" minOccurs="0"
+        maxOccurs="1"/>
+      <xsd:element name="extLst" minOccurs="0" type="CT_ExtensionList"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" use="required" type="s:ST_Xstring"/>
+    <xsd:attribute name="cacheId" use="required" type="xsd:unsignedInt"/>
+    <xsd:attribute name="dataOnRows" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="dataPosition" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attributeGroup ref="AG_AutoFormat"/>
+    <xsd:attribute name="dataCaption" use="required" type="s:ST_Xstring"/>
+    <xsd:attribute name="grandTotalCaption" type="s:ST_Xstring"/>
+    <xsd:attribute name="errorCaption" type="s:ST_Xstring"/>
+    <xsd:attribute name="showError" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="missingCaption" type="s:ST_Xstring"/>
+    <xsd:attribute name="showMissing" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="pageStyle" type="s:ST_Xstring"/>
+    <xsd:attribute name="pivotTableStyle" type="s:ST_Xstring"/>
+    <xsd:attribute name="vacatedStyle" type="s:ST_Xstring"/>
+    <xsd:attribute name="tag" type="s:ST_Xstring"/>
+    <xsd:attribute name="updatedVersion" type="xsd:unsignedByte" default="0"/>
+    <xsd:attribute name="minRefreshableVersion" type="xsd:unsignedByte" default="0"/>
+    <xsd:attribute name="asteriskTotals" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="showItems" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="editData" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="disableFieldList" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="showCalcMbrs" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="visualTotals" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="showMultipleLabel" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="showDataDropDown" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="showDrill" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="printDrill" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="showMemberPropertyTips" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="showDataTips" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="enableWizard" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="enableDrill" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="enableFieldProperties" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="preserveFormatting" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="useAutoFormatting" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="pageWrap" type="xsd:unsignedInt" default="0"/>
+    <xsd:attribute name="pageOverThenDown" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="subtotalHiddenItems" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="rowGrandTotals" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="colGrandTotals" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="fieldPrintTitles" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="itemPrintTitles" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="mergeItem" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="showDropZones" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="createdVersion" type="xsd:unsignedByte" default="0"/>
+    <xsd:attribute name="indent" type="xsd:unsignedInt" default="1"/>
+    <xsd:attribute name="showEmptyRow" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="showEmptyCol" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="showHeaders" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="compact" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="outline" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="outlineData" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="compactData" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="published" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="gridDropZones" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="immersive" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="multipleFieldFilters" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="chartFormat" type="xsd:unsignedInt" default="0"/>
+    <xsd:attribute name="rowHeaderCaption" type="s:ST_Xstring"/>
+    <xsd:attribute name="colHeaderCaption" type="s:ST_Xstring"/>
+    <xsd:attribute name="fieldListSortAscending" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="mdxSubqueries" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="customListSort" type="xsd:boolean" use="optional" default="true"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Location">
+    <xsd:attribute name="ref" use="required" type="ST_Ref"/>
+    <xsd:attribute name="firstHeaderRow" use="required" type="xsd:unsignedInt"/>
+    <xsd:attribute name="firstDataRow" use="required" type="xsd:unsignedInt"/>
+    <xsd:attribute name="firstDataCol" use="required" type="xsd:unsignedInt"/>
+    <xsd:attribute name="rowPageCount" type="xsd:unsignedInt" default="0"/>
+    <xsd:attribute name="colPageCount" type="xsd:unsignedInt" default="0"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PivotFields">
+    <xsd:sequence>
+      <xsd:element name="pivotField" maxOccurs="unbounded" type="CT_PivotField"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PivotField">
+    <xsd:sequence>
+      <xsd:element name="items" minOccurs="0" type="CT_Items"/>
+      <xsd:element name="autoSortScope" minOccurs="0" type="CT_AutoSortScope"/>
+      <xsd:element name="extLst" minOccurs="0" type="CT_ExtensionList"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="s:ST_Xstring"/>
+    <xsd:attribute name="axis" use="optional" type="ST_Axis"/>
+    <xsd:attribute name="dataField" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="subtotalCaption" type="s:ST_Xstring"/>
+    <xsd:attribute name="showDropDowns" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="hiddenLevel" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="uniqueMemberProperty" type="s:ST_Xstring"/>
+    <xsd:attribute name="compact" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="allDrilled" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="numFmtId" type="ST_NumFmtId" use="optional"/>
+    <xsd:attribute name="outline" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="subtotalTop" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="dragToRow" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="dragToCol" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="multipleItemSelectionAllowed" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="dragToPage" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="dragToData" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="dragOff" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="showAll" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="insertBlankRow" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="serverField" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="insertPageBreak" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="autoShow" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="topAutoShow" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="hideNewItems" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="measureFilter" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="includeNewItemsInFilter" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="itemPageCount" type="xsd:unsignedInt" default="10"/>
+    <xsd:attribute name="sortType" type="ST_FieldSortType" default="manual"/>
+    <xsd:attribute name="dataSourceSort" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="nonAutoSortDefault" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="rankBy" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="defaultSubtotal" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="sumSubtotal" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="countASubtotal" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="avgSubtotal" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="maxSubtotal" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="minSubtotal" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="productSubtotal" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="countSubtotal" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="stdDevSubtotal" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="stdDevPSubtotal" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="varSubtotal" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="varPSubtotal" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="showPropCell" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="showPropTip" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="showPropAsCaption" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="defaultAttributeDrillState" type="xsd:boolean" use="optional"
+      default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_AutoSortScope">
+    <xsd:sequence>
+      <xsd:element name="pivotArea" type="CT_PivotArea"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Items">
+    <xsd:sequence>
+      <xsd:element name="item" maxOccurs="unbounded" type="CT_Item"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Item">
+    <xsd:attribute name="n" type="s:ST_Xstring"/>
+    <xsd:attribute name="t" type="ST_ItemType" default="data"/>
+    <xsd:attribute name="h" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="s" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="sd" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="f" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="m" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="c" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="x" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="d" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="e" type="xsd:boolean" default="true"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PageFields">
+    <xsd:sequence>
+      <xsd:element name="pageField" maxOccurs="unbounded" type="CT_PageField"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PageField">
+    <xsd:sequence minOccurs="0">
+      <xsd:element name="extLst" minOccurs="0" type="CT_ExtensionList"/>
+    </xsd:sequence>
+    <xsd:attribute name="fld" use="required" type="xsd:int"/>
+    <xsd:attribute name="item" use="optional" type="xsd:unsignedInt"/>
+    <xsd:attribute name="hier" type="xsd:int"/>
+    <xsd:attribute name="name" type="s:ST_Xstring"/>
+    <xsd:attribute name="cap" type="s:ST_Xstring"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DataFields">
+    <xsd:sequence>
+      <xsd:element name="dataField" maxOccurs="unbounded" type="CT_DataField"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DataField">
+    <xsd:sequence>
+      <xsd:element name="extLst" minOccurs="0" type="CT_ExtensionList"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" use="optional" type="s:ST_Xstring"/>
+    <xsd:attribute name="fld" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="subtotal" type="ST_DataConsolidateFunction" default="sum"/>
+    <xsd:attribute name="showDataAs" type="ST_ShowDataAs" default="normal"/>
+    <xsd:attribute name="baseField" type="xsd:int" default="-1"/>
+    <xsd:attribute name="baseItem" type="xsd:unsignedInt" default="1048832"/>
+    <xsd:attribute name="numFmtId" type="ST_NumFmtId" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_rowItems">
+    <xsd:sequence>
+      <xsd:element name="i" maxOccurs="unbounded" type="CT_I"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_colItems">
+    <xsd:sequence>
+      <xsd:element name="i" maxOccurs="unbounded" type="CT_I"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_I">
+    <xsd:sequence>
+      <xsd:element name="x" minOccurs="0" maxOccurs="unbounded" type="CT_X"/>
+    </xsd:sequence>
+    <xsd:attribute name="t" type="ST_ItemType" default="data"/>
+    <xsd:attribute name="r" type="xsd:unsignedInt" default="0"/>
+    <xsd:attribute name="i" type="xsd:unsignedInt" default="0"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_X">
+    <xsd:attribute name="v" type="xsd:int" default="0"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_RowFields">
+    <xsd:sequence>
+      <xsd:element name="field" maxOccurs="unbounded" type="CT_Field"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt" default="0"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ColFields">
+    <xsd:sequence>
+      <xsd:element name="field" maxOccurs="unbounded" type="CT_Field"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt" default="0"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Field">
+    <xsd:attribute name="x" type="xsd:int" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Formats">
+    <xsd:sequence>
+      <xsd:element name="format" maxOccurs="unbounded" type="CT_Format"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt" default="0"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Format">
+    <xsd:sequence>
+      <xsd:element name="pivotArea" type="CT_PivotArea"/>
+      <xsd:element name="extLst" minOccurs="0" type="CT_ExtensionList"/>
+    </xsd:sequence>
+    <xsd:attribute name="action" type="ST_FormatAction" default="formatting"/>
+    <xsd:attribute name="dxfId" type="ST_DxfId" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ConditionalFormats">
+    <xsd:sequence>
+      <xsd:element name="conditionalFormat" maxOccurs="unbounded" type="CT_ConditionalFormat"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt" default="0"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ConditionalFormat">
+    <xsd:sequence>
+      <xsd:element name="pivotAreas" type="CT_PivotAreas"/>
+      <xsd:element name="extLst" minOccurs="0" type="CT_ExtensionList"/>
+    </xsd:sequence>
+    <xsd:attribute name="scope" type="ST_Scope" default="selection"/>
+    <xsd:attribute name="type" type="ST_Type" default="none"/>
+    <xsd:attribute name="priority" use="required" type="xsd:unsignedInt"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PivotAreas">
+    <xsd:sequence>
+      <xsd:element name="pivotArea" minOccurs="0" maxOccurs="unbounded" type="CT_PivotArea"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_Scope">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="selection"/>
+      <xsd:enumeration value="data"/>
+      <xsd:enumeration value="field"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_Type">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="all"/>
+      <xsd:enumeration value="row"/>
+      <xsd:enumeration value="column"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_ChartFormats">
+    <xsd:sequence>
+      <xsd:element name="chartFormat" maxOccurs="unbounded" type="CT_ChartFormat"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt" default="0"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ChartFormat">
+    <xsd:sequence>
+      <xsd:element name="pivotArea" type="CT_PivotArea"/>
+    </xsd:sequence>
+    <xsd:attribute name="chart" use="required" type="xsd:unsignedInt"/>
+    <xsd:attribute name="format" use="required" type="xsd:unsignedInt"/>
+    <xsd:attribute name="series" type="xsd:boolean" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PivotHierarchies">
+    <xsd:sequence>
+      <xsd:element name="pivotHierarchy" maxOccurs="unbounded" type="CT_PivotHierarchy"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PivotHierarchy">
+    <xsd:sequence>
+      <xsd:element name="mps" minOccurs="0" type="CT_MemberProperties"/>
+      <xsd:element name="members" minOccurs="0" maxOccurs="unbounded" type="CT_Members"/>
+      <xsd:element name="extLst" minOccurs="0" type="CT_ExtensionList"/>
+    </xsd:sequence>
+    <xsd:attribute name="outline" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="multipleItemSelectionAllowed" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="subtotalTop" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="showInFieldList" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="dragToRow" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="dragToCol" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="dragToPage" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="dragToData" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="dragOff" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="includeNewItemsInFilter" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="caption" type="s:ST_Xstring" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_RowHierarchiesUsage">
+    <xsd:sequence>
+      <xsd:element name="rowHierarchyUsage" minOccurs="1" maxOccurs="unbounded"
+        type="CT_HierarchyUsage"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ColHierarchiesUsage">
+    <xsd:sequence>
+      <xsd:element name="colHierarchyUsage" minOccurs="1" maxOccurs="unbounded"
+        type="CT_HierarchyUsage"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_HierarchyUsage">
+    <xsd:attribute name="hierarchyUsage" type="xsd:int" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_MemberProperties">
+    <xsd:sequence>
+      <xsd:element name="mp" maxOccurs="unbounded" type="CT_MemberProperty"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_MemberProperty">
+    <xsd:attribute name="name" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="showCell" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="showTip" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="showAsCaption" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="nameLen" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="pPos" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="pLen" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="level" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="field" use="required" type="xsd:unsignedInt"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Members">
+    <xsd:sequence>
+      <xsd:element name="member" maxOccurs="unbounded" type="CT_Member"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt"/>
+    <xsd:attribute name="level" use="optional" type="xsd:unsignedInt"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Member">
+    <xsd:attribute name="name" use="required" type="s:ST_Xstring"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Dimensions">
+    <xsd:sequence>
+      <xsd:element name="dimension" minOccurs="0" maxOccurs="unbounded" type="CT_PivotDimension"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PivotDimension">
+    <xsd:attribute name="measure" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="name" use="required" type="s:ST_Xstring"/>
+    <xsd:attribute name="uniqueName" use="required" type="s:ST_Xstring"/>
+    <xsd:attribute name="caption" use="required" type="s:ST_Xstring"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_MeasureGroups">
+    <xsd:sequence>
+      <xsd:element name="measureGroup" minOccurs="0" maxOccurs="unbounded" type="CT_MeasureGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_MeasureDimensionMaps">
+    <xsd:sequence>
+      <xsd:element name="map" minOccurs="0" maxOccurs="unbounded" type="CT_MeasureDimensionMap"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_MeasureGroup">
+    <xsd:attribute name="name" use="required" type="s:ST_Xstring"/>
+    <xsd:attribute name="caption" use="required" type="s:ST_Xstring"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_MeasureDimensionMap">
+    <xsd:attribute name="measureGroup" use="optional" type="xsd:unsignedInt"/>
+    <xsd:attribute name="dimension" use="optional" type="xsd:unsignedInt"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PivotTableStyle">
+    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute name="showRowHeaders" type="xsd:boolean"/>
+    <xsd:attribute name="showColHeaders" type="xsd:boolean"/>
+    <xsd:attribute name="showRowStripes" type="xsd:boolean"/>
+    <xsd:attribute name="showColStripes" type="xsd:boolean"/>
+    <xsd:attribute name="showLastColumn" type="xsd:boolean" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PivotFilters">
+    <xsd:sequence>
+      <xsd:element name="filter" minOccurs="0" maxOccurs="unbounded" type="CT_PivotFilter"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt" default="0"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PivotFilter">
+    <xsd:sequence>
+      <xsd:element name="autoFilter" minOccurs="1" maxOccurs="1" type="CT_AutoFilter"/>
+      <xsd:element name="extLst" minOccurs="0" type="CT_ExtensionList"/>
+    </xsd:sequence>
+    <xsd:attribute name="fld" use="required" type="xsd:unsignedInt"/>
+    <xsd:attribute name="mpFld" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="type" use="required" type="ST_PivotFilterType"/>
+    <xsd:attribute name="evalOrder" use="optional" type="xsd:int" default="0"/>
+    <xsd:attribute name="id" use="required" type="xsd:unsignedInt"/>
+    <xsd:attribute name="iMeasureHier" use="optional" type="xsd:unsignedInt"/>
+    <xsd:attribute name="iMeasureFld" use="optional" type="xsd:unsignedInt"/>
+    <xsd:attribute name="name" type="s:ST_Xstring"/>
+    <xsd:attribute name="description" type="s:ST_Xstring"/>
+    <xsd:attribute name="stringValue1" type="s:ST_Xstring"/>
+    <xsd:attribute name="stringValue2" type="s:ST_Xstring"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_ShowDataAs">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="normal"/>
+      <xsd:enumeration value="difference"/>
+      <xsd:enumeration value="percent"/>
+      <xsd:enumeration value="percentDiff"/>
+      <xsd:enumeration value="runTotal"/>
+      <xsd:enumeration value="percentOfRow"/>
+      <xsd:enumeration value="percentOfCol"/>
+      <xsd:enumeration value="percentOfTotal"/>
+      <xsd:enumeration value="index"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_ItemType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="data"/>
+      <xsd:enumeration value="default"/>
+      <xsd:enumeration value="sum"/>
+      <xsd:enumeration value="countA"/>
+      <xsd:enumeration value="avg"/>
+      <xsd:enumeration value="max"/>
+      <xsd:enumeration value="min"/>
+      <xsd:enumeration value="product"/>
+      <xsd:enumeration value="count"/>
+      <xsd:enumeration value="stdDev"/>
+      <xsd:enumeration value="stdDevP"/>
+      <xsd:enumeration value="var"/>
+      <xsd:enumeration value="varP"/>
+      <xsd:enumeration value="grand"/>
+      <xsd:enumeration value="blank"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_FormatAction">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="blank"/>
+      <xsd:enumeration value="formatting"/>
+      <xsd:enumeration value="drill"/>
+      <xsd:enumeration value="formula"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_FieldSortType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="manual"/>
+      <xsd:enumeration value="ascending"/>
+      <xsd:enumeration value="descending"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_PivotFilterType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="unknown"/>
+      <xsd:enumeration value="count"/>
+      <xsd:enumeration value="percent"/>
+      <xsd:enumeration value="sum"/>
+      <xsd:enumeration value="captionEqual"/>
+      <xsd:enumeration value="captionNotEqual"/>
+      <xsd:enumeration value="captionBeginsWith"/>
+      <xsd:enumeration value="captionNotBeginsWith"/>
+      <xsd:enumeration value="captionEndsWith"/>
+      <xsd:enumeration value="captionNotEndsWith"/>
+      <xsd:enumeration value="captionContains"/>
+      <xsd:enumeration value="captionNotContains"/>
+      <xsd:enumeration value="captionGreaterThan"/>
+      <xsd:enumeration value="captionGreaterThanOrEqual"/>
+      <xsd:enumeration value="captionLessThan"/>
+      <xsd:enumeration value="captionLessThanOrEqual"/>
+      <xsd:enumeration value="captionBetween"/>
+      <xsd:enumeration value="captionNotBetween"/>
+      <xsd:enumeration value="valueEqual"/>
+      <xsd:enumeration value="valueNotEqual"/>
+      <xsd:enumeration value="valueGreaterThan"/>
+      <xsd:enumeration value="valueGreaterThanOrEqual"/>
+      <xsd:enumeration value="valueLessThan"/>
+      <xsd:enumeration value="valueLessThanOrEqual"/>
+      <xsd:enumeration value="valueBetween"/>
+      <xsd:enumeration value="valueNotBetween"/>
+      <xsd:enumeration value="dateEqual"/>
+      <xsd:enumeration value="dateNotEqual"/>
+      <xsd:enumeration value="dateOlderThan"/>
+      <xsd:enumeration value="dateOlderThanOrEqual"/>
+      <xsd:enumeration value="dateNewerThan"/>
+      <xsd:enumeration value="dateNewerThanOrEqual"/>
+      <xsd:enumeration value="dateBetween"/>
+      <xsd:enumeration value="dateNotBetween"/>
+      <xsd:enumeration value="tomorrow"/>
+      <xsd:enumeration value="today"/>
+      <xsd:enumeration value="yesterday"/>
+      <xsd:enumeration value="nextWeek"/>
+      <xsd:enumeration value="thisWeek"/>
+      <xsd:enumeration value="lastWeek"/>
+      <xsd:enumeration value="nextMonth"/>
+      <xsd:enumeration value="thisMonth"/>
+      <xsd:enumeration value="lastMonth"/>
+      <xsd:enumeration value="nextQuarter"/>
+      <xsd:enumeration value="thisQuarter"/>
+      <xsd:enumeration value="lastQuarter"/>
+      <xsd:enumeration value="nextYear"/>
+      <xsd:enumeration value="thisYear"/>
+      <xsd:enumeration value="lastYear"/>
+      <xsd:enumeration value="yearToDate"/>
+      <xsd:enumeration value="Q1"/>
+      <xsd:enumeration value="Q2"/>
+      <xsd:enumeration value="Q3"/>
+      <xsd:enumeration value="Q4"/>
+      <xsd:enumeration value="M1"/>
+      <xsd:enumeration value="M2"/>
+      <xsd:enumeration value="M3"/>
+      <xsd:enumeration value="M4"/>
+      <xsd:enumeration value="M5"/>
+      <xsd:enumeration value="M6"/>
+      <xsd:enumeration value="M7"/>
+      <xsd:enumeration value="M8"/>
+      <xsd:enumeration value="M9"/>
+      <xsd:enumeration value="M10"/>
+      <xsd:enumeration value="M11"/>
+      <xsd:enumeration value="M12"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_PivotArea">
+    <xsd:sequence>
+      <xsd:element name="references" minOccurs="0" type="CT_PivotAreaReferences"/>
+      <xsd:element name="extLst" minOccurs="0" type="CT_ExtensionList"/>
+    </xsd:sequence>
+    <xsd:attribute name="field" use="optional" type="xsd:int"/>
+    <xsd:attribute name="type" type="ST_PivotAreaType" default="normal"/>
+    <xsd:attribute name="dataOnly" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="labelOnly" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="grandRow" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="grandCol" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="cacheIndex" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="outline" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="offset" type="ST_Ref"/>
+    <xsd:attribute name="collapsedLevelsAreSubtotals" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="axis" type="ST_Axis" use="optional"/>
+    <xsd:attribute name="fieldPosition" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_PivotAreaType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="normal"/>
+      <xsd:enumeration value="data"/>
+      <xsd:enumeration value="all"/>
+      <xsd:enumeration value="origin"/>
+      <xsd:enumeration value="button"/>
+      <xsd:enumeration value="topEnd"/>
+      <xsd:enumeration value="topRight"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_PivotAreaReferences">
+    <xsd:sequence>
+      <xsd:element name="reference" maxOccurs="unbounded" type="CT_PivotAreaReference"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PivotAreaReference">
+    <xsd:sequence>
+      <xsd:element name="x" minOccurs="0" maxOccurs="unbounded" type="CT_Index"/>
+      <xsd:element name="extLst" minOccurs="0" type="CT_ExtensionList"/>
+    </xsd:sequence>
+    <xsd:attribute name="field" use="optional" type="xsd:unsignedInt"/>
+    <xsd:attribute name="count" type="xsd:unsignedInt"/>
+    <xsd:attribute name="selected" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="byPosition" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="relative" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="defaultSubtotal" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="sumSubtotal" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="countASubtotal" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="avgSubtotal" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="maxSubtotal" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="minSubtotal" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="productSubtotal" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="countSubtotal" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="stdDevSubtotal" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="stdDevPSubtotal" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="varSubtotal" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="varPSubtotal" type="xsd:boolean" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Index">
+    <xsd:attribute name="v" use="required" type="xsd:unsignedInt"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_Axis">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="axisRow"/>
+      <xsd:enumeration value="axisCol"/>
+      <xsd:enumeration value="axisPage"/>
+      <xsd:enumeration value="axisValues"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:element name="queryTable" type="CT_QueryTable"/>
+  <xsd:complexType name="CT_QueryTable">
+    <xsd:sequence>
+      <xsd:element name="queryTableRefresh" type="CT_QueryTableRefresh" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="s:ST_Xstring" use="required"/>
+    <xsd:attribute name="headers" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="rowNumbers" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="disableRefresh" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="backgroundRefresh" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="firstBackgroundRefresh" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="refreshOnLoad" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="growShrinkType" type="ST_GrowShrinkType" use="optional"
+      default="insertDelete"/>
+    <xsd:attribute name="fillFormulas" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="removeDataOnSave" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="disableEdit" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="preserveFormatting" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="adjustColumnWidth" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="intermediate" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="connectionId" type="xsd:unsignedInt" use="required"/>
+    <xsd:attributeGroup ref="AG_AutoFormat"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_QueryTableRefresh">
+    <xsd:sequence>
+      <xsd:element name="queryTableFields" type="CT_QueryTableFields" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="queryTableDeletedFields" type="CT_QueryTableDeletedFields" minOccurs="0"
+        maxOccurs="1"/>
+      <xsd:element name="sortState" minOccurs="0" maxOccurs="1" type="CT_SortState"/>
+      <xsd:element name="extLst" minOccurs="0" maxOccurs="1" type="CT_ExtensionList"/>
+    </xsd:sequence>
+    <xsd:attribute name="preserveSortFilterLayout" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="fieldIdWrapped" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="headersInLastRefresh" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="minimumVersion" type="xsd:unsignedByte" use="optional" default="0"/>
+    <xsd:attribute name="nextId" type="xsd:unsignedInt" use="optional" default="1"/>
+    <xsd:attribute name="unboundColumnsLeft" type="xsd:unsignedInt" use="optional" default="0"/>
+    <xsd:attribute name="unboundColumnsRight" type="xsd:unsignedInt" use="optional" default="0"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_QueryTableDeletedFields">
+    <xsd:sequence>
+      <xsd:element name="deletedField" type="CT_DeletedField" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DeletedField">
+    <xsd:attribute name="name" type="s:ST_Xstring" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_QueryTableFields">
+    <xsd:sequence>
+      <xsd:element name="queryTableField" type="CT_QueryTableField" minOccurs="0"
+        maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt" use="optional" default="0"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_QueryTableField">
+    <xsd:sequence minOccurs="0">
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="name" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="dataBound" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="rowNumbers" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="fillFormulas" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="clipped" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="tableColumnId" type="xsd:unsignedInt" default="0"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_GrowShrinkType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="insertDelete"/>
+      <xsd:enumeration value="insertClear"/>
+      <xsd:enumeration value="overwriteClear"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:element name="sst" type="CT_Sst"/>
+  <xsd:complexType name="CT_Sst">
+    <xsd:sequence>
+      <xsd:element name="si" type="CT_Rst" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="extLst" minOccurs="0" type="CT_ExtensionList"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="uniqueCount" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_PhoneticType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="halfwidthKatakana"/>
+      <xsd:enumeration value="fullwidthKatakana"/>
+      <xsd:enumeration value="Hiragana"/>
+      <xsd:enumeration value="noConversion"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_PhoneticAlignment">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="noControl"/>
+      <xsd:enumeration value="left"/>
+      <xsd:enumeration value="center"/>
+      <xsd:enumeration value="distributed"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_PhoneticRun">
+    <xsd:sequence>
+      <xsd:element name="t" type="s:ST_Xstring" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="sb" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="eb" type="xsd:unsignedInt" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_RElt">
+    <xsd:sequence>
+      <xsd:element name="rPr" type="CT_RPrElt" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="t" type="s:ST_Xstring" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_RPrElt">
+    <xsd:choice maxOccurs="unbounded">
+      <xsd:element name="rFont" type="CT_FontName" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="charset" type="CT_IntProperty" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="family" type="CT_IntProperty" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="b" type="CT_BooleanProperty" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="i" type="CT_BooleanProperty" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="strike" type="CT_BooleanProperty" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="outline" type="CT_BooleanProperty" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="shadow" type="CT_BooleanProperty" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="condense" type="CT_BooleanProperty" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extend" type="CT_BooleanProperty" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="color" type="CT_Color" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="sz" type="CT_FontSize" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="u" type="CT_UnderlineProperty" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="vertAlign" type="CT_VerticalAlignFontProperty" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="scheme" type="CT_FontScheme" minOccurs="0" maxOccurs="1"/>
+    </xsd:choice>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Rst">
+    <xsd:sequence>
+      <xsd:element name="t" type="s:ST_Xstring" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="r" type="CT_RElt" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="rPh" type="CT_PhoneticRun" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="phoneticPr" minOccurs="0" maxOccurs="1" type="CT_PhoneticPr"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PhoneticPr">
+    <xsd:attribute name="fontId" type="ST_FontId" use="required"/>
+    <xsd:attribute name="type" type="ST_PhoneticType" use="optional" default="fullwidthKatakana"/>
+    <xsd:attribute name="alignment" type="ST_PhoneticAlignment" use="optional" default="left"/>
+  </xsd:complexType>
+  <xsd:element name="headers" type="CT_RevisionHeaders"/>
+  <xsd:element name="revisions" type="CT_Revisions"/>
+  <xsd:complexType name="CT_RevisionHeaders">
+    <xsd:sequence>
+      <xsd:element name="header" type="CT_RevisionHeader" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="guid" type="s:ST_Guid" use="required"/>
+    <xsd:attribute name="lastGuid" type="s:ST_Guid" use="optional"/>
+    <xsd:attribute name="shared" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="diskRevisions" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="history" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="trackRevisions" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="exclusive" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="revisionId" type="xsd:unsignedInt" default="0"/>
+    <xsd:attribute name="version" type="xsd:int" default="1"/>
+    <xsd:attribute name="keepChangeHistory" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="protected" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="preserveHistory" type="xsd:unsignedInt" default="30"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Revisions">
+    <xsd:choice maxOccurs="unbounded">
+      <xsd:element name="rrc" type="CT_RevisionRowColumn" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="rm" type="CT_RevisionMove" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="rcv" type="CT_RevisionCustomView" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="rsnm" type="CT_RevisionSheetRename" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="ris" type="CT_RevisionInsertSheet" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="rcc" type="CT_RevisionCellChange" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="rfmt" type="CT_RevisionFormatting" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="raf" type="CT_RevisionAutoFormatting" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="rdn" type="CT_RevisionDefinedName" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="rcmt" type="CT_RevisionComment" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="rqt" type="CT_RevisionQueryTableField" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="rcft" type="CT_RevisionConflict" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:choice>
+  </xsd:complexType>
+  <xsd:attributeGroup name="AG_RevData">
+    <xsd:attribute name="rId" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="ua" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="ra" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:attributeGroup>
+  <xsd:complexType name="CT_RevisionHeader">
+    <xsd:sequence>
+      <xsd:element name="sheetIdMap" minOccurs="1" maxOccurs="1" type="CT_SheetIdMap"/>
+      <xsd:element name="reviewedList" minOccurs="0" maxOccurs="1" type="CT_ReviewedRevisions"/>
+      <xsd:element name="extLst" minOccurs="0" type="CT_ExtensionList"/>
+    </xsd:sequence>
+    <xsd:attribute name="guid" type="s:ST_Guid" use="required"/>
+    <xsd:attribute name="dateTime" type="xsd:dateTime" use="required"/>
+    <xsd:attribute name="maxSheetId" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="userName" type="s:ST_Xstring" use="required"/>
+    <xsd:attribute ref="r:id" use="required"/>
+    <xsd:attribute name="minRId" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="maxRId" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SheetIdMap">
+    <xsd:sequence>
+      <xsd:element name="sheetId" type="CT_SheetId" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SheetId">
+    <xsd:attribute name="val" type="xsd:unsignedInt" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ReviewedRevisions">
+    <xsd:sequence>
+      <xsd:element name="reviewed" type="CT_Reviewed" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Reviewed">
+    <xsd:attribute name="rId" type="xsd:unsignedInt" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_UndoInfo">
+    <xsd:attribute name="index" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="exp" type="ST_FormulaExpression" use="required"/>
+    <xsd:attribute name="ref3D" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="array" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="v" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="nf" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="cs" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="dr" type="ST_RefA" use="required"/>
+    <xsd:attribute name="dn" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="r" type="ST_CellRef" use="optional"/>
+    <xsd:attribute name="sId" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_RevisionRowColumn">
+    <xsd:choice minOccurs="0" maxOccurs="unbounded">
+      <xsd:element name="undo" type="CT_UndoInfo" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="rcc" type="CT_RevisionCellChange" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="rfmt" type="CT_RevisionFormatting" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:choice>
+    <xsd:attributeGroup ref="AG_RevData"/>
+    <xsd:attribute name="sId" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="eol" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="ref" type="ST_Ref" use="required"/>
+    <xsd:attribute name="action" type="ST_rwColActionType" use="required"/>
+    <xsd:attribute name="edge" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_RevisionMove">
+    <xsd:choice minOccurs="0" maxOccurs="unbounded">
+      <xsd:element name="undo" type="CT_UndoInfo" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="rcc" type="CT_RevisionCellChange" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="rfmt" type="CT_RevisionFormatting" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:choice>
+    <xsd:attributeGroup ref="AG_RevData"/>
+    <xsd:attribute name="sheetId" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="source" type="ST_Ref" use="required"/>
+    <xsd:attribute name="destination" type="ST_Ref" use="required"/>
+    <xsd:attribute name="sourceSheetId" type="xsd:unsignedInt" use="optional" default="0"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_RevisionCustomView">
+    <xsd:attribute name="guid" type="s:ST_Guid" use="required"/>
+    <xsd:attribute name="action" type="ST_RevisionAction" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_RevisionSheetRename">
+    <xsd:sequence>
+      <xsd:element name="extLst" minOccurs="0" type="CT_ExtensionList"/>
+    </xsd:sequence>
+    <xsd:attributeGroup ref="AG_RevData"/>
+    <xsd:attribute name="sheetId" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="oldName" type="s:ST_Xstring" use="required"/>
+    <xsd:attribute name="newName" type="s:ST_Xstring" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_RevisionInsertSheet">
+    <xsd:attributeGroup ref="AG_RevData"/>
+    <xsd:attribute name="sheetId" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="name" type="s:ST_Xstring" use="required"/>
+    <xsd:attribute name="sheetPosition" type="xsd:unsignedInt" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_RevisionCellChange">
+    <xsd:sequence>
+      <xsd:element name="oc" type="CT_Cell" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="nc" type="CT_Cell" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="odxf" type="CT_Dxf" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="ndxf" type="CT_Dxf" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" minOccurs="0" type="CT_ExtensionList"/>
+    </xsd:sequence>
+    <xsd:attributeGroup ref="AG_RevData"/>
+    <xsd:attribute name="sId" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="odxf" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="xfDxf" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="s" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="dxf" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="numFmtId" type="ST_NumFmtId" use="optional"/>
+    <xsd:attribute name="quotePrefix" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="oldQuotePrefix" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="ph" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="oldPh" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="endOfListFormulaUpdate" type="xsd:boolean" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_RevisionFormatting">
+    <xsd:sequence>
+      <xsd:element name="dxf" type="CT_Dxf" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" minOccurs="0" type="CT_ExtensionList"/>
+    </xsd:sequence>
+    <xsd:attribute name="sheetId" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="xfDxf" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="s" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="sqref" type="ST_Sqref" use="required"/>
+    <xsd:attribute name="start" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="length" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_RevisionAutoFormatting">
+    <xsd:attribute name="sheetId" type="xsd:unsignedInt" use="required"/>
+    <xsd:attributeGroup ref="AG_AutoFormat"/>
+    <xsd:attribute name="ref" type="ST_Ref" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_RevisionComment">
+    <xsd:attribute name="sheetId" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="cell" type="ST_CellRef" use="required"/>
+    <xsd:attribute name="guid" type="s:ST_Guid" use="required"/>
+    <xsd:attribute name="action" type="ST_RevisionAction" default="add"/>
+    <xsd:attribute name="alwaysShow" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="old" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="hiddenRow" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="hiddenColumn" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="author" type="s:ST_Xstring" use="required"/>
+    <xsd:attribute name="oldLength" type="xsd:unsignedInt" default="0"/>
+    <xsd:attribute name="newLength" type="xsd:unsignedInt" default="0"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_RevisionDefinedName">
+    <xsd:sequence>
+      <xsd:element name="formula" type="ST_Formula" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="oldFormula" type="ST_Formula" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" minOccurs="0" type="CT_ExtensionList"/>
+    </xsd:sequence>
+    <xsd:attributeGroup ref="AG_RevData"/>
+    <xsd:attribute name="localSheetId" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="customView" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="name" type="s:ST_Xstring" use="required"/>
+    <xsd:attribute name="function" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="oldFunction" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="functionGroupId" type="xsd:unsignedByte" use="optional"/>
+    <xsd:attribute name="oldFunctionGroupId" type="xsd:unsignedByte" use="optional"/>
+    <xsd:attribute name="shortcutKey" type="xsd:unsignedByte" use="optional"/>
+    <xsd:attribute name="oldShortcutKey" type="xsd:unsignedByte" use="optional"/>
+    <xsd:attribute name="hidden" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="oldHidden" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="customMenu" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="oldCustomMenu" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="description" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="oldDescription" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="help" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="oldHelp" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="statusBar" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="oldStatusBar" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="comment" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="oldComment" type="s:ST_Xstring" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_RevisionConflict">
+    <xsd:attributeGroup ref="AG_RevData"/>
+    <xsd:attribute name="sheetId" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_RevisionQueryTableField">
+    <xsd:attribute name="sheetId" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="ref" type="ST_Ref" use="required"/>
+    <xsd:attribute name="fieldId" type="xsd:unsignedInt" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_rwColActionType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="insertRow"/>
+      <xsd:enumeration value="deleteRow"/>
+      <xsd:enumeration value="insertCol"/>
+      <xsd:enumeration value="deleteCol"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_RevisionAction">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="add"/>
+      <xsd:enumeration value="delete"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_FormulaExpression">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="ref"/>
+      <xsd:enumeration value="refError"/>
+      <xsd:enumeration value="area"/>
+      <xsd:enumeration value="areaError"/>
+      <xsd:enumeration value="computedArea"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:element name="users" type="CT_Users"/>
+  <xsd:complexType name="CT_Users">
+    <xsd:sequence>
+      <xsd:element name="userInfo" minOccurs="0" maxOccurs="256" type="CT_SharedUser"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SharedUser">
+    <xsd:sequence>
+      <xsd:element name="extLst" minOccurs="0" type="CT_ExtensionList"/>
+    </xsd:sequence>
+    <xsd:attribute name="guid" type="s:ST_Guid" use="required"/>
+    <xsd:attribute name="name" type="s:ST_Xstring" use="required"/>
+    <xsd:attribute name="id" type="xsd:int" use="required"/>
+    <xsd:attribute name="dateTime" type="xsd:dateTime" use="required"/>
+  </xsd:complexType>
+  <xsd:element name="worksheet" type="CT_Worksheet"/>
+  <xsd:element name="chartsheet" type="CT_Chartsheet"/>
+  <xsd:element name="dialogsheet" type="CT_Dialogsheet"/>
+  <xsd:complexType name="CT_Macrosheet">
+    <xsd:sequence>
+      <xsd:element name="sheetPr" type="CT_SheetPr" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="dimension" type="CT_SheetDimension" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="sheetViews" type="CT_SheetViews" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="sheetFormatPr" type="CT_SheetFormatPr" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="cols" type="CT_Cols" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="sheetData" type="CT_SheetData" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="sheetProtection" type="CT_SheetProtection" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="autoFilter" type="CT_AutoFilter" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="sortState" type="CT_SortState" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="dataConsolidate" type="CT_DataConsolidate" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="customSheetViews" type="CT_CustomSheetViews" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="phoneticPr" type="CT_PhoneticPr" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="conditionalFormatting" type="CT_ConditionalFormatting" minOccurs="0"
+        maxOccurs="unbounded"/>
+      <xsd:element name="printOptions" type="CT_PrintOptions" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="pageMargins" type="CT_PageMargins" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="pageSetup" type="CT_PageSetup" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="headerFooter" type="CT_HeaderFooter" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="rowBreaks" type="CT_PageBreak" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="colBreaks" type="CT_PageBreak" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="customProperties" type="CT_CustomProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="drawing" type="CT_Drawing" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="legacyDrawing" type="CT_LegacyDrawing" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="legacyDrawingHF" type="CT_LegacyDrawing" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="drawingHF" type="CT_DrawingHF" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="picture" type="CT_SheetBackgroundPicture" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="oleObjects" type="CT_OleObjects" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" minOccurs="0" type="CT_ExtensionList"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Dialogsheet">
+    <xsd:sequence>
+      <xsd:element name="sheetPr" minOccurs="0" type="CT_SheetPr"/>
+      <xsd:element name="sheetViews" minOccurs="0" type="CT_SheetViews"/>
+      <xsd:element name="sheetFormatPr" minOccurs="0" type="CT_SheetFormatPr"/>
+      <xsd:element name="sheetProtection" type="CT_SheetProtection" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="customSheetViews" minOccurs="0" type="CT_CustomSheetViews"/>
+      <xsd:element name="printOptions" minOccurs="0" type="CT_PrintOptions"/>
+      <xsd:element name="pageMargins" minOccurs="0" type="CT_PageMargins"/>
+      <xsd:element name="pageSetup" minOccurs="0" type="CT_PageSetup"/>
+      <xsd:element name="headerFooter" minOccurs="0" type="CT_HeaderFooter"/>
+      <xsd:element name="drawing" minOccurs="0" type="CT_Drawing"/>
+      <xsd:element name="legacyDrawing" minOccurs="0" type="CT_LegacyDrawing"/>
+      <xsd:element name="legacyDrawingHF" type="CT_LegacyDrawing" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="drawingHF" type="CT_DrawingHF" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="oleObjects" type="CT_OleObjects" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="controls" type="CT_Controls" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" minOccurs="0" type="CT_ExtensionList"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Worksheet">
+    <xsd:sequence>
+      <xsd:element name="sheetPr" type="CT_SheetPr" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="dimension" type="CT_SheetDimension" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="sheetViews" type="CT_SheetViews" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="sheetFormatPr" type="CT_SheetFormatPr" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="cols" type="CT_Cols" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="sheetData" type="CT_SheetData" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="sheetCalcPr" type="CT_SheetCalcPr" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="sheetProtection" type="CT_SheetProtection" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="protectedRanges" type="CT_ProtectedRanges" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="scenarios" type="CT_Scenarios" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="autoFilter" type="CT_AutoFilter" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="sortState" type="CT_SortState" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="dataConsolidate" type="CT_DataConsolidate" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="customSheetViews" type="CT_CustomSheetViews" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="mergeCells" type="CT_MergeCells" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="phoneticPr" type="CT_PhoneticPr" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="conditionalFormatting" type="CT_ConditionalFormatting" minOccurs="0"
+        maxOccurs="unbounded"/>
+      <xsd:element name="dataValidations" type="CT_DataValidations" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="hyperlinks" type="CT_Hyperlinks" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="printOptions" type="CT_PrintOptions" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="pageMargins" type="CT_PageMargins" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="pageSetup" type="CT_PageSetup" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="headerFooter" type="CT_HeaderFooter" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="rowBreaks" type="CT_PageBreak" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="colBreaks" type="CT_PageBreak" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="customProperties" type="CT_CustomProperties" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="cellWatches" type="CT_CellWatches" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="ignoredErrors" type="CT_IgnoredErrors" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="smartTags" type="CT_SmartTags" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="drawing" type="CT_Drawing" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="legacyDrawing" type="CT_LegacyDrawing" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="legacyDrawingHF" type="CT_LegacyDrawing" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="drawingHF" type="CT_DrawingHF" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="picture" type="CT_SheetBackgroundPicture" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="oleObjects" type="CT_OleObjects" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="controls" type="CT_Controls" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="webPublishItems" type="CT_WebPublishItems" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tableParts" type="CT_TableParts" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SheetData">
+    <xsd:sequence>
+      <xsd:element name="row" type="CT_Row" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SheetCalcPr">
+    <xsd:attribute name="fullCalcOnLoad" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SheetFormatPr">
+    <xsd:attribute name="baseColWidth" type="xsd:unsignedInt" use="optional" default="8"/>
+    <xsd:attribute name="defaultColWidth" type="xsd:double" use="optional"/>
+    <xsd:attribute name="defaultRowHeight" type="xsd:double" use="required"/>
+    <xsd:attribute name="customHeight" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="zeroHeight" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="thickTop" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="thickBottom" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="outlineLevelRow" type="xsd:unsignedByte" use="optional" default="0"/>
+    <xsd:attribute name="outlineLevelCol" type="xsd:unsignedByte" use="optional" default="0"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Cols">
+    <xsd:sequence>
+      <xsd:element name="col" type="CT_Col" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Col">
+    <xsd:attribute name="min" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="max" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="width" type="xsd:double" use="optional"/>
+    <xsd:attribute name="style" type="xsd:unsignedInt" use="optional" default="0"/>
+    <xsd:attribute name="hidden" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="bestFit" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="customWidth" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="phonetic" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="outlineLevel" type="xsd:unsignedByte" use="optional" default="0"/>
+    <xsd:attribute name="collapsed" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_CellSpan">
+    <xsd:restriction base="xsd:string"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_CellSpans">
+    <xsd:list itemType="ST_CellSpan"/>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Row">
+    <xsd:sequence>
+      <xsd:element name="c" type="CT_Cell" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="extLst" minOccurs="0" type="CT_ExtensionList"/>
+    </xsd:sequence>
+    <xsd:attribute name="r" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="spans" type="ST_CellSpans" use="optional"/>
+    <xsd:attribute name="s" type="xsd:unsignedInt" use="optional" default="0"/>
+    <xsd:attribute name="customFormat" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="ht" type="xsd:double" use="optional"/>
+    <xsd:attribute name="hidden" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="customHeight" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="outlineLevel" type="xsd:unsignedByte" use="optional" default="0"/>
+    <xsd:attribute name="collapsed" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="thickTop" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="thickBot" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="ph" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Cell">
+    <xsd:sequence>
+      <xsd:element name="f" type="CT_CellFormula" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="v" type="s:ST_Xstring" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="is" type="CT_Rst" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" minOccurs="0" type="CT_ExtensionList"/>
+    </xsd:sequence>
+    <xsd:attribute name="r" type="ST_CellRef" use="optional"/>
+    <xsd:attribute name="s" type="xsd:unsignedInt" use="optional" default="0"/>
+    <xsd:attribute name="t" type="ST_CellType" use="optional" default="n"/>
+    <xsd:attribute name="cm" type="xsd:unsignedInt" use="optional" default="0"/>
+    <xsd:attribute name="vm" type="xsd:unsignedInt" use="optional" default="0"/>
+    <xsd:attribute name="ph" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_CellType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="b"/>
+      <xsd:enumeration value="n"/>
+      <xsd:enumeration value="e"/>
+      <xsd:enumeration value="s"/>
+      <xsd:enumeration value="str"/>
+      <xsd:enumeration value="inlineStr"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_CellFormulaType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="normal"/>
+      <xsd:enumeration value="array"/>
+      <xsd:enumeration value="dataTable"/>
+      <xsd:enumeration value="shared"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_SheetPr">
+    <xsd:sequence>
+      <xsd:element name="tabColor" type="CT_Color" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="outlinePr" type="CT_OutlinePr" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="pageSetUpPr" type="CT_PageSetUpPr" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="syncHorizontal" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="syncVertical" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="syncRef" type="ST_Ref" use="optional"/>
+    <xsd:attribute name="transitionEvaluation" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="transitionEntry" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="published" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="codeName" type="xsd:string" use="optional"/>
+    <xsd:attribute name="filterMode" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="enableFormatConditionsCalculation" type="xsd:boolean" use="optional"
+      default="true"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SheetDimension">
+    <xsd:attribute name="ref" type="ST_Ref" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SheetViews">
+    <xsd:sequence>
+      <xsd:element name="sheetView" type="CT_SheetView" minOccurs="1" maxOccurs="unbounded"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SheetView">
+    <xsd:sequence>
+      <xsd:element name="pane" type="CT_Pane" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="selection" type="CT_Selection" minOccurs="0" maxOccurs="4"/>
+      <xsd:element name="pivotSelection" type="CT_PivotSelection" minOccurs="0" maxOccurs="4"/>
+      <xsd:element name="extLst" minOccurs="0" maxOccurs="1" type="CT_ExtensionList"/>
+    </xsd:sequence>
+    <xsd:attribute name="windowProtection" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="showFormulas" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="showGridLines" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="showRowColHeaders" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="showZeros" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="rightToLeft" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="tabSelected" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="showRuler" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="showOutlineSymbols" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="defaultGridColor" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="showWhiteSpace" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="view" type="ST_SheetViewType" use="optional" default="normal"/>
+    <xsd:attribute name="topLeftCell" type="ST_CellRef" use="optional"/>
+    <xsd:attribute name="colorId" type="xsd:unsignedInt" use="optional" default="64"/>
+    <xsd:attribute name="zoomScale" type="xsd:unsignedInt" use="optional" default="100"/>
+    <xsd:attribute name="zoomScaleNormal" type="xsd:unsignedInt" use="optional" default="0"/>
+    <xsd:attribute name="zoomScaleSheetLayoutView" type="xsd:unsignedInt" use="optional" default="0"/>
+    <xsd:attribute name="zoomScalePageLayoutView" type="xsd:unsignedInt" use="optional" default="0"/>
+    <xsd:attribute name="workbookViewId" type="xsd:unsignedInt" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Pane">
+    <xsd:attribute name="xSplit" type="xsd:double" use="optional" default="0"/>
+    <xsd:attribute name="ySplit" type="xsd:double" use="optional" default="0"/>
+    <xsd:attribute name="topLeftCell" type="ST_CellRef" use="optional"/>
+    <xsd:attribute name="activePane" type="ST_Pane" use="optional" default="topLeft"/>
+    <xsd:attribute name="state" type="ST_PaneState" use="optional" default="split"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PivotSelection">
+    <xsd:sequence>
+      <xsd:element name="pivotArea" type="CT_PivotArea"/>
+    </xsd:sequence>
+    <xsd:attribute name="pane" type="ST_Pane" use="optional" default="topLeft"/>
+    <xsd:attribute name="showHeader" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="label" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="data" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="extendable" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="count" type="xsd:unsignedInt" default="0"/>
+    <xsd:attribute name="axis" type="ST_Axis" use="optional"/>
+    <xsd:attribute name="dimension" type="xsd:unsignedInt" default="0"/>
+    <xsd:attribute name="start" type="xsd:unsignedInt" default="0"/>
+    <xsd:attribute name="min" type="xsd:unsignedInt" default="0"/>
+    <xsd:attribute name="max" type="xsd:unsignedInt" default="0"/>
+    <xsd:attribute name="activeRow" type="xsd:unsignedInt" default="0"/>
+    <xsd:attribute name="activeCol" type="xsd:unsignedInt" default="0"/>
+    <xsd:attribute name="previousRow" type="xsd:unsignedInt" default="0"/>
+    <xsd:attribute name="previousCol" type="xsd:unsignedInt" default="0"/>
+    <xsd:attribute name="click" type="xsd:unsignedInt" default="0"/>
+    <xsd:attribute ref="r:id" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Selection">
+    <xsd:attribute name="pane" type="ST_Pane" use="optional" default="topLeft"/>
+    <xsd:attribute name="activeCell" type="ST_CellRef" use="optional"/>
+    <xsd:attribute name="activeCellId" type="xsd:unsignedInt" use="optional" default="0"/>
+    <xsd:attribute name="sqref" type="ST_Sqref" use="optional" default="A1"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_Pane">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="bottomRight"/>
+      <xsd:enumeration value="topRight"/>
+      <xsd:enumeration value="bottomLeft"/>
+      <xsd:enumeration value="topLeft"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_PageBreak">
+    <xsd:sequence>
+      <xsd:element name="brk" type="CT_Break" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt" use="optional" default="0"/>
+    <xsd:attribute name="manualBreakCount" type="xsd:unsignedInt" use="optional" default="0"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Break">
+    <xsd:attribute name="id" type="xsd:unsignedInt" use="optional" default="0"/>
+    <xsd:attribute name="min" type="xsd:unsignedInt" use="optional" default="0"/>
+    <xsd:attribute name="max" type="xsd:unsignedInt" use="optional" default="0"/>
+    <xsd:attribute name="man" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="pt" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_SheetViewType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="normal"/>
+      <xsd:enumeration value="pageBreakPreview"/>
+      <xsd:enumeration value="pageLayout"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_OutlinePr">
+    <xsd:attribute name="applyStyles" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="summaryBelow" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="summaryRight" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="showOutlineSymbols" type="xsd:boolean" use="optional" default="true"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PageSetUpPr">
+    <xsd:attribute name="autoPageBreaks" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="fitToPage" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DataConsolidate">
+    <xsd:sequence>
+      <xsd:element name="dataRefs" type="CT_DataRefs" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="function" type="ST_DataConsolidateFunction" use="optional" default="sum"/>
+    <xsd:attribute name="startLabels" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="leftLabels" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="topLabels" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="link" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_DataConsolidateFunction">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="average"/>
+      <xsd:enumeration value="count"/>
+      <xsd:enumeration value="countNums"/>
+      <xsd:enumeration value="max"/>
+      <xsd:enumeration value="min"/>
+      <xsd:enumeration value="product"/>
+      <xsd:enumeration value="stdDev"/>
+      <xsd:enumeration value="stdDevp"/>
+      <xsd:enumeration value="sum"/>
+      <xsd:enumeration value="var"/>
+      <xsd:enumeration value="varp"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_DataRefs">
+    <xsd:sequence>
+      <xsd:element name="dataRef" type="CT_DataRef" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DataRef">
+    <xsd:attribute name="ref" type="ST_Ref" use="optional"/>
+    <xsd:attribute name="name" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="sheet" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute ref="r:id" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_MergeCells">
+    <xsd:sequence>
+      <xsd:element name="mergeCell" type="CT_MergeCell" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_MergeCell">
+    <xsd:attribute name="ref" type="ST_Ref" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SmartTags">
+    <xsd:sequence>
+      <xsd:element name="cellSmartTags" type="CT_CellSmartTags" minOccurs="1" maxOccurs="unbounded"
+      />
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CellSmartTags">
+    <xsd:sequence>
+      <xsd:element name="cellSmartTag" type="CT_CellSmartTag" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="r" type="ST_CellRef" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CellSmartTag">
+    <xsd:sequence>
+      <xsd:element name="cellSmartTagPr" minOccurs="0" maxOccurs="unbounded"
+        type="CT_CellSmartTagPr"/>
+    </xsd:sequence>
+    <xsd:attribute name="type" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="deleted" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="xmlBased" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CellSmartTagPr">
+    <xsd:attribute name="key" type="s:ST_Xstring" use="required"/>
+    <xsd:attribute name="val" type="s:ST_Xstring" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Drawing">
+    <xsd:attribute ref="r:id" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_LegacyDrawing">
+    <xsd:attribute ref="r:id" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DrawingHF">
+    <xsd:attribute ref="r:id" use="required"/>
+    <xsd:attribute name="lho" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="lhe" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="lhf" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="cho" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="che" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="chf" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="rho" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="rhe" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="rhf" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="lfo" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="lfe" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="lff" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="cfo" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="cfe" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="cff" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="rfo" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="rfe" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="rff" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CustomSheetViews">
+    <xsd:sequence>
+      <xsd:element name="customSheetView" minOccurs="1" maxOccurs="unbounded"
+        type="CT_CustomSheetView"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CustomSheetView">
+    <xsd:sequence>
+      <xsd:element name="pane" type="CT_Pane" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="selection" type="CT_Selection" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="rowBreaks" type="CT_PageBreak" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="colBreaks" type="CT_PageBreak" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="pageMargins" type="CT_PageMargins" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="printOptions" type="CT_PrintOptions" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="pageSetup" type="CT_PageSetup" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="headerFooter" type="CT_HeaderFooter" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="autoFilter" type="CT_AutoFilter" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" minOccurs="0" type="CT_ExtensionList"/>
+    </xsd:sequence>
+    <xsd:attribute name="guid" type="s:ST_Guid" use="required"/>
+    <xsd:attribute name="scale" type="xsd:unsignedInt" default="100"/>
+    <xsd:attribute name="colorId" type="xsd:unsignedInt" default="64"/>
+    <xsd:attribute name="showPageBreaks" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="showFormulas" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="showGridLines" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="showRowCol" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="outlineSymbols" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="zeroValues" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="fitToPage" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="printArea" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="filter" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="showAutoFilter" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="hiddenRows" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="hiddenColumns" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="state" type="ST_SheetState" default="visible"/>
+    <xsd:attribute name="filterUnique" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="view" type="ST_SheetViewType" default="normal"/>
+    <xsd:attribute name="showRuler" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="topLeftCell" type="ST_CellRef" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DataValidations">
+    <xsd:sequence>
+      <xsd:element name="dataValidation" type="CT_DataValidation" minOccurs="1"
+        maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="disablePrompts" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="xWindow" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="yWindow" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="count" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DataValidation">
+    <xsd:sequence>
+      <xsd:element name="formula1" type="ST_Formula" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="formula2" type="ST_Formula" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="type" type="ST_DataValidationType" use="optional" default="none"/>
+    <xsd:attribute name="errorStyle" type="ST_DataValidationErrorStyle" use="optional"
+      default="stop"/>
+    <xsd:attribute name="imeMode" type="ST_DataValidationImeMode" use="optional" default="noControl"/>
+    <xsd:attribute name="operator" type="ST_DataValidationOperator" use="optional" default="between"/>
+    <xsd:attribute name="allowBlank" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="showDropDown" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="showInputMessage" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="showErrorMessage" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="errorTitle" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="error" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="promptTitle" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="prompt" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="sqref" type="ST_Sqref" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_DataValidationType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="whole"/>
+      <xsd:enumeration value="decimal"/>
+      <xsd:enumeration value="list"/>
+      <xsd:enumeration value="date"/>
+      <xsd:enumeration value="time"/>
+      <xsd:enumeration value="textLength"/>
+      <xsd:enumeration value="custom"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_DataValidationOperator">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="between"/>
+      <xsd:enumeration value="notBetween"/>
+      <xsd:enumeration value="equal"/>
+      <xsd:enumeration value="notEqual"/>
+      <xsd:enumeration value="lessThan"/>
+      <xsd:enumeration value="lessThanOrEqual"/>
+      <xsd:enumeration value="greaterThan"/>
+      <xsd:enumeration value="greaterThanOrEqual"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_DataValidationErrorStyle">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="stop"/>
+      <xsd:enumeration value="warning"/>
+      <xsd:enumeration value="information"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_DataValidationImeMode">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="noControl"/>
+      <xsd:enumeration value="off"/>
+      <xsd:enumeration value="on"/>
+      <xsd:enumeration value="disabled"/>
+      <xsd:enumeration value="hiragana"/>
+      <xsd:enumeration value="fullKatakana"/>
+      <xsd:enumeration value="halfKatakana"/>
+      <xsd:enumeration value="fullAlpha"/>
+      <xsd:enumeration value="halfAlpha"/>
+      <xsd:enumeration value="fullHangul"/>
+      <xsd:enumeration value="halfHangul"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_CfType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="expression"/>
+      <xsd:enumeration value="cellIs"/>
+      <xsd:enumeration value="colorScale"/>
+      <xsd:enumeration value="dataBar"/>
+      <xsd:enumeration value="iconSet"/>
+      <xsd:enumeration value="top10"/>
+      <xsd:enumeration value="uniqueValues"/>
+      <xsd:enumeration value="duplicateValues"/>
+      <xsd:enumeration value="containsText"/>
+      <xsd:enumeration value="notContainsText"/>
+      <xsd:enumeration value="beginsWith"/>
+      <xsd:enumeration value="endsWith"/>
+      <xsd:enumeration value="containsBlanks"/>
+      <xsd:enumeration value="notContainsBlanks"/>
+      <xsd:enumeration value="containsErrors"/>
+      <xsd:enumeration value="notContainsErrors"/>
+      <xsd:enumeration value="timePeriod"/>
+      <xsd:enumeration value="aboveAverage"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TimePeriod">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="today"/>
+      <xsd:enumeration value="yesterday"/>
+      <xsd:enumeration value="tomorrow"/>
+      <xsd:enumeration value="last7Days"/>
+      <xsd:enumeration value="thisMonth"/>
+      <xsd:enumeration value="lastMonth"/>
+      <xsd:enumeration value="nextMonth"/>
+      <xsd:enumeration value="thisWeek"/>
+      <xsd:enumeration value="lastWeek"/>
+      <xsd:enumeration value="nextWeek"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_ConditionalFormattingOperator">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="lessThan"/>
+      <xsd:enumeration value="lessThanOrEqual"/>
+      <xsd:enumeration value="equal"/>
+      <xsd:enumeration value="notEqual"/>
+      <xsd:enumeration value="greaterThanOrEqual"/>
+      <xsd:enumeration value="greaterThan"/>
+      <xsd:enumeration value="between"/>
+      <xsd:enumeration value="notBetween"/>
+      <xsd:enumeration value="containsText"/>
+      <xsd:enumeration value="notContains"/>
+      <xsd:enumeration value="beginsWith"/>
+      <xsd:enumeration value="endsWith"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_CfvoType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="num"/>
+      <xsd:enumeration value="percent"/>
+      <xsd:enumeration value="max"/>
+      <xsd:enumeration value="min"/>
+      <xsd:enumeration value="formula"/>
+      <xsd:enumeration value="percentile"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_ConditionalFormatting">
+    <xsd:sequence>
+      <xsd:element name="cfRule" type="CT_CfRule" minOccurs="1" maxOccurs="unbounded"/>
+      <xsd:element name="extLst" minOccurs="0" type="CT_ExtensionList"/>
+    </xsd:sequence>
+    <xsd:attribute name="pivot" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="sqref" type="ST_Sqref"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CfRule">
+    <xsd:sequence>
+      <xsd:element name="formula" type="ST_Formula" minOccurs="0" maxOccurs="3"/>
+      <xsd:element name="colorScale" type="CT_ColorScale" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="dataBar" type="CT_DataBar" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="iconSet" type="CT_IconSet" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" minOccurs="0" type="CT_ExtensionList"/>
+    </xsd:sequence>
+    <xsd:attribute name="type" type="ST_CfType"/>
+    <xsd:attribute name="dxfId" type="ST_DxfId" use="optional"/>
+    <xsd:attribute name="priority" type="xsd:int" use="required"/>
+    <xsd:attribute name="stopIfTrue" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="aboveAverage" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="percent" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="bottom" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="operator" type="ST_ConditionalFormattingOperator" use="optional"/>
+    <xsd:attribute name="text" type="xsd:string" use="optional"/>
+    <xsd:attribute name="timePeriod" type="ST_TimePeriod" use="optional"/>
+    <xsd:attribute name="rank" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="stdDev" type="xsd:int" use="optional"/>
+    <xsd:attribute name="equalAverage" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Hyperlinks">
+    <xsd:sequence>
+      <xsd:element name="hyperlink" type="CT_Hyperlink" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Hyperlink">
+    <xsd:attribute name="ref" type="ST_Ref" use="required"/>
+    <xsd:attribute ref="r:id" use="optional"/>
+    <xsd:attribute name="location" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="tooltip" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="display" type="s:ST_Xstring" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CellFormula">
+    <xsd:simpleContent>
+      <xsd:extension base="ST_Formula">
+        <xsd:attribute name="t" type="ST_CellFormulaType" use="optional" default="normal"/>
+        <xsd:attribute name="aca" type="xsd:boolean" use="optional" default="false"/>
+        <xsd:attribute name="ref" type="ST_Ref" use="optional"/>
+        <xsd:attribute name="dt2D" type="xsd:boolean" use="optional" default="false"/>
+        <xsd:attribute name="dtr" type="xsd:boolean" use="optional" default="false"/>
+        <xsd:attribute name="del1" type="xsd:boolean" use="optional" default="false"/>
+        <xsd:attribute name="del2" type="xsd:boolean" use="optional" default="false"/>
+        <xsd:attribute name="r1" type="ST_CellRef" use="optional"/>
+        <xsd:attribute name="r2" type="ST_CellRef" use="optional"/>
+        <xsd:attribute name="ca" type="xsd:boolean" use="optional" default="false"/>
+        <xsd:attribute name="si" type="xsd:unsignedInt" use="optional"/>
+        <xsd:attribute name="bx" type="xsd:boolean" use="optional" default="false"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ColorScale">
+    <xsd:sequence>
+      <xsd:element name="cfvo" type="CT_Cfvo" minOccurs="2" maxOccurs="unbounded"/>
+      <xsd:element name="color" type="CT_Color" minOccurs="2" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DataBar">
+    <xsd:sequence>
+      <xsd:element name="cfvo" type="CT_Cfvo" minOccurs="2" maxOccurs="2"/>
+      <xsd:element name="color" type="CT_Color" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="minLength" type="xsd:unsignedInt" use="optional" default="10"/>
+    <xsd:attribute name="maxLength" type="xsd:unsignedInt" use="optional" default="90"/>
+    <xsd:attribute name="showValue" type="xsd:boolean" use="optional" default="true"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_IconSet">
+    <xsd:sequence>
+      <xsd:element name="cfvo" type="CT_Cfvo" minOccurs="2" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="iconSet" type="ST_IconSetType" use="optional" default="3TrafficLights1"/>
+    <xsd:attribute name="showValue" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="percent" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="reverse" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Cfvo">
+    <xsd:sequence>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="type" type="ST_CfvoType" use="required"/>
+    <xsd:attribute name="val" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="gte" type="xsd:boolean" use="optional" default="true"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PageMargins">
+    <xsd:attribute name="left" type="xsd:double" use="required"/>
+    <xsd:attribute name="right" type="xsd:double" use="required"/>
+    <xsd:attribute name="top" type="xsd:double" use="required"/>
+    <xsd:attribute name="bottom" type="xsd:double" use="required"/>
+    <xsd:attribute name="header" type="xsd:double" use="required"/>
+    <xsd:attribute name="footer" type="xsd:double" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PrintOptions">
+    <xsd:attribute name="horizontalCentered" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="verticalCentered" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="headings" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="gridLines" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="gridLinesSet" type="xsd:boolean" use="optional" default="true"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PageSetup">
+    <xsd:attribute name="paperSize" type="xsd:unsignedInt" use="optional" default="1"/>
+    <xsd:attribute name="paperHeight" type="s:ST_PositiveUniversalMeasure" use="optional"/>
+    <xsd:attribute name="paperWidth" type="s:ST_PositiveUniversalMeasure" use="optional"/>
+    <xsd:attribute name="scale" type="xsd:unsignedInt" use="optional" default="100"/>
+    <xsd:attribute name="firstPageNumber" type="xsd:unsignedInt" use="optional" default="1"/>
+    <xsd:attribute name="fitToWidth" type="xsd:unsignedInt" use="optional" default="1"/>
+    <xsd:attribute name="fitToHeight" type="xsd:unsignedInt" use="optional" default="1"/>
+    <xsd:attribute name="pageOrder" type="ST_PageOrder" use="optional" default="downThenOver"/>
+    <xsd:attribute name="orientation" type="ST_Orientation" use="optional" default="default"/>
+    <xsd:attribute name="usePrinterDefaults" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="blackAndWhite" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="draft" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="cellComments" type="ST_CellComments" use="optional" default="none"/>
+    <xsd:attribute name="useFirstPageNumber" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="errors" type="ST_PrintError" use="optional" default="displayed"/>
+    <xsd:attribute name="horizontalDpi" type="xsd:unsignedInt" use="optional" default="600"/>
+    <xsd:attribute name="verticalDpi" type="xsd:unsignedInt" use="optional" default="600"/>
+    <xsd:attribute name="copies" type="xsd:unsignedInt" use="optional" default="1"/>
+    <xsd:attribute ref="r:id" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_PageOrder">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="downThenOver"/>
+      <xsd:enumeration value="overThenDown"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_Orientation">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="default"/>
+      <xsd:enumeration value="portrait"/>
+      <xsd:enumeration value="landscape"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_CellComments">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="asDisplayed"/>
+      <xsd:enumeration value="atEnd"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_HeaderFooter">
+    <xsd:sequence>
+      <xsd:element name="oddHeader" type="s:ST_Xstring" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="oddFooter" type="s:ST_Xstring" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="evenHeader" type="s:ST_Xstring" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="evenFooter" type="s:ST_Xstring" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="firstHeader" type="s:ST_Xstring" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="firstFooter" type="s:ST_Xstring" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="differentOddEven" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="differentFirst" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="scaleWithDoc" type="xsd:boolean" default="true"/>
+    <xsd:attribute name="alignWithMargins" type="xsd:boolean" default="true"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_PrintError">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="displayed"/>
+      <xsd:enumeration value="blank"/>
+      <xsd:enumeration value="dash"/>
+      <xsd:enumeration value="NA"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Scenarios">
+    <xsd:sequence>
+      <xsd:element name="scenario" type="CT_Scenario" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="current" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="show" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="sqref" type="ST_Sqref" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SheetProtection">
+    <xsd:attribute name="password" type="ST_UnsignedShortHex" use="optional"/>
+    <xsd:attribute name="algorithmName" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="hashValue" type="xsd:base64Binary" use="optional"/>
+    <xsd:attribute name="saltValue" type="xsd:base64Binary" use="optional"/>
+    <xsd:attribute name="spinCount" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="sheet" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="objects" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="scenarios" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="formatCells" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="formatColumns" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="formatRows" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="insertColumns" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="insertRows" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="insertHyperlinks" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="deleteColumns" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="deleteRows" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="selectLockedCells" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="sort" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="autoFilter" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="pivotTables" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="selectUnlockedCells" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ProtectedRanges">
+    <xsd:sequence>
+      <xsd:element name="protectedRange" type="CT_ProtectedRange" minOccurs="1"
+        maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ProtectedRange">
+    <xsd:sequence>
+      <xsd:element name="securityDescriptor" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="password" type="ST_UnsignedShortHex" use="optional"/>
+    <xsd:attribute name="sqref" type="ST_Sqref" use="required"/>
+    <xsd:attribute name="name" type="s:ST_Xstring" use="required"/>
+    <xsd:attribute name="securityDescriptor" type="xsd:string" use="optional"/>
+    <xsd:attribute name="algorithmName" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="hashValue" type="xsd:base64Binary" use="optional"/>
+    <xsd:attribute name="saltValue" type="xsd:base64Binary" use="optional"/>
+    <xsd:attribute name="spinCount" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Scenario">
+    <xsd:sequence>
+      <xsd:element name="inputCells" type="CT_InputCells" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="s:ST_Xstring" use="required"/>
+    <xsd:attribute name="locked" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="hidden" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="count" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="user" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="comment" type="s:ST_Xstring" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_InputCells">
+    <xsd:attribute name="r" type="ST_CellRef" use="required"/>
+    <xsd:attribute name="deleted" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="undone" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="val" type="s:ST_Xstring" use="required"/>
+    <xsd:attribute name="numFmtId" type="ST_NumFmtId" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CellWatches">
+    <xsd:sequence>
+      <xsd:element name="cellWatch" type="CT_CellWatch" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CellWatch">
+    <xsd:attribute name="r" type="ST_CellRef" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Chartsheet">
+    <xsd:sequence>
+      <xsd:element name="sheetPr" type="CT_ChartsheetPr" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="sheetViews" type="CT_ChartsheetViews" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="sheetProtection" type="CT_ChartsheetProtection" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="customSheetViews" type="CT_CustomChartsheetViews" minOccurs="0"
+        maxOccurs="1"/>
+      <xsd:element name="pageMargins" minOccurs="0" type="CT_PageMargins"/>
+      <xsd:element name="pageSetup" type="CT_CsPageSetup" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="headerFooter" minOccurs="0" type="CT_HeaderFooter"/>
+      <xsd:element name="drawing" type="CT_Drawing" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="legacyDrawing" type="CT_LegacyDrawing" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="legacyDrawingHF" type="CT_LegacyDrawing" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="drawingHF" type="CT_DrawingHF" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="picture" type="CT_SheetBackgroundPicture" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="webPublishItems" type="CT_WebPublishItems" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ChartsheetPr">
+    <xsd:sequence>
+      <xsd:element name="tabColor" type="CT_Color" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="published" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="codeName" type="xsd:string" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ChartsheetViews">
+    <xsd:sequence>
+      <xsd:element name="sheetView" type="CT_ChartsheetView" minOccurs="1" maxOccurs="unbounded"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ChartsheetView">
+    <xsd:sequence>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="tabSelected" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="zoomScale" type="xsd:unsignedInt" default="100" use="optional"/>
+    <xsd:attribute name="workbookViewId" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="zoomToFit" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ChartsheetProtection">
+    <xsd:attribute name="password" type="ST_UnsignedShortHex" use="optional"/>
+    <xsd:attribute name="algorithmName" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="hashValue" type="xsd:base64Binary" use="optional"/>
+    <xsd:attribute name="saltValue" type="xsd:base64Binary" use="optional"/>
+    <xsd:attribute name="spinCount" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="content" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="objects" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CsPageSetup">
+    <xsd:attribute name="paperSize" type="xsd:unsignedInt" use="optional" default="1"/>
+    <xsd:attribute name="paperHeight" type="s:ST_PositiveUniversalMeasure" use="optional"/>
+    <xsd:attribute name="paperWidth" type="s:ST_PositiveUniversalMeasure" use="optional"/>
+    <xsd:attribute name="firstPageNumber" type="xsd:unsignedInt" use="optional" default="1"/>
+    <xsd:attribute name="orientation" type="ST_Orientation" use="optional" default="default"/>
+    <xsd:attribute name="usePrinterDefaults" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="blackAndWhite" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="draft" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="useFirstPageNumber" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="horizontalDpi" type="xsd:unsignedInt" use="optional" default="600"/>
+    <xsd:attribute name="verticalDpi" type="xsd:unsignedInt" use="optional" default="600"/>
+    <xsd:attribute name="copies" type="xsd:unsignedInt" use="optional" default="1"/>
+    <xsd:attribute ref="r:id" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CustomChartsheetViews">
+    <xsd:sequence>
+      <xsd:element name="customSheetView" minOccurs="0" maxOccurs="unbounded"
+        type="CT_CustomChartsheetView"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CustomChartsheetView">
+    <xsd:sequence>
+      <xsd:element name="pageMargins" type="CT_PageMargins" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="pageSetup" type="CT_CsPageSetup" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="headerFooter" type="CT_HeaderFooter" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="guid" type="s:ST_Guid" use="required"/>
+    <xsd:attribute name="scale" type="xsd:unsignedInt" default="100"/>
+    <xsd:attribute name="state" type="ST_SheetState" default="visible"/>
+    <xsd:attribute name="zoomToFit" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CustomProperties">
+    <xsd:sequence>
+      <xsd:element name="customPr" type="CT_CustomProperty" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CustomProperty">
+    <xsd:attribute name="name" type="s:ST_Xstring" use="required"/>
+    <xsd:attribute ref="r:id" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_OleObjects">
+    <xsd:sequence>
+      <xsd:element name="oleObject" type="CT_OleObject" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_OleObject">
+    <xsd:sequence>
+      <xsd:element name="objectPr" type="CT_ObjectPr" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="progId" type="xsd:string" use="optional"/>
+    <xsd:attribute name="dvAspect" type="ST_DvAspect" use="optional" default="DVASPECT_CONTENT"/>
+    <xsd:attribute name="link" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="oleUpdate" type="ST_OleUpdate" use="optional"/>
+    <xsd:attribute name="autoLoad" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="shapeId" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute ref="r:id" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ObjectPr">
+    <xsd:sequence>
+      <xsd:element name="anchor" type="CT_ObjectAnchor" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="locked" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="defaultSize" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="print" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="disabled" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="uiObject" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="autoFill" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="autoLine" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="autoPict" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="macro" type="ST_Formula" use="optional"/>
+    <xsd:attribute name="altText" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="dde" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute ref="r:id" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_DvAspect">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="DVASPECT_CONTENT"/>
+      <xsd:enumeration value="DVASPECT_ICON"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_OleUpdate">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="OLEUPDATE_ALWAYS"/>
+      <xsd:enumeration value="OLEUPDATE_ONCALL"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_WebPublishItems">
+    <xsd:sequence>
+      <xsd:element name="webPublishItem" type="CT_WebPublishItem" minOccurs="1"
+        maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_WebPublishItem">
+    <xsd:attribute name="id" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="divId" type="s:ST_Xstring" use="required"/>
+    <xsd:attribute name="sourceType" type="ST_WebSourceType" use="required"/>
+    <xsd:attribute name="sourceRef" type="ST_Ref" use="optional"/>
+    <xsd:attribute name="sourceObject" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="destinationFile" type="s:ST_Xstring" use="required"/>
+    <xsd:attribute name="title" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="autoRepublish" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Controls">
+    <xsd:sequence>
+      <xsd:element name="control" type="CT_Control" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Control">
+    <xsd:sequence>
+      <xsd:element name="controlPr" type="CT_ControlPr" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="shapeId" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute ref="r:id" use="required"/>
+    <xsd:attribute name="name" type="xsd:string" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ControlPr">
+    <xsd:sequence>
+      <xsd:element name="anchor" type="CT_ObjectAnchor" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="locked" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="defaultSize" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="print" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="disabled" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="recalcAlways" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="uiObject" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="autoFill" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="autoLine" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="autoPict" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="macro" type="ST_Formula" use="optional"/>
+    <xsd:attribute name="altText" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="linkedCell" type="ST_Formula" use="optional"/>
+    <xsd:attribute name="listFillRange" type="ST_Formula" use="optional"/>
+    <xsd:attribute name="cf" type="s:ST_Xstring" use="optional" default="pict"/>
+    <xsd:attribute ref="r:id" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_WebSourceType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="sheet"/>
+      <xsd:enumeration value="printArea"/>
+      <xsd:enumeration value="autoFilter"/>
+      <xsd:enumeration value="range"/>
+      <xsd:enumeration value="chart"/>
+      <xsd:enumeration value="pivotTable"/>
+      <xsd:enumeration value="query"/>
+      <xsd:enumeration value="label"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_IgnoredErrors">
+    <xsd:sequence>
+      <xsd:element name="ignoredError" type="CT_IgnoredError" minOccurs="1" maxOccurs="unbounded"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_IgnoredError">
+    <xsd:attribute name="sqref" type="ST_Sqref" use="required"/>
+    <xsd:attribute name="evalError" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="twoDigitTextYear" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="numberStoredAsText" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="formula" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="formulaRange" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="unlockedFormula" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="emptyCellReference" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="listDataValidation" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="calculatedColumn" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_PaneState">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="split"/>
+      <xsd:enumeration value="frozen"/>
+      <xsd:enumeration value="frozenSplit"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TableParts">
+    <xsd:sequence>
+      <xsd:element name="tablePart" type="CT_TablePart" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TablePart">
+    <xsd:attribute ref="r:id" use="required"/>
+  </xsd:complexType>
+  <xsd:element name="metadata" type="CT_Metadata"/>
+  <xsd:complexType name="CT_Metadata">
+    <xsd:sequence>
+      <xsd:element name="metadataTypes" type="CT_MetadataTypes" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="metadataStrings" type="CT_MetadataStrings" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="mdxMetadata" type="CT_MdxMetadata" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="futureMetadata" type="CT_FutureMetadata" minOccurs="0"
+        maxOccurs="unbounded"/>
+      <xsd:element name="cellMetadata" type="CT_MetadataBlocks" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="valueMetadata" type="CT_MetadataBlocks" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" minOccurs="0" maxOccurs="1" type="CT_ExtensionList"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_MetadataTypes">
+    <xsd:sequence>
+      <xsd:element name="metadataType" type="CT_MetadataType" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt" use="optional" default="0"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_MetadataType">
+    <xsd:attribute name="name" type="s:ST_Xstring" use="required"/>
+    <xsd:attribute name="minSupportedVersion" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="ghostRow" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="ghostCol" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="edit" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="delete" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="copy" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="pasteAll" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="pasteFormulas" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="pasteValues" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="pasteFormats" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="pasteComments" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="pasteDataValidation" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="pasteBorders" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="pasteColWidths" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="pasteNumberFormats" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="merge" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="splitFirst" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="splitAll" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="rowColShift" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="clearAll" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="clearFormats" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="clearContents" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="clearComments" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="assign" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="coerce" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="adjust" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="cellMeta" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_MetadataBlocks">
+    <xsd:sequence>
+      <xsd:element name="bk" type="CT_MetadataBlock" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt" use="optional" default="0"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_MetadataBlock">
+    <xsd:sequence>
+      <xsd:element name="rc" type="CT_MetadataRecord" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_MetadataRecord">
+    <xsd:attribute name="t" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="v" type="xsd:unsignedInt" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_FutureMetadata">
+    <xsd:sequence>
+      <xsd:element name="bk" type="CT_FutureMetadataBlock" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="extLst" minOccurs="0" maxOccurs="1" type="CT_ExtensionList"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="s:ST_Xstring" use="required"/>
+    <xsd:attribute name="count" type="xsd:unsignedInt" use="optional" default="0"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_FutureMetadataBlock">
+    <xsd:sequence>
+      <xsd:element name="extLst" minOccurs="0" maxOccurs="1" type="CT_ExtensionList"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_MdxMetadata">
+    <xsd:sequence>
+      <xsd:element name="mdx" type="CT_Mdx" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt" use="optional" default="0"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Mdx">
+    <xsd:choice minOccurs="1" maxOccurs="1">
+      <xsd:element name="t" type="CT_MdxTuple"/>
+      <xsd:element name="ms" type="CT_MdxSet"/>
+      <xsd:element name="p" type="CT_MdxMemeberProp"/>
+      <xsd:element name="k" type="CT_MdxKPI"/>
+    </xsd:choice>
+    <xsd:attribute name="n" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="f" type="ST_MdxFunctionType" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_MdxFunctionType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="m"/>
+      <xsd:enumeration value="v"/>
+      <xsd:enumeration value="s"/>
+      <xsd:enumeration value="c"/>
+      <xsd:enumeration value="r"/>
+      <xsd:enumeration value="p"/>
+      <xsd:enumeration value="k"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_MdxTuple">
+    <xsd:sequence>
+      <xsd:element name="n" type="CT_MetadataStringIndex" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="c" type="xsd:unsignedInt" use="optional" default="0"/>
+    <xsd:attribute name="ct" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="si" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="fi" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="bc" type="ST_UnsignedIntHex" use="optional"/>
+    <xsd:attribute name="fc" type="ST_UnsignedIntHex" use="optional"/>
+    <xsd:attribute name="i" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="u" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="st" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="b" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_MdxSet">
+    <xsd:sequence>
+      <xsd:element name="n" type="CT_MetadataStringIndex" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="ns" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="c" type="xsd:unsignedInt" use="optional" default="0"/>
+    <xsd:attribute name="o" type="ST_MdxSetOrder" use="optional" default="u"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_MdxSetOrder">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="u"/>
+      <xsd:enumeration value="a"/>
+      <xsd:enumeration value="d"/>
+      <xsd:enumeration value="aa"/>
+      <xsd:enumeration value="ad"/>
+      <xsd:enumeration value="na"/>
+      <xsd:enumeration value="nd"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_MdxMemeberProp">
+    <xsd:attribute name="n" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="np" type="xsd:unsignedInt" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_MdxKPI">
+    <xsd:attribute name="n" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="np" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="p" type="ST_MdxKPIProperty" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_MdxKPIProperty">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="v"/>
+      <xsd:enumeration value="g"/>
+      <xsd:enumeration value="s"/>
+      <xsd:enumeration value="t"/>
+      <xsd:enumeration value="w"/>
+      <xsd:enumeration value="m"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_MetadataStringIndex">
+    <xsd:attribute name="x" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="s" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_MetadataStrings">
+    <xsd:sequence>
+      <xsd:element name="s" type="CT_XStringElement" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt" use="optional" default="0"/>
+  </xsd:complexType>
+  <xsd:element name="singleXmlCells" type="CT_SingleXmlCells"/>
+  <xsd:complexType name="CT_SingleXmlCells">
+    <xsd:sequence>
+      <xsd:element name="singleXmlCell" type="CT_SingleXmlCell" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SingleXmlCell">
+    <xsd:sequence>
+      <xsd:element name="xmlCellPr" type="CT_XmlCellPr" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="r" type="ST_CellRef" use="required"/>
+    <xsd:attribute name="connectionId" type="xsd:unsignedInt" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_XmlCellPr">
+    <xsd:sequence>
+      <xsd:element name="xmlPr" type="CT_XmlPr" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="uniqueName" type="s:ST_Xstring" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_XmlPr">
+    <xsd:sequence>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="mapId" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="xpath" type="s:ST_Xstring" use="required"/>
+    <xsd:attribute name="xmlDataType" type="ST_XmlDataType" use="required"/>
+  </xsd:complexType>
+  <xsd:element name="styleSheet" type="CT_Stylesheet"/>
+  <xsd:complexType name="CT_Stylesheet">
+    <xsd:sequence>
+      <xsd:element name="numFmts" type="CT_NumFmts" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="fonts" type="CT_Fonts" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="fills" type="CT_Fills" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="borders" type="CT_Borders" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="cellStyleXfs" type="CT_CellStyleXfs" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="cellXfs" type="CT_CellXfs" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="cellStyles" type="CT_CellStyles" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="dxfs" type="CT_Dxfs" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tableStyles" type="CT_TableStyles" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="colors" type="CT_Colors" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CellAlignment">
+    <xsd:attribute name="horizontal" type="ST_HorizontalAlignment" use="optional"/>
+    <xsd:attribute name="vertical" type="ST_VerticalAlignment" default="bottom" use="optional"/>
+    <xsd:attribute name="textRotation" type="ST_TextRotation" use="optional"/>
+    <xsd:attribute name="wrapText" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="indent" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="relativeIndent" type="xsd:int" use="optional"/>
+    <xsd:attribute name="justifyLastLine" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="shrinkToFit" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="readingOrder" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TextRotation">
+    <xsd:union>
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:nonNegativeInteger">
+          <xsd:maxInclusive value="180"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:nonNegativeInteger">
+          <xsd:enumeration value="255"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_BorderStyle">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="thin"/>
+      <xsd:enumeration value="medium"/>
+      <xsd:enumeration value="dashed"/>
+      <xsd:enumeration value="dotted"/>
+      <xsd:enumeration value="thick"/>
+      <xsd:enumeration value="double"/>
+      <xsd:enumeration value="hair"/>
+      <xsd:enumeration value="mediumDashed"/>
+      <xsd:enumeration value="dashDot"/>
+      <xsd:enumeration value="mediumDashDot"/>
+      <xsd:enumeration value="dashDotDot"/>
+      <xsd:enumeration value="mediumDashDotDot"/>
+      <xsd:enumeration value="slantDashDot"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Borders">
+    <xsd:sequence>
+      <xsd:element name="border" type="CT_Border" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Border">
+    <xsd:sequence>
+      <xsd:element name="start" type="CT_BorderPr" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="end" type="CT_BorderPr" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="left" type="CT_BorderPr" minOccurs="0"/>
+      <xsd:element name="right" type="CT_BorderPr" minOccurs="0"/>
+      <xsd:element name="top" type="CT_BorderPr" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="bottom" type="CT_BorderPr" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="diagonal" type="CT_BorderPr" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="vertical" type="CT_BorderPr" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="horizontal" type="CT_BorderPr" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="diagonalUp" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="diagonalDown" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="outline" type="xsd:boolean" use="optional" default="true"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_BorderPr">
+    <xsd:sequence>
+      <xsd:element name="color" type="CT_Color" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="style" type="ST_BorderStyle" use="optional" default="none"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CellProtection">
+    <xsd:attribute name="locked" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="hidden" type="xsd:boolean" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Fonts">
+    <xsd:sequence>
+      <xsd:element name="font" type="CT_Font" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Fills">
+    <xsd:sequence>
+      <xsd:element name="fill" type="CT_Fill" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Fill">
+    <xsd:choice minOccurs="1" maxOccurs="1">
+      <xsd:element name="patternFill" type="CT_PatternFill" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="gradientFill" type="CT_GradientFill" minOccurs="0" maxOccurs="1"/>
+    </xsd:choice>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PatternFill">
+    <xsd:sequence>
+      <xsd:element name="fgColor" type="CT_Color" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="bgColor" type="CT_Color" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="patternType" type="ST_PatternType" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Color">
+    <xsd:attribute name="auto" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="indexed" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="rgb" type="ST_UnsignedIntHex" use="optional"/>
+    <xsd:attribute name="theme" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="tint" type="xsd:double" use="optional" default="0.0"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_PatternType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="solid"/>
+      <xsd:enumeration value="mediumGray"/>
+      <xsd:enumeration value="darkGray"/>
+      <xsd:enumeration value="lightGray"/>
+      <xsd:enumeration value="darkHorizontal"/>
+      <xsd:enumeration value="darkVertical"/>
+      <xsd:enumeration value="darkDown"/>
+      <xsd:enumeration value="darkUp"/>
+      <xsd:enumeration value="darkGrid"/>
+      <xsd:enumeration value="darkTrellis"/>
+      <xsd:enumeration value="lightHorizontal"/>
+      <xsd:enumeration value="lightVertical"/>
+      <xsd:enumeration value="lightDown"/>
+      <xsd:enumeration value="lightUp"/>
+      <xsd:enumeration value="lightGrid"/>
+      <xsd:enumeration value="lightTrellis"/>
+      <xsd:enumeration value="gray125"/>
+      <xsd:enumeration value="gray0625"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_GradientFill">
+    <xsd:sequence>
+      <xsd:element name="stop" type="CT_GradientStop" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="type" type="ST_GradientType" use="optional" default="linear"/>
+    <xsd:attribute name="degree" type="xsd:double" use="optional" default="0"/>
+    <xsd:attribute name="left" type="xsd:double" use="optional" default="0"/>
+    <xsd:attribute name="right" type="xsd:double" use="optional" default="0"/>
+    <xsd:attribute name="top" type="xsd:double" use="optional" default="0"/>
+    <xsd:attribute name="bottom" type="xsd:double" use="optional" default="0"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GradientStop">
+    <xsd:sequence>
+      <xsd:element name="color" type="CT_Color" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="position" type="xsd:double" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_GradientType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="linear"/>
+      <xsd:enumeration value="path"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_HorizontalAlignment">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="general"/>
+      <xsd:enumeration value="left"/>
+      <xsd:enumeration value="center"/>
+      <xsd:enumeration value="right"/>
+      <xsd:enumeration value="fill"/>
+      <xsd:enumeration value="justify"/>
+      <xsd:enumeration value="centerContinuous"/>
+      <xsd:enumeration value="distributed"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_VerticalAlignment">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="top"/>
+      <xsd:enumeration value="center"/>
+      <xsd:enumeration value="bottom"/>
+      <xsd:enumeration value="justify"/>
+      <xsd:enumeration value="distributed"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_NumFmts">
+    <xsd:sequence>
+      <xsd:element name="numFmt" type="CT_NumFmt" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_NumFmt">
+    <xsd:attribute name="numFmtId" type="ST_NumFmtId" use="required"/>
+    <xsd:attribute name="formatCode" type="s:ST_Xstring" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CellStyleXfs">
+    <xsd:sequence>
+      <xsd:element name="xf" type="CT_Xf" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CellXfs">
+    <xsd:sequence>
+      <xsd:element name="xf" type="CT_Xf" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Xf">
+    <xsd:sequence>
+      <xsd:element name="alignment" type="CT_CellAlignment" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="protection" type="CT_CellProtection" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="numFmtId" type="ST_NumFmtId" use="optional"/>
+    <xsd:attribute name="fontId" type="ST_FontId" use="optional"/>
+    <xsd:attribute name="fillId" type="ST_FillId" use="optional"/>
+    <xsd:attribute name="borderId" type="ST_BorderId" use="optional"/>
+    <xsd:attribute name="xfId" type="ST_CellStyleXfId" use="optional"/>
+    <xsd:attribute name="quotePrefix" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="pivotButton" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="applyNumberFormat" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="applyFont" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="applyFill" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="applyBorder" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="applyAlignment" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="applyProtection" type="xsd:boolean" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CellStyles">
+    <xsd:sequence>
+      <xsd:element name="cellStyle" type="CT_CellStyle" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CellStyle">
+    <xsd:sequence>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="xfId" type="ST_CellStyleXfId" use="required"/>
+    <xsd:attribute name="builtinId" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="iLevel" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="hidden" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="customBuiltin" type="xsd:boolean" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Dxfs">
+    <xsd:sequence>
+      <xsd:element name="dxf" type="CT_Dxf" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Dxf">
+    <xsd:sequence>
+      <xsd:element name="font" type="CT_Font" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="numFmt" type="CT_NumFmt" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="fill" type="CT_Fill" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="alignment" type="CT_CellAlignment" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="border" type="CT_Border" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="protection" type="CT_CellProtection" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_NumFmtId">
+    <xsd:restriction base="xsd:unsignedInt"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_FontId">
+    <xsd:restriction base="xsd:unsignedInt"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_FillId">
+    <xsd:restriction base="xsd:unsignedInt"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_BorderId">
+    <xsd:restriction base="xsd:unsignedInt"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_CellStyleXfId">
+    <xsd:restriction base="xsd:unsignedInt"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_DxfId">
+    <xsd:restriction base="xsd:unsignedInt"/>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Colors">
+    <xsd:sequence>
+      <xsd:element name="indexedColors" type="CT_IndexedColors" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="mruColors" type="CT_MRUColors" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_IndexedColors">
+    <xsd:sequence>
+      <xsd:element name="rgbColor" type="CT_RgbColor" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_MRUColors">
+    <xsd:sequence>
+      <xsd:element name="color" type="CT_Color" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_RgbColor">
+    <xsd:attribute name="rgb" type="ST_UnsignedIntHex" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TableStyles">
+    <xsd:sequence>
+      <xsd:element name="tableStyle" type="CT_TableStyle" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="defaultTableStyle" type="xsd:string" use="optional"/>
+    <xsd:attribute name="defaultPivotStyle" type="xsd:string" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TableStyle">
+    <xsd:sequence>
+      <xsd:element name="tableStyleElement" type="CT_TableStyleElement" minOccurs="0"
+        maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="pivot" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="table" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="count" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TableStyleElement">
+    <xsd:attribute name="type" type="ST_TableStyleType" use="required"/>
+    <xsd:attribute name="size" type="xsd:unsignedInt" use="optional" default="1"/>
+    <xsd:attribute name="dxfId" type="ST_DxfId" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TableStyleType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="wholeTable"/>
+      <xsd:enumeration value="headerRow"/>
+      <xsd:enumeration value="totalRow"/>
+      <xsd:enumeration value="firstColumn"/>
+      <xsd:enumeration value="lastColumn"/>
+      <xsd:enumeration value="firstRowStripe"/>
+      <xsd:enumeration value="secondRowStripe"/>
+      <xsd:enumeration value="firstColumnStripe"/>
+      <xsd:enumeration value="secondColumnStripe"/>
+      <xsd:enumeration value="firstHeaderCell"/>
+      <xsd:enumeration value="lastHeaderCell"/>
+      <xsd:enumeration value="firstTotalCell"/>
+      <xsd:enumeration value="lastTotalCell"/>
+      <xsd:enumeration value="firstSubtotalColumn"/>
+      <xsd:enumeration value="secondSubtotalColumn"/>
+      <xsd:enumeration value="thirdSubtotalColumn"/>
+      <xsd:enumeration value="firstSubtotalRow"/>
+      <xsd:enumeration value="secondSubtotalRow"/>
+      <xsd:enumeration value="thirdSubtotalRow"/>
+      <xsd:enumeration value="blankRow"/>
+      <xsd:enumeration value="firstColumnSubheading"/>
+      <xsd:enumeration value="secondColumnSubheading"/>
+      <xsd:enumeration value="thirdColumnSubheading"/>
+      <xsd:enumeration value="firstRowSubheading"/>
+      <xsd:enumeration value="secondRowSubheading"/>
+      <xsd:enumeration value="thirdRowSubheading"/>
+      <xsd:enumeration value="pageFieldLabels"/>
+      <xsd:enumeration value="pageFieldValues"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_BooleanProperty">
+    <xsd:attribute name="val" type="xsd:boolean" use="optional" default="true"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_FontSize">
+    <xsd:attribute name="val" type="xsd:double" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_IntProperty">
+    <xsd:attribute name="val" type="xsd:int" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_FontName">
+    <xsd:attribute name="val" type="s:ST_Xstring" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_VerticalAlignFontProperty">
+    <xsd:attribute name="val" type="s:ST_VerticalAlignRun" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_FontScheme">
+    <xsd:attribute name="val" type="ST_FontScheme" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_FontScheme">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="major"/>
+      <xsd:enumeration value="minor"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_UnderlineProperty">
+    <xsd:attribute name="val" type="ST_UnderlineValues" use="optional" default="single"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_UnderlineValues">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="single"/>
+      <xsd:enumeration value="double"/>
+      <xsd:enumeration value="singleAccounting"/>
+      <xsd:enumeration value="doubleAccounting"/>
+      <xsd:enumeration value="none"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Font">
+    <xsd:choice maxOccurs="unbounded">
+      <xsd:element name="name" type="CT_FontName" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="charset" type="CT_IntProperty" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="family" type="CT_FontFamily" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="b" type="CT_BooleanProperty" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="i" type="CT_BooleanProperty" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="strike" type="CT_BooleanProperty" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="outline" type="CT_BooleanProperty" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="shadow" type="CT_BooleanProperty" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="condense" type="CT_BooleanProperty" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extend" type="CT_BooleanProperty" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="color" type="CT_Color" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="sz" type="CT_FontSize" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="u" type="CT_UnderlineProperty" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="vertAlign" type="CT_VerticalAlignFontProperty" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="scheme" type="CT_FontScheme" minOccurs="0" maxOccurs="1"/>
+    </xsd:choice>
+  </xsd:complexType>
+  <xsd:complexType name="CT_FontFamily">
+    <xsd:attribute name="val" type="ST_FontFamily" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_FontFamily">
+    <xsd:restriction base="xsd:integer">
+      <xsd:minInclusive value="0"/>
+      <xsd:maxInclusive value="14"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:attributeGroup name="AG_AutoFormat">
+    <xsd:attribute name="autoFormatId" type="xsd:unsignedInt"/>
+    <xsd:attribute name="applyNumberFormats" type="xsd:boolean"/>
+    <xsd:attribute name="applyBorderFormats" type="xsd:boolean"/>
+    <xsd:attribute name="applyFontFormats" type="xsd:boolean"/>
+    <xsd:attribute name="applyPatternFormats" type="xsd:boolean"/>
+    <xsd:attribute name="applyAlignmentFormats" type="xsd:boolean"/>
+    <xsd:attribute name="applyWidthHeightFormats" type="xsd:boolean"/>
+  </xsd:attributeGroup>
+  <xsd:element name="externalLink" type="CT_ExternalLink"/>
+  <xsd:complexType name="CT_ExternalLink">
+    <xsd:sequence>
+      <xsd:choice>
+        <xsd:element name="externalBook" type="CT_ExternalBook" minOccurs="0" maxOccurs="1"/>
+        <xsd:element name="ddeLink" type="CT_DdeLink" minOccurs="0" maxOccurs="1"/>
+        <xsd:element name="oleLink" type="CT_OleLink" minOccurs="0" maxOccurs="1"/>
+      </xsd:choice>
+      <xsd:element name="extLst" minOccurs="0" type="CT_ExtensionList"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ExternalBook">
+    <xsd:sequence>
+      <xsd:element name="sheetNames" type="CT_ExternalSheetNames" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="definedNames" type="CT_ExternalDefinedNames" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="sheetDataSet" type="CT_ExternalSheetDataSet" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute ref="r:id" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ExternalSheetNames">
+    <xsd:sequence>
+      <xsd:element name="sheetName" minOccurs="1" maxOccurs="unbounded" type="CT_ExternalSheetName"
+      />
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ExternalSheetName">
+    <xsd:attribute name="val" type="s:ST_Xstring"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ExternalDefinedNames">
+    <xsd:sequence>
+      <xsd:element name="definedName" type="CT_ExternalDefinedName" minOccurs="0"
+        maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ExternalDefinedName">
+    <xsd:attribute name="name" type="s:ST_Xstring" use="required"/>
+    <xsd:attribute name="refersTo" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="sheetId" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ExternalSheetDataSet">
+    <xsd:sequence>
+      <xsd:element name="sheetData" type="CT_ExternalSheetData" minOccurs="1" maxOccurs="unbounded"
+      />
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ExternalSheetData">
+    <xsd:sequence>
+      <xsd:element name="row" type="CT_ExternalRow" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="sheetId" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="refreshError" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ExternalRow">
+    <xsd:sequence>
+      <xsd:element name="cell" type="CT_ExternalCell" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="r" type="xsd:unsignedInt" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ExternalCell">
+    <xsd:sequence>
+      <xsd:element name="v" type="s:ST_Xstring" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="r" type="ST_CellRef" use="optional"/>
+    <xsd:attribute name="t" type="ST_CellType" use="optional" default="n"/>
+    <xsd:attribute name="vm" type="xsd:unsignedInt" use="optional" default="0"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DdeLink">
+    <xsd:sequence>
+      <xsd:element name="ddeItems" type="CT_DdeItems" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="ddeService" type="s:ST_Xstring" use="required"/>
+    <xsd:attribute name="ddeTopic" type="s:ST_Xstring" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DdeItems">
+    <xsd:sequence>
+      <xsd:element name="ddeItem" type="CT_DdeItem" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DdeItem">
+    <xsd:sequence>
+      <xsd:element name="values" type="CT_DdeValues" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="s:ST_Xstring" default="0"/>
+    <xsd:attribute name="ole" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="advise" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="preferPic" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DdeValues">
+    <xsd:sequence>
+      <xsd:element name="value" minOccurs="1" maxOccurs="unbounded" type="CT_DdeValue"/>
+    </xsd:sequence>
+    <xsd:attribute name="rows" type="xsd:unsignedInt" use="optional" default="1"/>
+    <xsd:attribute name="cols" type="xsd:unsignedInt" use="optional" default="1"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DdeValue">
+    <xsd:sequence>
+      <xsd:element name="val" type="s:ST_Xstring" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="t" type="ST_DdeValueType" use="optional" default="n"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_DdeValueType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="nil"/>
+      <xsd:enumeration value="b"/>
+      <xsd:enumeration value="n"/>
+      <xsd:enumeration value="e"/>
+      <xsd:enumeration value="str"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_OleLink">
+    <xsd:sequence>
+      <xsd:element name="oleItems" type="CT_OleItems" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute ref="r:id" use="required"/>
+    <xsd:attribute name="progId" type="s:ST_Xstring" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_OleItems">
+    <xsd:sequence>
+      <xsd:element name="oleItem" type="CT_OleItem" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_OleItem">
+    <xsd:attribute name="name" type="s:ST_Xstring" use="required"/>
+    <xsd:attribute name="icon" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="advise" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="preferPic" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:element name="table" type="CT_Table"/>
+  <xsd:complexType name="CT_Table">
+    <xsd:sequence>
+      <xsd:element name="autoFilter" type="CT_AutoFilter" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="sortState" type="CT_SortState" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tableColumns" type="CT_TableColumns" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="tableStyleInfo" type="CT_TableStyleInfo" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="name" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="displayName" type="s:ST_Xstring" use="required"/>
+    <xsd:attribute name="comment" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="ref" type="ST_Ref" use="required"/>
+    <xsd:attribute name="tableType" type="ST_TableType" use="optional" default="worksheet"/>
+    <xsd:attribute name="headerRowCount" type="xsd:unsignedInt" use="optional" default="1"/>
+    <xsd:attribute name="insertRow" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="insertRowShift" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="totalsRowCount" type="xsd:unsignedInt" use="optional" default="0"/>
+    <xsd:attribute name="totalsRowShown" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="published" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="headerRowDxfId" type="ST_DxfId" use="optional"/>
+    <xsd:attribute name="dataDxfId" type="ST_DxfId" use="optional"/>
+    <xsd:attribute name="totalsRowDxfId" type="ST_DxfId" use="optional"/>
+    <xsd:attribute name="headerRowBorderDxfId" type="ST_DxfId" use="optional"/>
+    <xsd:attribute name="tableBorderDxfId" type="ST_DxfId" use="optional"/>
+    <xsd:attribute name="totalsRowBorderDxfId" type="ST_DxfId" use="optional"/>
+    <xsd:attribute name="headerRowCellStyle" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="dataCellStyle" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="totalsRowCellStyle" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="connectionId" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TableType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="worksheet"/>
+      <xsd:enumeration value="xml"/>
+      <xsd:enumeration value="queryTable"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TableStyleInfo">
+    <xsd:attribute name="name" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="showFirstColumn" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="showLastColumn" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="showRowStripes" type="xsd:boolean" use="optional"/>
+    <xsd:attribute name="showColumnStripes" type="xsd:boolean" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TableColumns">
+    <xsd:sequence>
+      <xsd:element name="tableColumn" type="CT_TableColumn" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TableColumn">
+    <xsd:sequence>
+      <xsd:element name="calculatedColumnFormula" type="CT_TableFormula" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="totalsRowFormula" type="CT_TableFormula" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="xmlColumnPr" type="CT_XmlColumnPr" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="uniqueName" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="name" type="s:ST_Xstring" use="required"/>
+    <xsd:attribute name="totalsRowFunction" type="ST_TotalsRowFunction" use="optional"
+      default="none"/>
+    <xsd:attribute name="totalsRowLabel" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="queryTableFieldId" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="headerRowDxfId" type="ST_DxfId" use="optional"/>
+    <xsd:attribute name="dataDxfId" type="ST_DxfId" use="optional"/>
+    <xsd:attribute name="totalsRowDxfId" type="ST_DxfId" use="optional"/>
+    <xsd:attribute name="headerRowCellStyle" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="dataCellStyle" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="totalsRowCellStyle" type="s:ST_Xstring" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TableFormula">
+    <xsd:simpleContent>
+      <xsd:extension base="ST_Formula">
+        <xsd:attribute name="array" type="xsd:boolean" default="false"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TotalsRowFunction">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="sum"/>
+      <xsd:enumeration value="min"/>
+      <xsd:enumeration value="max"/>
+      <xsd:enumeration value="average"/>
+      <xsd:enumeration value="count"/>
+      <xsd:enumeration value="countNums"/>
+      <xsd:enumeration value="stdDev"/>
+      <xsd:enumeration value="var"/>
+      <xsd:enumeration value="custom"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_XmlColumnPr">
+    <xsd:sequence>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="mapId" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="xpath" type="s:ST_Xstring" use="required"/>
+    <xsd:attribute name="denormalized" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="xmlDataType" type="ST_XmlDataType" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_XmlDataType">
+    <xsd:restriction base="xsd:string"/>
+  </xsd:simpleType>
+  <xsd:element name="volTypes" type="CT_VolTypes"/>
+  <xsd:complexType name="CT_VolTypes">
+    <xsd:sequence>
+      <xsd:element name="volType" type="CT_VolType" minOccurs="1" maxOccurs="unbounded"/>
+      <xsd:element name="extLst" minOccurs="0" type="CT_ExtensionList"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_VolType">
+    <xsd:sequence>
+      <xsd:element name="main" type="CT_VolMain" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="type" type="ST_VolDepType" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_VolMain">
+    <xsd:sequence>
+      <xsd:element name="tp" type="CT_VolTopic" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="first" type="s:ST_Xstring" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_VolTopic">
+    <xsd:sequence>
+      <xsd:element name="v" type="s:ST_Xstring" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="stp" type="s:ST_Xstring" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="tr" type="CT_VolTopicRef" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="t" type="ST_VolValueType" use="optional" default="n"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_VolTopicRef">
+    <xsd:attribute name="r" type="ST_CellRef" use="required"/>
+    <xsd:attribute name="s" type="xsd:unsignedInt" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_VolDepType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="realTimeData"/>
+      <xsd:enumeration value="olapFunctions"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_VolValueType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="b"/>
+      <xsd:enumeration value="n"/>
+      <xsd:enumeration value="e"/>
+      <xsd:enumeration value="s"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:element name="workbook" type="CT_Workbook"/>
+  <xsd:complexType name="CT_Workbook">
+    <xsd:sequence>
+      <xsd:element name="fileVersion" type="CT_FileVersion" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="fileSharing" type="CT_FileSharing" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="workbookPr" type="CT_WorkbookPr" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="workbookProtection" type="CT_WorkbookProtection" minOccurs="0"
+        maxOccurs="1"/>
+      <xsd:element name="bookViews" type="CT_BookViews" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="sheets" type="CT_Sheets" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="functionGroups" type="CT_FunctionGroups" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="externalReferences" type="CT_ExternalReferences" minOccurs="0"
+        maxOccurs="1"/>
+      <xsd:element name="definedNames" type="CT_DefinedNames" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="calcPr" type="CT_CalcPr" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="oleSize" type="CT_OleSize" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="customWorkbookViews" type="CT_CustomWorkbookViews" minOccurs="0"
+        maxOccurs="1"/>
+      <xsd:element name="pivotCaches" type="CT_PivotCaches" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="smartTagPr" type="CT_SmartTagPr" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="smartTagTypes" type="CT_SmartTagTypes" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="webPublishing" type="CT_WebPublishing" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="fileRecoveryPr" type="CT_FileRecoveryPr" minOccurs="0"
+        maxOccurs="unbounded"/>
+      <xsd:element name="webPublishObjects" type="CT_WebPublishObjects" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="conformance" type="s:ST_ConformanceClass"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_FileVersion">
+    <xsd:attribute name="appName" type="xsd:string" use="optional"/>
+    <xsd:attribute name="lastEdited" type="xsd:string" use="optional"/>
+    <xsd:attribute name="lowestEdited" type="xsd:string" use="optional"/>
+    <xsd:attribute name="rupBuild" type="xsd:string" use="optional"/>
+    <xsd:attribute name="codeName" type="s:ST_Guid" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_BookViews">
+    <xsd:sequence>
+      <xsd:element name="workbookView" type="CT_BookView" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_BookView">
+    <xsd:sequence>
+      <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="visibility" type="ST_Visibility" use="optional" default="visible"/>
+    <xsd:attribute name="minimized" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="showHorizontalScroll" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="showVerticalScroll" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="showSheetTabs" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="xWindow" type="xsd:int" use="optional"/>
+    <xsd:attribute name="yWindow" type="xsd:int" use="optional"/>
+    <xsd:attribute name="windowWidth" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="windowHeight" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="tabRatio" type="xsd:unsignedInt" use="optional" default="600"/>
+    <xsd:attribute name="firstSheet" type="xsd:unsignedInt" use="optional" default="0"/>
+    <xsd:attribute name="activeTab" type="xsd:unsignedInt" use="optional" default="0"/>
+    <xsd:attribute name="autoFilterDateGrouping" type="xsd:boolean" use="optional" default="true"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_Visibility">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="visible"/>
+      <xsd:enumeration value="hidden"/>
+      <xsd:enumeration value="veryHidden"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_CustomWorkbookViews">
+    <xsd:sequence>
+      <xsd:element name="customWorkbookView" minOccurs="1" maxOccurs="unbounded"
+        type="CT_CustomWorkbookView"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CustomWorkbookView">
+    <xsd:sequence>
+      <xsd:element name="extLst" minOccurs="0" type="CT_ExtensionList"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="s:ST_Xstring" use="required"/>
+    <xsd:attribute name="guid" type="s:ST_Guid" use="required"/>
+    <xsd:attribute name="autoUpdate" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="mergeInterval" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="changesSavedWin" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="onlySync" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="personalView" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="includePrintSettings" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="includeHiddenRowCol" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="maximized" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="minimized" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="showHorizontalScroll" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="showVerticalScroll" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="showSheetTabs" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="xWindow" type="xsd:int" use="optional" default="0"/>
+    <xsd:attribute name="yWindow" type="xsd:int" use="optional" default="0"/>
+    <xsd:attribute name="windowWidth" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="windowHeight" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="tabRatio" type="xsd:unsignedInt" use="optional" default="600"/>
+    <xsd:attribute name="activeSheetId" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="showFormulaBar" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="showStatusbar" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="showComments" type="ST_Comments" use="optional" default="commIndicator"/>
+    <xsd:attribute name="showObjects" type="ST_Objects" use="optional" default="all"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_Comments">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="commNone"/>
+      <xsd:enumeration value="commIndicator"/>
+      <xsd:enumeration value="commIndAndComment"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_Objects">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="all"/>
+      <xsd:enumeration value="placeholders"/>
+      <xsd:enumeration value="none"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Sheets">
+    <xsd:sequence>
+      <xsd:element name="sheet" type="CT_Sheet" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Sheet">
+    <xsd:attribute name="name" type="s:ST_Xstring" use="required"/>
+    <xsd:attribute name="sheetId" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="state" type="ST_SheetState" use="optional" default="visible"/>
+    <xsd:attribute ref="r:id" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_SheetState">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="visible"/>
+      <xsd:enumeration value="hidden"/>
+      <xsd:enumeration value="veryHidden"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_WorkbookPr">
+    <xsd:attribute name="date1904" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="showObjects" type="ST_Objects" use="optional" default="all"/>
+    <xsd:attribute name="showBorderUnselectedTables" type="xsd:boolean" use="optional"
+      default="true"/>
+    <xsd:attribute name="filterPrivacy" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="promptedSolutions" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="showInkAnnotation" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="backupFile" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="saveExternalLinkValues" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="updateLinks" type="ST_UpdateLinks" use="optional" default="userSet"/>
+    <xsd:attribute name="codeName" type="xsd:string" use="optional"/>
+    <xsd:attribute name="hidePivotFieldList" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="showPivotChartFilter" type="xsd:boolean" default="false"/>
+    <xsd:attribute name="allowRefreshQuery" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="publishItems" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="checkCompatibility" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="autoCompressPictures" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="refreshAllConnections" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="defaultThemeVersion" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_UpdateLinks">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="userSet"/>
+      <xsd:enumeration value="never"/>
+      <xsd:enumeration value="always"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_SmartTagPr">
+    <xsd:attribute name="embed" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="show" type="ST_SmartTagShow" use="optional" default="all"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_SmartTagShow">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="all"/>
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="noIndicator"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_SmartTagTypes">
+    <xsd:sequence>
+      <xsd:element name="smartTagType" type="CT_SmartTagType" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SmartTagType">
+    <xsd:attribute name="namespaceUri" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="name" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="url" type="s:ST_Xstring" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_FileRecoveryPr">
+    <xsd:attribute name="autoRecover" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="crashSave" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="dataExtractLoad" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="repairLoad" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CalcPr">
+    <xsd:attribute name="calcId" type="xsd:unsignedInt"/>
+    <xsd:attribute name="calcMode" type="ST_CalcMode" use="optional" default="auto"/>
+    <xsd:attribute name="fullCalcOnLoad" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="refMode" type="ST_RefMode" use="optional" default="A1"/>
+    <xsd:attribute name="iterate" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="iterateCount" type="xsd:unsignedInt" use="optional" default="100"/>
+    <xsd:attribute name="iterateDelta" type="xsd:double" use="optional" default="0.001"/>
+    <xsd:attribute name="fullPrecision" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="calcCompleted" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="calcOnSave" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="concurrentCalc" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="concurrentManualCount" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="forceFullCalc" type="xsd:boolean" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_CalcMode">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="manual"/>
+      <xsd:enumeration value="auto"/>
+      <xsd:enumeration value="autoNoTable"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_RefMode">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="A1"/>
+      <xsd:enumeration value="R1C1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_DefinedNames">
+    <xsd:sequence>
+      <xsd:element name="definedName" type="CT_DefinedName" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DefinedName">
+    <xsd:simpleContent>
+      <xsd:extension base="ST_Formula">
+        <xsd:attribute name="name" type="s:ST_Xstring" use="required"/>
+        <xsd:attribute name="comment" type="s:ST_Xstring" use="optional"/>
+        <xsd:attribute name="customMenu" type="s:ST_Xstring" use="optional"/>
+        <xsd:attribute name="description" type="s:ST_Xstring" use="optional"/>
+        <xsd:attribute name="help" type="s:ST_Xstring" use="optional"/>
+        <xsd:attribute name="statusBar" type="s:ST_Xstring" use="optional"/>
+        <xsd:attribute name="localSheetId" type="xsd:unsignedInt" use="optional"/>
+        <xsd:attribute name="hidden" type="xsd:boolean" use="optional" default="false"/>
+        <xsd:attribute name="function" type="xsd:boolean" use="optional" default="false"/>
+        <xsd:attribute name="vbProcedure" type="xsd:boolean" use="optional" default="false"/>
+        <xsd:attribute name="xlm" type="xsd:boolean" use="optional" default="false"/>
+        <xsd:attribute name="functionGroupId" type="xsd:unsignedInt" use="optional"/>
+        <xsd:attribute name="shortcutKey" type="s:ST_Xstring" use="optional"/>
+        <xsd:attribute name="publishToServer" type="xsd:boolean" use="optional" default="false"/>
+        <xsd:attribute name="workbookParameter" type="xsd:boolean" use="optional" default="false"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ExternalReferences">
+    <xsd:sequence>
+      <xsd:element name="externalReference" type="CT_ExternalReference" minOccurs="1"
+        maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ExternalReference">
+    <xsd:attribute ref="r:id" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SheetBackgroundPicture">
+    <xsd:attribute ref="r:id" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PivotCaches">
+    <xsd:sequence>
+      <xsd:element name="pivotCache" type="CT_PivotCache" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PivotCache">
+    <xsd:attribute name="cacheId" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute ref="r:id" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_FileSharing">
+    <xsd:attribute name="readOnlyRecommended" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="userName" type="s:ST_Xstring"/>
+    <xsd:attribute name="reservationPassword" type="ST_UnsignedShortHex"/>
+    <xsd:attribute name="algorithmName" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="hashValue" type="xsd:base64Binary" use="optional"/>
+    <xsd:attribute name="saltValue" type="xsd:base64Binary" use="optional"/>
+    <xsd:attribute name="spinCount" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_OleSize">
+    <xsd:attribute name="ref" type="ST_Ref" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_WorkbookProtection">
+    <xsd:attribute name="workbookPassword" type="ST_UnsignedShortHex" use="optional"/>
+    <xsd:attribute name="workbookPasswordCharacterSet" type="xsd:string" use="optional"/>
+    <xsd:attribute name="revisionsPassword" type="ST_UnsignedShortHex" use="optional"/>
+    <xsd:attribute name="revisionsPasswordCharacterSet" type="xsd:string" use="optional"/>
+    <xsd:attribute name="lockStructure" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="lockWindows" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="lockRevision" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="revisionsAlgorithmName" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="revisionsHashValue" type="xsd:base64Binary" use="optional"/>
+    <xsd:attribute name="revisionsSaltValue" type="xsd:base64Binary" use="optional"/>
+    <xsd:attribute name="revisionsSpinCount" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="workbookAlgorithmName" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="workbookHashValue" type="xsd:base64Binary" use="optional"/>
+    <xsd:attribute name="workbookSaltValue" type="xsd:base64Binary" use="optional"/>
+    <xsd:attribute name="workbookSpinCount" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_WebPublishing">
+    <xsd:attribute name="css" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="thicket" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="longFileNames" type="xsd:boolean" use="optional" default="true"/>
+    <xsd:attribute name="vml" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="allowPng" type="xsd:boolean" use="optional" default="false"/>
+    <xsd:attribute name="targetScreenSize" type="ST_TargetScreenSize" use="optional"
+      default="800x600"/>
+    <xsd:attribute name="dpi" type="xsd:unsignedInt" use="optional" default="96"/>
+    <xsd:attribute name="codePage" type="xsd:unsignedInt" use="optional"/>
+    <xsd:attribute name="characterSet" type="xsd:string" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TargetScreenSize">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="544x376"/>
+      <xsd:enumeration value="640x480"/>
+      <xsd:enumeration value="720x512"/>
+      <xsd:enumeration value="800x600"/>
+      <xsd:enumeration value="1024x768"/>
+      <xsd:enumeration value="1152x882"/>
+      <xsd:enumeration value="1152x900"/>
+      <xsd:enumeration value="1280x1024"/>
+      <xsd:enumeration value="1600x1200"/>
+      <xsd:enumeration value="1800x1440"/>
+      <xsd:enumeration value="1920x1200"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_FunctionGroups">
+    <xsd:sequence maxOccurs="unbounded">
+      <xsd:element name="functionGroup" type="CT_FunctionGroup" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="builtInGroupCount" type="xsd:unsignedInt" default="16" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_FunctionGroup">
+    <xsd:attribute name="name" type="s:ST_Xstring"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_WebPublishObjects">
+    <xsd:sequence>
+      <xsd:element name="webPublishObject" type="CT_WebPublishObject" minOccurs="1"
+        maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="count" type="xsd:unsignedInt" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_WebPublishObject">
+    <xsd:attribute name="id" type="xsd:unsignedInt" use="required"/>
+    <xsd:attribute name="divId" type="s:ST_Xstring" use="required"/>
+    <xsd:attribute name="sourceObject" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="destinationFile" type="s:ST_Xstring" use="required"/>
+    <xsd:attribute name="title" type="s:ST_Xstring" use="optional"/>
+    <xsd:attribute name="autoRepublish" type="xsd:boolean" use="optional" default="false"/>
+  </xsd:complexType>
+</xsd:schema>

--- a/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/vml-main.xsd
+++ b/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/vml-main.xsd
@@ -1,0 +1,570 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="urn:schemas-microsoft-com:vml"
+  xmlns:pvml="urn:schemas-microsoft-com:office:powerpoint"
+  xmlns:o="urn:schemas-microsoft-com:office:office"
+  xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+  xmlns:w10="urn:schemas-microsoft-com:office:word"
+  xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+  xmlns:x="urn:schemas-microsoft-com:office:excel"
+  xmlns:s="http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"
+  targetNamespace="urn:schemas-microsoft-com:vml" elementFormDefault="qualified"
+  attributeFormDefault="unqualified">
+  <xsd:import namespace="urn:schemas-microsoft-com:office:office"
+    schemaLocation="vml-officeDrawing.xsd"/>
+  <xsd:import namespace="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+    schemaLocation="wml.xsd"/>
+  <xsd:import namespace="urn:schemas-microsoft-com:office:word"
+    schemaLocation="vml-wordprocessingDrawing.xsd"/>
+  <xsd:import namespace="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+    schemaLocation="shared-relationshipReference.xsd"/>
+  <xsd:import namespace="urn:schemas-microsoft-com:office:excel"
+    schemaLocation="vml-spreadsheetDrawing.xsd"/>
+  <xsd:import namespace="urn:schemas-microsoft-com:office:powerpoint"
+    schemaLocation="vml-presentationDrawing.xsd"/>
+  <xsd:import namespace="http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"
+    schemaLocation="shared-commonSimpleTypes.xsd"/>
+  <xsd:attributeGroup name="AG_Id">
+    <xsd:attribute name="id" type="xsd:string" use="optional"/>
+  </xsd:attributeGroup>
+  <xsd:attributeGroup name="AG_Style">
+    <xsd:attribute name="style" type="xsd:string" use="optional"/>
+  </xsd:attributeGroup>
+  <xsd:attributeGroup name="AG_Type">
+    <xsd:attribute name="type" type="xsd:string" use="optional"/>
+  </xsd:attributeGroup>
+  <xsd:attributeGroup name="AG_Adj">
+    <xsd:attribute name="adj" type="xsd:string" use="optional"/>
+  </xsd:attributeGroup>
+  <xsd:attributeGroup name="AG_Path">
+    <xsd:attribute name="path" type="xsd:string" use="optional"/>
+  </xsd:attributeGroup>
+  <xsd:attributeGroup name="AG_Fill">
+    <xsd:attribute name="filled" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="fillcolor" type="s:ST_ColorType" use="optional"/>
+  </xsd:attributeGroup>
+  <xsd:attributeGroup name="AG_Chromakey">
+    <xsd:attribute name="chromakey" type="s:ST_ColorType" use="optional"/>
+  </xsd:attributeGroup>
+  <xsd:attributeGroup name="AG_Ext">
+    <xsd:attribute name="ext" form="qualified" type="ST_Ext"/>
+  </xsd:attributeGroup>
+  <xsd:attributeGroup name="AG_CoreAttributes">
+    <xsd:attributeGroup ref="AG_Id"/>
+    <xsd:attributeGroup ref="AG_Style"/>
+    <xsd:attribute name="href" type="xsd:string" use="optional"/>
+    <xsd:attribute name="target" type="xsd:string" use="optional"/>
+    <xsd:attribute name="class" type="xsd:string" use="optional"/>
+    <xsd:attribute name="title" type="xsd:string" use="optional"/>
+    <xsd:attribute name="alt" type="xsd:string" use="optional"/>
+    <xsd:attribute name="coordsize" type="xsd:string" use="optional"/>
+    <xsd:attribute name="coordorigin" type="xsd:string" use="optional"/>
+    <xsd:attribute name="wrapcoords" type="xsd:string" use="optional"/>
+    <xsd:attribute name="print" type="s:ST_TrueFalse" use="optional"/>
+  </xsd:attributeGroup>
+  <xsd:attributeGroup name="AG_ShapeAttributes">
+    <xsd:attributeGroup ref="AG_Chromakey"/>
+    <xsd:attributeGroup ref="AG_Fill"/>
+    <xsd:attribute name="opacity" type="xsd:string" use="optional"/>
+    <xsd:attribute name="stroked" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="strokecolor" type="s:ST_ColorType" use="optional"/>
+    <xsd:attribute name="strokeweight" type="xsd:string" use="optional"/>
+    <xsd:attribute name="insetpen" type="s:ST_TrueFalse" use="optional"/>
+  </xsd:attributeGroup>
+  <xsd:attributeGroup name="AG_OfficeCoreAttributes">
+    <xsd:attribute ref="o:spid"/>
+    <xsd:attribute ref="o:oned"/>
+    <xsd:attribute ref="o:regroupid"/>
+    <xsd:attribute ref="o:doubleclicknotify"/>
+    <xsd:attribute ref="o:button"/>
+    <xsd:attribute ref="o:userhidden"/>
+    <xsd:attribute ref="o:bullet"/>
+    <xsd:attribute ref="o:hr"/>
+    <xsd:attribute ref="o:hrstd"/>
+    <xsd:attribute ref="o:hrnoshade"/>
+    <xsd:attribute ref="o:hrpct"/>
+    <xsd:attribute ref="o:hralign"/>
+    <xsd:attribute ref="o:allowincell"/>
+    <xsd:attribute ref="o:allowoverlap"/>
+    <xsd:attribute ref="o:userdrawn"/>
+    <xsd:attribute ref="o:bordertopcolor"/>
+    <xsd:attribute ref="o:borderleftcolor"/>
+    <xsd:attribute ref="o:borderbottomcolor"/>
+    <xsd:attribute ref="o:borderrightcolor"/>
+    <xsd:attribute ref="o:dgmlayout"/>
+    <xsd:attribute ref="o:dgmnodekind"/>
+    <xsd:attribute ref="o:dgmlayoutmru"/>
+    <xsd:attribute ref="o:insetmode"/>
+  </xsd:attributeGroup>
+  <xsd:attributeGroup name="AG_OfficeShapeAttributes">
+    <xsd:attribute ref="o:spt"/>
+    <xsd:attribute ref="o:connectortype"/>
+    <xsd:attribute ref="o:bwmode"/>
+    <xsd:attribute ref="o:bwpure"/>
+    <xsd:attribute ref="o:bwnormal"/>
+    <xsd:attribute ref="o:forcedash"/>
+    <xsd:attribute ref="o:oleicon"/>
+    <xsd:attribute ref="o:ole"/>
+    <xsd:attribute ref="o:preferrelative"/>
+    <xsd:attribute ref="o:cliptowrap"/>
+    <xsd:attribute ref="o:clip"/>
+  </xsd:attributeGroup>
+  <xsd:attributeGroup name="AG_AllCoreAttributes">
+    <xsd:attributeGroup ref="AG_CoreAttributes"/>
+    <xsd:attributeGroup ref="AG_OfficeCoreAttributes"/>
+  </xsd:attributeGroup>
+  <xsd:attributeGroup name="AG_AllShapeAttributes">
+    <xsd:attributeGroup ref="AG_ShapeAttributes"/>
+    <xsd:attributeGroup ref="AG_OfficeShapeAttributes"/>
+  </xsd:attributeGroup>
+  <xsd:attributeGroup name="AG_ImageAttributes">
+    <xsd:attribute name="src" type="xsd:string" use="optional"/>
+    <xsd:attribute name="cropleft" type="xsd:string" use="optional"/>
+    <xsd:attribute name="croptop" type="xsd:string" use="optional"/>
+    <xsd:attribute name="cropright" type="xsd:string" use="optional"/>
+    <xsd:attribute name="cropbottom" type="xsd:string" use="optional"/>
+    <xsd:attribute name="gain" type="xsd:string" use="optional"/>
+    <xsd:attribute name="blacklevel" type="xsd:string" use="optional"/>
+    <xsd:attribute name="gamma" type="xsd:string" use="optional"/>
+    <xsd:attribute name="grayscale" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="bilevel" type="s:ST_TrueFalse" use="optional"/>
+  </xsd:attributeGroup>
+  <xsd:attributeGroup name="AG_StrokeAttributes">
+    <xsd:attribute name="on" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="weight" type="xsd:string" use="optional"/>
+    <xsd:attribute name="color" type="s:ST_ColorType" use="optional"/>
+    <xsd:attribute name="opacity" type="xsd:string" use="optional"/>
+    <xsd:attribute name="linestyle" type="ST_StrokeLineStyle" use="optional"/>
+    <xsd:attribute name="miterlimit" type="xsd:decimal" use="optional"/>
+    <xsd:attribute name="joinstyle" type="ST_StrokeJoinStyle" use="optional"/>
+    <xsd:attribute name="endcap" type="ST_StrokeEndCap" use="optional"/>
+    <xsd:attribute name="dashstyle" type="xsd:string" use="optional"/>
+    <xsd:attribute name="filltype" type="ST_FillType" use="optional"/>
+    <xsd:attribute name="src" type="xsd:string" use="optional"/>
+    <xsd:attribute name="imageaspect" type="ST_ImageAspect" use="optional"/>
+    <xsd:attribute name="imagesize" type="xsd:string" use="optional"/>
+    <xsd:attribute name="imagealignshape" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="color2" type="s:ST_ColorType" use="optional"/>
+    <xsd:attribute name="startarrow" type="ST_StrokeArrowType" use="optional"/>
+    <xsd:attribute name="startarrowwidth" type="ST_StrokeArrowWidth" use="optional"/>
+    <xsd:attribute name="startarrowlength" type="ST_StrokeArrowLength" use="optional"/>
+    <xsd:attribute name="endarrow" type="ST_StrokeArrowType" use="optional"/>
+    <xsd:attribute name="endarrowwidth" type="ST_StrokeArrowWidth" use="optional"/>
+    <xsd:attribute name="endarrowlength" type="ST_StrokeArrowLength" use="optional"/>
+    <xsd:attribute ref="o:href"/>
+    <xsd:attribute ref="o:althref"/>
+    <xsd:attribute ref="o:title"/>
+    <xsd:attribute ref="o:forcedash"/>
+    <xsd:attribute ref="r:id" use="optional"/>
+    <xsd:attribute name="insetpen" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute ref="o:relid"/>
+  </xsd:attributeGroup>
+  <xsd:group name="EG_ShapeElements">
+    <xsd:choice>
+      <xsd:element ref="path"/>
+      <xsd:element ref="formulas"/>
+      <xsd:element ref="handles"/>
+      <xsd:element ref="fill"/>
+      <xsd:element ref="stroke"/>
+      <xsd:element ref="shadow"/>
+      <xsd:element ref="textbox"/>
+      <xsd:element ref="textpath"/>
+      <xsd:element ref="imagedata"/>
+      <xsd:element ref="o:skew"/>
+      <xsd:element ref="o:extrusion"/>
+      <xsd:element ref="o:callout"/>
+      <xsd:element ref="o:lock"/>
+      <xsd:element ref="o:clippath"/>
+      <xsd:element ref="o:signatureline"/>
+      <xsd:element ref="w10:wrap"/>
+      <xsd:element ref="w10:anchorlock"/>
+      <xsd:element ref="w10:bordertop"/>
+      <xsd:element ref="w10:borderbottom"/>
+      <xsd:element ref="w10:borderleft"/>
+      <xsd:element ref="w10:borderright"/>
+      <xsd:element ref="x:ClientData" minOccurs="0"/>
+      <xsd:element ref="pvml:textdata" minOccurs="0"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:element name="shape" type="CT_Shape"/>
+  <xsd:element name="shapetype" type="CT_Shapetype"/>
+  <xsd:element name="group" type="CT_Group"/>
+  <xsd:element name="background" type="CT_Background"/>
+  <xsd:complexType name="CT_Shape">
+    <xsd:choice maxOccurs="unbounded">
+      <xsd:group ref="EG_ShapeElements"/>
+      <xsd:element ref="o:ink"/>
+      <xsd:element ref="pvml:iscomment"/>
+      <xsd:element ref="o:equationxml"/>
+    </xsd:choice>
+    <xsd:attributeGroup ref="AG_AllCoreAttributes"/>
+    <xsd:attributeGroup ref="AG_AllShapeAttributes"/>
+    <xsd:attributeGroup ref="AG_Type"/>
+    <xsd:attributeGroup ref="AG_Adj"/>
+    <xsd:attributeGroup ref="AG_Path"/>
+    <xsd:attribute ref="o:gfxdata"/>
+    <xsd:attribute name="equationxml" type="xsd:string" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Shapetype">
+    <xsd:sequence>
+      <xsd:group ref="EG_ShapeElements" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element ref="o:complex" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attributeGroup ref="AG_AllCoreAttributes"/>
+    <xsd:attributeGroup ref="AG_AllShapeAttributes"/>
+    <xsd:attributeGroup ref="AG_Adj"/>
+    <xsd:attributeGroup ref="AG_Path"/>
+    <xsd:attribute ref="o:master"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Group">
+    <xsd:choice maxOccurs="unbounded">
+      <xsd:group ref="EG_ShapeElements"/>
+      <xsd:element ref="group"/>
+      <xsd:element ref="shape"/>
+      <xsd:element ref="shapetype"/>
+      <xsd:element ref="arc"/>
+      <xsd:element ref="curve"/>
+      <xsd:element ref="image"/>
+      <xsd:element ref="line"/>
+      <xsd:element ref="oval"/>
+      <xsd:element ref="polyline"/>
+      <xsd:element ref="rect"/>
+      <xsd:element ref="roundrect"/>
+      <xsd:element ref="o:diagram"/>
+    </xsd:choice>
+    <xsd:attributeGroup ref="AG_AllCoreAttributes"/>
+    <xsd:attributeGroup ref="AG_Fill"/>
+    <xsd:attribute name="editas" type="ST_EditAs" use="optional"/>
+    <xsd:attribute ref="o:tableproperties"/>
+    <xsd:attribute ref="o:tablelimits"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Background">
+    <xsd:sequence>
+      <xsd:element ref="fill" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attributeGroup ref="AG_Id"/>
+    <xsd:attributeGroup ref="AG_Fill"/>
+    <xsd:attribute ref="o:bwmode"/>
+    <xsd:attribute ref="o:bwpure"/>
+    <xsd:attribute ref="o:bwnormal"/>
+    <xsd:attribute ref="o:targetscreensize"/>
+  </xsd:complexType>
+  <xsd:element name="fill" type="CT_Fill"/>
+  <xsd:element name="formulas" type="CT_Formulas"/>
+  <xsd:element name="handles" type="CT_Handles"/>
+  <xsd:element name="imagedata" type="CT_ImageData"/>
+  <xsd:element name="path" type="CT_Path"/>
+  <xsd:element name="textbox" type="CT_Textbox"/>
+  <xsd:element name="shadow" type="CT_Shadow"/>
+  <xsd:element name="stroke" type="CT_Stroke"/>
+  <xsd:element name="textpath" type="CT_TextPath"/>
+  <xsd:complexType name="CT_Fill">
+    <xsd:sequence>
+      <xsd:element ref="o:fill" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attributeGroup ref="AG_Id"/>
+    <xsd:attribute name="type" type="ST_FillType" use="optional"/>
+    <xsd:attribute name="on" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="color" type="s:ST_ColorType" use="optional"/>
+    <xsd:attribute name="opacity" type="xsd:string" use="optional"/>
+    <xsd:attribute name="color2" type="s:ST_ColorType" use="optional"/>
+    <xsd:attribute name="src" type="xsd:string" use="optional"/>
+    <xsd:attribute ref="o:href"/>
+    <xsd:attribute ref="o:althref"/>
+    <xsd:attribute name="size" type="xsd:string" use="optional"/>
+    <xsd:attribute name="origin" type="xsd:string" use="optional"/>
+    <xsd:attribute name="position" type="xsd:string" use="optional"/>
+    <xsd:attribute name="aspect" type="ST_ImageAspect" use="optional"/>
+    <xsd:attribute name="colors" type="xsd:string" use="optional"/>
+    <xsd:attribute name="angle" type="xsd:decimal" use="optional"/>
+    <xsd:attribute name="alignshape" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="focus" type="xsd:string" use="optional"/>
+    <xsd:attribute name="focussize" type="xsd:string" use="optional"/>
+    <xsd:attribute name="focusposition" type="xsd:string" use="optional"/>
+    <xsd:attribute name="method" type="ST_FillMethod" use="optional"/>
+    <xsd:attribute ref="o:detectmouseclick"/>
+    <xsd:attribute ref="o:title"/>
+    <xsd:attribute ref="o:opacity2"/>
+    <xsd:attribute name="recolor" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="rotate" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute ref="r:id" use="optional"/>
+    <xsd:attribute ref="o:relid" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Formulas">
+    <xsd:sequence>
+      <xsd:element name="f" type="CT_F" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_F">
+    <xsd:attribute name="eqn" type="xsd:string"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Handles">
+    <xsd:sequence>
+      <xsd:element name="h" type="CT_H" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_H">
+    <xsd:attribute name="position" type="xsd:string"/>
+    <xsd:attribute name="polar" type="xsd:string"/>
+    <xsd:attribute name="map" type="xsd:string"/>
+    <xsd:attribute name="invx" type="s:ST_TrueFalse"/>
+    <xsd:attribute name="invy" type="s:ST_TrueFalse"/>
+    <xsd:attribute name="switch" type="s:ST_TrueFalseBlank"/>
+    <xsd:attribute name="xrange" type="xsd:string"/>
+    <xsd:attribute name="yrange" type="xsd:string"/>
+    <xsd:attribute name="radiusrange" type="xsd:string"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ImageData">
+    <xsd:attributeGroup ref="AG_Id"/>
+    <xsd:attributeGroup ref="AG_ImageAttributes"/>
+    <xsd:attributeGroup ref="AG_Chromakey"/>
+    <xsd:attribute name="embosscolor" type="s:ST_ColorType" use="optional"/>
+    <xsd:attribute name="recolortarget" type="s:ST_ColorType"/>
+    <xsd:attribute ref="o:href"/>
+    <xsd:attribute ref="o:althref"/>
+    <xsd:attribute ref="o:title"/>
+    <xsd:attribute ref="o:oleid"/>
+    <xsd:attribute ref="o:detectmouseclick"/>
+    <xsd:attribute ref="o:movie"/>
+    <xsd:attribute ref="o:relid"/>
+    <xsd:attribute ref="r:id"/>
+    <xsd:attribute ref="r:pict"/>
+    <xsd:attribute ref="r:href"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Path">
+    <xsd:attributeGroup ref="AG_Id"/>
+    <xsd:attribute name="v" type="xsd:string" use="optional"/>
+    <xsd:attribute name="limo" type="xsd:string" use="optional"/>
+    <xsd:attribute name="textboxrect" type="xsd:string" use="optional"/>
+    <xsd:attribute name="fillok" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="strokeok" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="shadowok" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="arrowok" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="gradientshapeok" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="textpathok" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="insetpenok" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute ref="o:connecttype"/>
+    <xsd:attribute ref="o:connectlocs"/>
+    <xsd:attribute ref="o:connectangles"/>
+    <xsd:attribute ref="o:extrusionok"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Shadow">
+    <xsd:attributeGroup ref="AG_Id"/>
+    <xsd:attribute name="on" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="type" type="ST_ShadowType" use="optional"/>
+    <xsd:attribute name="obscured" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="color" type="s:ST_ColorType" use="optional"/>
+    <xsd:attribute name="opacity" type="xsd:string" use="optional"/>
+    <xsd:attribute name="offset" type="xsd:string" use="optional"/>
+    <xsd:attribute name="color2" type="s:ST_ColorType" use="optional"/>
+    <xsd:attribute name="offset2" type="xsd:string" use="optional"/>
+    <xsd:attribute name="origin" type="xsd:string" use="optional"/>
+    <xsd:attribute name="matrix" type="xsd:string" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Stroke">
+    <xsd:sequence>
+      <xsd:element ref="o:left" minOccurs="0"/>
+      <xsd:element ref="o:top" minOccurs="0"/>
+      <xsd:element ref="o:right" minOccurs="0"/>
+      <xsd:element ref="o:bottom" minOccurs="0"/>
+      <xsd:element ref="o:column" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attributeGroup ref="AG_Id"/>
+    <xsd:attributeGroup ref="AG_StrokeAttributes"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Textbox">
+    <xsd:choice>
+      <xsd:element ref="w:txbxContent" minOccurs="0"/>
+      <xsd:any namespace="##local" processContents="skip"/>
+    </xsd:choice>
+    <xsd:attributeGroup ref="AG_Id"/>
+    <xsd:attributeGroup ref="AG_Style"/>
+    <xsd:attribute name="inset" type="xsd:string" use="optional"/>
+    <xsd:attribute ref="o:singleclick"/>
+    <xsd:attribute ref="o:insetmode"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TextPath">
+    <xsd:attributeGroup ref="AG_Id"/>
+    <xsd:attributeGroup ref="AG_Style"/>
+    <xsd:attribute name="on" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="fitshape" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="fitpath" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="trim" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="xscale" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="string" type="xsd:string" use="optional"/>
+  </xsd:complexType>
+  <xsd:element name="arc" type="CT_Arc"/>
+  <xsd:element name="curve" type="CT_Curve"/>
+  <xsd:element name="image" type="CT_Image"/>
+  <xsd:element name="line" type="CT_Line"/>
+  <xsd:element name="oval" type="CT_Oval"/>
+  <xsd:element name="polyline" type="CT_PolyLine"/>
+  <xsd:element name="rect" type="CT_Rect"/>
+  <xsd:element name="roundrect" type="CT_RoundRect"/>
+  <xsd:complexType name="CT_Arc">
+    <xsd:sequence>
+      <xsd:group ref="EG_ShapeElements" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attributeGroup ref="AG_AllCoreAttributes"/>
+    <xsd:attributeGroup ref="AG_AllShapeAttributes"/>
+    <xsd:attribute name="startAngle" type="xsd:decimal" use="optional"/>
+    <xsd:attribute name="endAngle" type="xsd:decimal" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Curve">
+    <xsd:sequence>
+      <xsd:group ref="EG_ShapeElements" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attributeGroup ref="AG_AllCoreAttributes"/>
+    <xsd:attributeGroup ref="AG_AllShapeAttributes"/>
+    <xsd:attribute name="from" type="xsd:string" use="optional"/>
+    <xsd:attribute name="control1" type="xsd:string" use="optional"/>
+    <xsd:attribute name="control2" type="xsd:string" use="optional"/>
+    <xsd:attribute name="to" type="xsd:string" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Image">
+    <xsd:sequence>
+      <xsd:group ref="EG_ShapeElements" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attributeGroup ref="AG_AllCoreAttributes"/>
+    <xsd:attributeGroup ref="AG_AllShapeAttributes"/>
+    <xsd:attributeGroup ref="AG_ImageAttributes"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Line">
+    <xsd:sequence>
+      <xsd:group ref="EG_ShapeElements" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attributeGroup ref="AG_AllCoreAttributes"/>
+    <xsd:attributeGroup ref="AG_AllShapeAttributes"/>
+    <xsd:attribute name="from" type="xsd:string" use="optional"/>
+    <xsd:attribute name="to" type="xsd:string" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Oval">
+    <xsd:choice maxOccurs="unbounded">
+      <xsd:group ref="EG_ShapeElements" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:choice>
+    <xsd:attributeGroup ref="AG_AllCoreAttributes"/>
+    <xsd:attributeGroup ref="AG_AllShapeAttributes"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PolyLine">
+    <xsd:choice minOccurs="0" maxOccurs="unbounded">
+      <xsd:group ref="EG_ShapeElements"/>
+      <xsd:element ref="o:ink"/>
+    </xsd:choice>
+    <xsd:attributeGroup ref="AG_AllCoreAttributes"/>
+    <xsd:attributeGroup ref="AG_AllShapeAttributes"/>
+    <xsd:attribute name="points" type="xsd:string" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Rect">
+    <xsd:choice maxOccurs="unbounded">
+      <xsd:group ref="EG_ShapeElements" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:choice>
+    <xsd:attributeGroup ref="AG_AllCoreAttributes"/>
+    <xsd:attributeGroup ref="AG_AllShapeAttributes"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_RoundRect">
+    <xsd:choice maxOccurs="unbounded">
+      <xsd:group ref="EG_ShapeElements" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:choice>
+    <xsd:attributeGroup ref="AG_AllCoreAttributes"/>
+    <xsd:attributeGroup ref="AG_AllShapeAttributes"/>
+    <xsd:attribute name="arcsize" type="xsd:string" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_Ext">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="view"/>
+      <xsd:enumeration value="edit"/>
+      <xsd:enumeration value="backwardCompatible"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_FillType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="solid"/>
+      <xsd:enumeration value="gradient"/>
+      <xsd:enumeration value="gradientRadial"/>
+      <xsd:enumeration value="tile"/>
+      <xsd:enumeration value="pattern"/>
+      <xsd:enumeration value="frame"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_FillMethod">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="linear"/>
+      <xsd:enumeration value="sigma"/>
+      <xsd:enumeration value="any"/>
+      <xsd:enumeration value="linear sigma"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_ShadowType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="single"/>
+      <xsd:enumeration value="double"/>
+      <xsd:enumeration value="emboss"/>
+      <xsd:enumeration value="perspective"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_StrokeLineStyle">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="single"/>
+      <xsd:enumeration value="thinThin"/>
+      <xsd:enumeration value="thinThick"/>
+      <xsd:enumeration value="thickThin"/>
+      <xsd:enumeration value="thickBetweenThin"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_StrokeJoinStyle">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="round"/>
+      <xsd:enumeration value="bevel"/>
+      <xsd:enumeration value="miter"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_StrokeEndCap">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="flat"/>
+      <xsd:enumeration value="square"/>
+      <xsd:enumeration value="round"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_StrokeArrowLength">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="short"/>
+      <xsd:enumeration value="medium"/>
+      <xsd:enumeration value="long"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_StrokeArrowWidth">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="narrow"/>
+      <xsd:enumeration value="medium"/>
+      <xsd:enumeration value="wide"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_StrokeArrowType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="block"/>
+      <xsd:enumeration value="classic"/>
+      <xsd:enumeration value="oval"/>
+      <xsd:enumeration value="diamond"/>
+      <xsd:enumeration value="open"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_ImageAspect">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="ignore"/>
+      <xsd:enumeration value="atMost"/>
+      <xsd:enumeration value="atLeast"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_EditAs">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="canvas"/>
+      <xsd:enumeration value="orgchart"/>
+      <xsd:enumeration value="radial"/>
+      <xsd:enumeration value="cycle"/>
+      <xsd:enumeration value="stacked"/>
+      <xsd:enumeration value="venn"/>
+      <xsd:enumeration value="bullseye"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+</xsd:schema>

--- a/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/vml-officeDrawing.xsd
+++ b/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/vml-officeDrawing.xsd
@@ -1,0 +1,509 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns="urn:schemas-microsoft-com:office:office" xmlns:v="urn:schemas-microsoft-com:vml"
+  xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+  xmlns:s="http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"
+  targetNamespace="urn:schemas-microsoft-com:office:office" elementFormDefault="qualified"
+  attributeFormDefault="unqualified">
+  <xsd:import namespace="urn:schemas-microsoft-com:vml" schemaLocation="vml-main.xsd"/>
+  <xsd:import namespace="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+    schemaLocation="shared-relationshipReference.xsd"/>
+  <xsd:import namespace="http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"
+    schemaLocation="shared-commonSimpleTypes.xsd"/>
+  <xsd:attribute name="bwmode" type="ST_BWMode"/>
+  <xsd:attribute name="bwpure" type="ST_BWMode"/>
+  <xsd:attribute name="bwnormal" type="ST_BWMode"/>
+  <xsd:attribute name="targetscreensize" type="ST_ScreenSize"/>
+  <xsd:attribute name="insetmode" type="ST_InsetMode" default="custom"/>
+  <xsd:attribute name="spt" type="xsd:float"/>
+  <xsd:attribute name="wrapcoords" type="xsd:string"/>
+  <xsd:attribute name="oned" type="s:ST_TrueFalse"/>
+  <xsd:attribute name="regroupid" type="xsd:integer"/>
+  <xsd:attribute name="doubleclicknotify" type="s:ST_TrueFalse"/>
+  <xsd:attribute name="connectortype" type="ST_ConnectorType" default="straight"/>
+  <xsd:attribute name="button" type="s:ST_TrueFalse"/>
+  <xsd:attribute name="userhidden" type="s:ST_TrueFalse"/>
+  <xsd:attribute name="forcedash" type="s:ST_TrueFalse"/>
+  <xsd:attribute name="oleicon" type="s:ST_TrueFalse"/>
+  <xsd:attribute name="ole" type="s:ST_TrueFalseBlank"/>
+  <xsd:attribute name="preferrelative" type="s:ST_TrueFalse"/>
+  <xsd:attribute name="cliptowrap" type="s:ST_TrueFalse"/>
+  <xsd:attribute name="clip" type="s:ST_TrueFalse"/>
+  <xsd:attribute name="bullet" type="s:ST_TrueFalse"/>
+  <xsd:attribute name="hr" type="s:ST_TrueFalse"/>
+  <xsd:attribute name="hrstd" type="s:ST_TrueFalse"/>
+  <xsd:attribute name="hrnoshade" type="s:ST_TrueFalse"/>
+  <xsd:attribute name="hrpct" type="xsd:float"/>
+  <xsd:attribute name="hralign" type="ST_HrAlign" default="left"/>
+  <xsd:attribute name="allowincell" type="s:ST_TrueFalse"/>
+  <xsd:attribute name="allowoverlap" type="s:ST_TrueFalse"/>
+  <xsd:attribute name="userdrawn" type="s:ST_TrueFalse"/>
+  <xsd:attribute name="bordertopcolor" type="xsd:string"/>
+  <xsd:attribute name="borderleftcolor" type="xsd:string"/>
+  <xsd:attribute name="borderbottomcolor" type="xsd:string"/>
+  <xsd:attribute name="borderrightcolor" type="xsd:string"/>
+  <xsd:attribute name="connecttype" type="ST_ConnectType"/>
+  <xsd:attribute name="connectlocs" type="xsd:string"/>
+  <xsd:attribute name="connectangles" type="xsd:string"/>
+  <xsd:attribute name="master" type="xsd:string"/>
+  <xsd:attribute name="extrusionok" type="s:ST_TrueFalse"/>
+  <xsd:attribute name="href" type="xsd:string"/>
+  <xsd:attribute name="althref" type="xsd:string"/>
+  <xsd:attribute name="title" type="xsd:string"/>
+  <xsd:attribute name="singleclick" type="s:ST_TrueFalse"/>
+  <xsd:attribute name="oleid" type="xsd:float"/>
+  <xsd:attribute name="detectmouseclick" type="s:ST_TrueFalse"/>
+  <xsd:attribute name="movie" type="xsd:float"/>
+  <xsd:attribute name="spid" type="xsd:string"/>
+  <xsd:attribute name="opacity2" type="xsd:string"/>
+  <xsd:attribute name="relid" type="r:ST_RelationshipId"/>
+  <xsd:attribute name="dgmlayout" type="ST_DiagramLayout"/>
+  <xsd:attribute name="dgmnodekind" type="xsd:integer"/>
+  <xsd:attribute name="dgmlayoutmru" type="ST_DiagramLayout"/>
+  <xsd:attribute name="gfxdata" type="xsd:base64Binary"/>
+  <xsd:attribute name="tableproperties" type="xsd:string"/>
+  <xsd:attribute name="tablelimits" type="xsd:string"/>
+  <xsd:element name="shapedefaults" type="CT_ShapeDefaults"/>
+  <xsd:element name="shapelayout" type="CT_ShapeLayout"/>
+  <xsd:element name="signatureline" type="CT_SignatureLine"/>
+  <xsd:element name="ink" type="CT_Ink"/>
+  <xsd:element name="diagram" type="CT_Diagram"/>
+  <xsd:element name="equationxml" type="CT_EquationXml"/>
+  <xsd:complexType name="CT_ShapeDefaults">
+    <xsd:all minOccurs="0">
+      <xsd:element ref="v:fill" minOccurs="0"/>
+      <xsd:element ref="v:stroke" minOccurs="0"/>
+      <xsd:element ref="v:textbox" minOccurs="0"/>
+      <xsd:element ref="v:shadow" minOccurs="0"/>
+      <xsd:element ref="skew" minOccurs="0"/>
+      <xsd:element ref="extrusion" minOccurs="0"/>
+      <xsd:element ref="callout" minOccurs="0"/>
+      <xsd:element ref="lock" minOccurs="0"/>
+      <xsd:element name="colormru" minOccurs="0" type="CT_ColorMru"/>
+      <xsd:element name="colormenu" minOccurs="0" type="CT_ColorMenu"/>
+    </xsd:all>
+    <xsd:attributeGroup ref="v:AG_Ext"/>
+    <xsd:attribute name="spidmax" type="xsd:integer" use="optional"/>
+    <xsd:attribute name="style" type="xsd:string" use="optional"/>
+    <xsd:attribute name="fill" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="fillcolor" type="s:ST_ColorType" use="optional"/>
+    <xsd:attribute name="stroke" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="strokecolor" type="s:ST_ColorType"/>
+    <xsd:attribute name="allowincell" form="qualified" type="s:ST_TrueFalse"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Ink">
+    <xsd:sequence/>
+    <xsd:attribute name="i" type="xsd:string"/>
+    <xsd:attribute name="annotation" type="s:ST_TrueFalse"/>
+    <xsd:attribute name="contentType" type="ST_ContentType" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SignatureLine">
+    <xsd:attributeGroup ref="v:AG_Ext"/>
+    <xsd:attribute name="issignatureline" type="s:ST_TrueFalse"/>
+    <xsd:attribute name="id" type="s:ST_Guid"/>
+    <xsd:attribute name="provid" type="s:ST_Guid"/>
+    <xsd:attribute name="signinginstructionsset" type="s:ST_TrueFalse"/>
+    <xsd:attribute name="allowcomments" type="s:ST_TrueFalse"/>
+    <xsd:attribute name="showsigndate" type="s:ST_TrueFalse"/>
+    <xsd:attribute name="suggestedsigner" type="xsd:string" form="qualified"/>
+    <xsd:attribute name="suggestedsigner2" type="xsd:string" form="qualified"/>
+    <xsd:attribute name="suggestedsigneremail" type="xsd:string" form="qualified"/>
+    <xsd:attribute name="signinginstructions" type="xsd:string"/>
+    <xsd:attribute name="addlxml" type="xsd:string"/>
+    <xsd:attribute name="sigprovurl" type="xsd:string"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ShapeLayout">
+    <xsd:all>
+      <xsd:element name="idmap" type="CT_IdMap" minOccurs="0"/>
+      <xsd:element name="regrouptable" type="CT_RegroupTable" minOccurs="0"/>
+      <xsd:element name="rules" type="CT_Rules" minOccurs="0"/>
+    </xsd:all>
+    <xsd:attributeGroup ref="v:AG_Ext"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_IdMap">
+    <xsd:attributeGroup ref="v:AG_Ext"/>
+    <xsd:attribute name="data" type="xsd:string" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_RegroupTable">
+    <xsd:sequence>
+      <xsd:element name="entry" type="CT_Entry" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attributeGroup ref="v:AG_Ext"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Entry">
+    <xsd:attribute name="new" type="xsd:int" use="optional"/>
+    <xsd:attribute name="old" type="xsd:int" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Rules">
+    <xsd:sequence>
+      <xsd:element name="r" type="CT_R" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attributeGroup ref="v:AG_Ext"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_R">
+    <xsd:sequence>
+      <xsd:element name="proxy" type="CT_Proxy" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:string" use="required"/>
+    <xsd:attribute name="type" type="ST_RType" use="optional"/>
+    <xsd:attribute name="how" type="ST_How" use="optional"/>
+    <xsd:attribute name="idref" type="xsd:string" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Proxy">
+    <xsd:attribute name="start" type="s:ST_TrueFalseBlank" use="optional" default="false"/>
+    <xsd:attribute name="end" type="s:ST_TrueFalseBlank" use="optional" default="false"/>
+    <xsd:attribute name="idref" type="xsd:string" use="optional"/>
+    <xsd:attribute name="connectloc" type="xsd:int" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Diagram">
+    <xsd:sequence>
+      <xsd:element name="relationtable" type="CT_RelationTable" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attributeGroup ref="v:AG_Ext"/>
+    <xsd:attribute name="dgmstyle" type="xsd:integer" use="optional"/>
+    <xsd:attribute name="autoformat" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="reverse" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="autolayout" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="dgmscalex" type="xsd:integer" use="optional"/>
+    <xsd:attribute name="dgmscaley" type="xsd:integer" use="optional"/>
+    <xsd:attribute name="dgmfontsize" type="xsd:integer" use="optional"/>
+    <xsd:attribute name="constrainbounds" type="xsd:string" use="optional"/>
+    <xsd:attribute name="dgmbasetextscale" type="xsd:integer" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_EquationXml">
+    <xsd:sequence>
+      <xsd:any namespace="##any"/>
+    </xsd:sequence>
+    <xsd:attribute name="contentType" type="ST_AlternateMathContentType" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_AlternateMathContentType">
+    <xsd:restriction base="xsd:string"/>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_RelationTable">
+    <xsd:sequence>
+      <xsd:element name="rel" type="CT_Relation" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attributeGroup ref="v:AG_Ext"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Relation">
+    <xsd:attributeGroup ref="v:AG_Ext"/>
+    <xsd:attribute name="idsrc" type="xsd:string" use="optional"/>
+    <xsd:attribute name="iddest" type="xsd:string" use="optional"/>
+    <xsd:attribute name="idcntr" type="xsd:string" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ColorMru">
+    <xsd:attributeGroup ref="v:AG_Ext"/>
+    <xsd:attribute name="colors" type="xsd:string"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ColorMenu">
+    <xsd:attributeGroup ref="v:AG_Ext"/>
+    <xsd:attribute name="strokecolor" type="s:ST_ColorType"/>
+    <xsd:attribute name="fillcolor" type="s:ST_ColorType"/>
+    <xsd:attribute name="shadowcolor" type="s:ST_ColorType"/>
+    <xsd:attribute name="extrusioncolor" type="s:ST_ColorType"/>
+  </xsd:complexType>
+  <xsd:element name="skew" type="CT_Skew"/>
+  <xsd:element name="extrusion" type="CT_Extrusion"/>
+  <xsd:element name="callout" type="CT_Callout"/>
+  <xsd:element name="lock" type="CT_Lock"/>
+  <xsd:element name="OLEObject" type="CT_OLEObject"/>
+  <xsd:element name="complex" type="CT_Complex"/>
+  <xsd:element name="left" type="CT_StrokeChild"/>
+  <xsd:element name="top" type="CT_StrokeChild"/>
+  <xsd:element name="right" type="CT_StrokeChild"/>
+  <xsd:element name="bottom" type="CT_StrokeChild"/>
+  <xsd:element name="column" type="CT_StrokeChild"/>
+  <xsd:element name="clippath" type="CT_ClipPath"/>
+  <xsd:element name="fill" type="CT_Fill"/>
+  <xsd:complexType name="CT_Skew">
+    <xsd:attributeGroup ref="v:AG_Ext"/>
+    <xsd:attribute name="id" type="xsd:string" use="optional"/>
+    <xsd:attribute name="on" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="offset" type="xsd:string" use="optional"/>
+    <xsd:attribute name="origin" type="xsd:string" use="optional"/>
+    <xsd:attribute name="matrix" type="xsd:string" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Extrusion">
+    <xsd:attributeGroup ref="v:AG_Ext"/>
+    <xsd:attribute name="on" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="type" type="ST_ExtrusionType" default="parallel" use="optional"/>
+    <xsd:attribute name="render" type="ST_ExtrusionRender" default="solid" use="optional"/>
+    <xsd:attribute name="viewpointorigin" type="xsd:string" use="optional"/>
+    <xsd:attribute name="viewpoint" type="xsd:string" use="optional"/>
+    <xsd:attribute name="plane" type="ST_ExtrusionPlane" default="XY" use="optional"/>
+    <xsd:attribute name="skewangle" type="xsd:float" use="optional"/>
+    <xsd:attribute name="skewamt" type="xsd:string" use="optional"/>
+    <xsd:attribute name="foredepth" type="xsd:string" use="optional"/>
+    <xsd:attribute name="backdepth" type="xsd:string" use="optional"/>
+    <xsd:attribute name="orientation" type="xsd:string" use="optional"/>
+    <xsd:attribute name="orientationangle" type="xsd:float" use="optional"/>
+    <xsd:attribute name="lockrotationcenter" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="autorotationcenter" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="rotationcenter" type="xsd:string" use="optional"/>
+    <xsd:attribute name="rotationangle" type="xsd:string" use="optional"/>
+    <xsd:attribute name="colormode" type="ST_ColorMode" use="optional"/>
+    <xsd:attribute name="color" type="s:ST_ColorType" use="optional"/>
+    <xsd:attribute name="shininess" type="xsd:float" use="optional"/>
+    <xsd:attribute name="specularity" type="xsd:string" use="optional"/>
+    <xsd:attribute name="diffusity" type="xsd:string" use="optional"/>
+    <xsd:attribute name="metal" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="edge" type="xsd:string" use="optional"/>
+    <xsd:attribute name="facet" type="xsd:string" use="optional"/>
+    <xsd:attribute name="lightface" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="brightness" type="xsd:string" use="optional"/>
+    <xsd:attribute name="lightposition" type="xsd:string" use="optional"/>
+    <xsd:attribute name="lightlevel" type="xsd:string" use="optional"/>
+    <xsd:attribute name="lightharsh" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="lightposition2" type="xsd:string" use="optional"/>
+    <xsd:attribute name="lightlevel2" type="xsd:string" use="optional"/>
+    <xsd:attribute name="lightharsh2" type="s:ST_TrueFalse" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Callout">
+    <xsd:attributeGroup ref="v:AG_Ext"/>
+    <xsd:attribute name="on" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="type" type="xsd:string" use="optional"/>
+    <xsd:attribute name="gap" type="xsd:string" use="optional"/>
+    <xsd:attribute name="angle" type="ST_Angle" use="optional"/>
+    <xsd:attribute name="dropauto" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="drop" type="ST_CalloutDrop" use="optional"/>
+    <xsd:attribute name="distance" type="xsd:string" use="optional"/>
+    <xsd:attribute name="lengthspecified" type="s:ST_TrueFalse" default="f" use="optional"/>
+    <xsd:attribute name="length" type="xsd:string" use="optional"/>
+    <xsd:attribute name="accentbar" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="textborder" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="minusx" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="minusy" type="s:ST_TrueFalse" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Lock">
+    <xsd:attributeGroup ref="v:AG_Ext"/>
+    <xsd:attribute name="position" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="selection" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="grouping" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="ungrouping" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="rotation" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="cropping" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="verticies" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="adjusthandles" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="text" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="aspectratio" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="shapetype" type="s:ST_TrueFalse" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_OLEObject">
+    <xsd:sequence>
+      <xsd:element name="LinkType" type="ST_OLELinkType" minOccurs="0"/>
+      <xsd:element name="LockedField" type="s:ST_TrueFalseBlank" minOccurs="0"/>
+      <xsd:element name="FieldCodes" type="xsd:string" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="Type" type="ST_OLEType" use="optional"/>
+    <xsd:attribute name="ProgID" type="xsd:string" use="optional"/>
+    <xsd:attribute name="ShapeID" type="xsd:string" use="optional"/>
+    <xsd:attribute name="DrawAspect" type="ST_OLEDrawAspect" use="optional"/>
+    <xsd:attribute name="ObjectID" type="xsd:string" use="optional"/>
+    <xsd:attribute ref="r:id" use="optional"/>
+    <xsd:attribute name="UpdateMode" type="ST_OLEUpdateMode" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Complex">
+    <xsd:attributeGroup ref="v:AG_Ext"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_StrokeChild">
+    <xsd:attributeGroup ref="v:AG_Ext"/>
+    <xsd:attribute name="on" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="weight" type="xsd:string" use="optional"/>
+    <xsd:attribute name="color" type="s:ST_ColorType" use="optional"/>
+    <xsd:attribute name="color2" type="s:ST_ColorType" use="optional"/>
+    <xsd:attribute name="opacity" type="xsd:string" use="optional"/>
+    <xsd:attribute name="linestyle" type="v:ST_StrokeLineStyle" use="optional"/>
+    <xsd:attribute name="miterlimit" type="xsd:decimal" use="optional"/>
+    <xsd:attribute name="joinstyle" type="v:ST_StrokeJoinStyle" use="optional"/>
+    <xsd:attribute name="endcap" type="v:ST_StrokeEndCap" use="optional"/>
+    <xsd:attribute name="dashstyle" type="xsd:string" use="optional"/>
+    <xsd:attribute name="insetpen" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="filltype" type="v:ST_FillType" use="optional"/>
+    <xsd:attribute name="src" type="xsd:string" use="optional"/>
+    <xsd:attribute name="imageaspect" type="v:ST_ImageAspect" use="optional"/>
+    <xsd:attribute name="imagesize" type="xsd:string" use="optional"/>
+    <xsd:attribute name="imagealignshape" type="s:ST_TrueFalse" use="optional"/>
+    <xsd:attribute name="startarrow" type="v:ST_StrokeArrowType" use="optional"/>
+    <xsd:attribute name="startarrowwidth" type="v:ST_StrokeArrowWidth" use="optional"/>
+    <xsd:attribute name="startarrowlength" type="v:ST_StrokeArrowLength" use="optional"/>
+    <xsd:attribute name="endarrow" type="v:ST_StrokeArrowType" use="optional"/>
+    <xsd:attribute name="endarrowwidth" type="v:ST_StrokeArrowWidth" use="optional"/>
+    <xsd:attribute name="endarrowlength" type="v:ST_StrokeArrowLength" use="optional"/>
+    <xsd:attribute ref="href"/>
+    <xsd:attribute ref="althref"/>
+    <xsd:attribute ref="title"/>
+    <xsd:attribute ref="forcedash"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ClipPath">
+    <xsd:attribute name="v" type="xsd:string" use="required" form="qualified"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Fill">
+    <xsd:attributeGroup ref="v:AG_Ext"/>
+    <xsd:attribute name="type" type="ST_FillType"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_RType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="arc"/>
+      <xsd:enumeration value="callout"/>
+      <xsd:enumeration value="connector"/>
+      <xsd:enumeration value="align"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_How">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="top"/>
+      <xsd:enumeration value="middle"/>
+      <xsd:enumeration value="bottom"/>
+      <xsd:enumeration value="left"/>
+      <xsd:enumeration value="center"/>
+      <xsd:enumeration value="right"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_BWMode">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="color"/>
+      <xsd:enumeration value="auto"/>
+      <xsd:enumeration value="grayScale"/>
+      <xsd:enumeration value="lightGrayscale"/>
+      <xsd:enumeration value="inverseGray"/>
+      <xsd:enumeration value="grayOutline"/>
+      <xsd:enumeration value="highContrast"/>
+      <xsd:enumeration value="black"/>
+      <xsd:enumeration value="white"/>
+      <xsd:enumeration value="hide"/>
+      <xsd:enumeration value="undrawn"/>
+      <xsd:enumeration value="blackTextAndLines"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_ScreenSize">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="544,376"/>
+      <xsd:enumeration value="640,480"/>
+      <xsd:enumeration value="720,512"/>
+      <xsd:enumeration value="800,600"/>
+      <xsd:enumeration value="1024,768"/>
+      <xsd:enumeration value="1152,862"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_InsetMode">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="auto"/>
+      <xsd:enumeration value="custom"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_ColorMode">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="auto"/>
+      <xsd:enumeration value="custom"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_ContentType">
+    <xsd:restriction base="xsd:string"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_DiagramLayout">
+    <xsd:restriction base="xsd:integer">
+      <xsd:enumeration value="0"/>
+      <xsd:enumeration value="1"/>
+      <xsd:enumeration value="2"/>
+      <xsd:enumeration value="3"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_ExtrusionType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="perspective"/>
+      <xsd:enumeration value="parallel"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_ExtrusionRender">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="solid"/>
+      <xsd:enumeration value="wireFrame"/>
+      <xsd:enumeration value="boundingCube"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_ExtrusionPlane">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="XY"/>
+      <xsd:enumeration value="ZX"/>
+      <xsd:enumeration value="YZ"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_Angle">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="any"/>
+      <xsd:enumeration value="30"/>
+      <xsd:enumeration value="45"/>
+      <xsd:enumeration value="60"/>
+      <xsd:enumeration value="90"/>
+      <xsd:enumeration value="auto"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_CalloutDrop">
+    <xsd:restriction base="xsd:string"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_CalloutPlacement">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="top"/>
+      <xsd:enumeration value="center"/>
+      <xsd:enumeration value="bottom"/>
+      <xsd:enumeration value="user"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_ConnectorType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="straight"/>
+      <xsd:enumeration value="elbow"/>
+      <xsd:enumeration value="curved"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_HrAlign">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="left"/>
+      <xsd:enumeration value="right"/>
+      <xsd:enumeration value="center"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_ConnectType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="rect"/>
+      <xsd:enumeration value="segments"/>
+      <xsd:enumeration value="custom"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_OLELinkType">
+    <xsd:restriction base="xsd:string"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_OLEType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="Embed"/>
+      <xsd:enumeration value="Link"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_OLEDrawAspect">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="Content"/>
+      <xsd:enumeration value="Icon"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_OLEUpdateMode">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="Always"/>
+      <xsd:enumeration value="OnCall"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_FillType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="gradientCenter"/>
+      <xsd:enumeration value="solid"/>
+      <xsd:enumeration value="pattern"/>
+      <xsd:enumeration value="tile"/>
+      <xsd:enumeration value="frame"/>
+      <xsd:enumeration value="gradientUnscaled"/>
+      <xsd:enumeration value="gradientRadial"/>
+      <xsd:enumeration value="gradient"/>
+      <xsd:enumeration value="background"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+</xsd:schema>

--- a/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/vml-presentationDrawing.xsd
+++ b/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/vml-presentationDrawing.xsd
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns="urn:schemas-microsoft-com:office:powerpoint"
+  targetNamespace="urn:schemas-microsoft-com:office:powerpoint" elementFormDefault="qualified"
+  attributeFormDefault="unqualified">
+  <xsd:element name="iscomment" type="CT_Empty"/>
+  <xsd:element name="textdata" type="CT_Rel"/>
+  <xsd:complexType name="CT_Empty"/>
+  <xsd:complexType name="CT_Rel">
+    <xsd:attribute name="id" type="xsd:string"/>
+  </xsd:complexType>
+</xsd:schema>

--- a/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/vml-spreadsheetDrawing.xsd
+++ b/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/vml-spreadsheetDrawing.xsd
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns="urn:schemas-microsoft-com:office:excel"
+  xmlns:s="http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"
+  targetNamespace="urn:schemas-microsoft-com:office:excel" elementFormDefault="qualified"
+  attributeFormDefault="unqualified">
+  <xsd:import namespace="http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"
+    schemaLocation="shared-commonSimpleTypes.xsd"/>
+  <xsd:element name="ClientData" type="CT_ClientData"/>
+  <xsd:complexType name="CT_ClientData">
+    <xsd:choice minOccurs="0" maxOccurs="unbounded">
+      <xsd:element name="MoveWithCells" type="s:ST_TrueFalseBlank"/>
+      <xsd:element name="SizeWithCells" type="s:ST_TrueFalseBlank"/>
+      <xsd:element name="Anchor" type="xsd:string"/>
+      <xsd:element name="Locked" type="s:ST_TrueFalseBlank"/>
+      <xsd:element name="DefaultSize" type="s:ST_TrueFalseBlank"/>
+      <xsd:element name="PrintObject" type="s:ST_TrueFalseBlank"/>
+      <xsd:element name="Disabled" type="s:ST_TrueFalseBlank"/>
+      <xsd:element name="AutoFill" type="s:ST_TrueFalseBlank"/>
+      <xsd:element name="AutoLine" type="s:ST_TrueFalseBlank"/>
+      <xsd:element name="AutoPict" type="s:ST_TrueFalseBlank"/>
+      <xsd:element name="FmlaMacro" type="xsd:string"/>
+      <xsd:element name="TextHAlign" type="xsd:string"/>
+      <xsd:element name="TextVAlign" type="xsd:string"/>
+      <xsd:element name="LockText" type="s:ST_TrueFalseBlank"/>
+      <xsd:element name="JustLastX" type="s:ST_TrueFalseBlank"/>
+      <xsd:element name="SecretEdit" type="s:ST_TrueFalseBlank"/>
+      <xsd:element name="Default" type="s:ST_TrueFalseBlank"/>
+      <xsd:element name="Help" type="s:ST_TrueFalseBlank"/>
+      <xsd:element name="Cancel" type="s:ST_TrueFalseBlank"/>
+      <xsd:element name="Dismiss" type="s:ST_TrueFalseBlank"/>
+      <xsd:element name="Accel" type="xsd:integer"/>
+      <xsd:element name="Accel2" type="xsd:integer"/>
+      <xsd:element name="Row" type="xsd:integer"/>
+      <xsd:element name="Column" type="xsd:integer"/>
+      <xsd:element name="Visible" type="s:ST_TrueFalseBlank"/>
+      <xsd:element name="RowHidden" type="s:ST_TrueFalseBlank"/>
+      <xsd:element name="ColHidden" type="s:ST_TrueFalseBlank"/>
+      <xsd:element name="VTEdit" type="xsd:integer"/>
+      <xsd:element name="MultiLine" type="s:ST_TrueFalseBlank"/>
+      <xsd:element name="VScroll" type="s:ST_TrueFalseBlank"/>
+      <xsd:element name="ValidIds" type="s:ST_TrueFalseBlank"/>
+      <xsd:element name="FmlaRange" type="xsd:string"/>
+      <xsd:element name="WidthMin" type="xsd:integer"/>
+      <xsd:element name="Sel" type="xsd:integer"/>
+      <xsd:element name="NoThreeD2" type="s:ST_TrueFalseBlank"/>
+      <xsd:element name="SelType" type="xsd:string"/>
+      <xsd:element name="MultiSel" type="xsd:string"/>
+      <xsd:element name="LCT" type="xsd:string"/>
+      <xsd:element name="ListItem" type="xsd:string"/>
+      <xsd:element name="DropStyle" type="xsd:string"/>
+      <xsd:element name="Colored" type="s:ST_TrueFalseBlank"/>
+      <xsd:element name="DropLines" type="xsd:integer"/>
+      <xsd:element name="Checked" type="xsd:integer"/>
+      <xsd:element name="FmlaLink" type="xsd:string"/>
+      <xsd:element name="FmlaPict" type="xsd:string"/>
+      <xsd:element name="NoThreeD" type="s:ST_TrueFalseBlank"/>
+      <xsd:element name="FirstButton" type="s:ST_TrueFalseBlank"/>
+      <xsd:element name="FmlaGroup" type="xsd:string"/>
+      <xsd:element name="Val" type="xsd:integer"/>
+      <xsd:element name="Min" type="xsd:integer"/>
+      <xsd:element name="Max" type="xsd:integer"/>
+      <xsd:element name="Inc" type="xsd:integer"/>
+      <xsd:element name="Page" type="xsd:integer"/>
+      <xsd:element name="Horiz" type="s:ST_TrueFalseBlank"/>
+      <xsd:element name="Dx" type="xsd:integer"/>
+      <xsd:element name="MapOCX" type="s:ST_TrueFalseBlank"/>
+      <xsd:element name="CF" type="ST_CF"/>
+      <xsd:element name="Camera" type="s:ST_TrueFalseBlank"/>
+      <xsd:element name="RecalcAlways" type="s:ST_TrueFalseBlank"/>
+      <xsd:element name="AutoScale" type="s:ST_TrueFalseBlank"/>
+      <xsd:element name="DDE" type="s:ST_TrueFalseBlank"/>
+      <xsd:element name="UIObj" type="s:ST_TrueFalseBlank"/>
+      <xsd:element name="ScriptText" type="xsd:string"/>
+      <xsd:element name="ScriptExtended" type="xsd:string"/>
+      <xsd:element name="ScriptLanguage" type="xsd:nonNegativeInteger"/>
+      <xsd:element name="ScriptLocation" type="xsd:nonNegativeInteger"/>
+      <xsd:element name="FmlaTxbx" type="xsd:string"/>
+    </xsd:choice>
+    <xsd:attribute name="ObjectType" type="ST_ObjectType" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_CF">
+    <xsd:restriction base="xsd:string"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_ObjectType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="Button"/>
+      <xsd:enumeration value="Checkbox"/>
+      <xsd:enumeration value="Dialog"/>
+      <xsd:enumeration value="Drop"/>
+      <xsd:enumeration value="Edit"/>
+      <xsd:enumeration value="GBox"/>
+      <xsd:enumeration value="Label"/>
+      <xsd:enumeration value="LineA"/>
+      <xsd:enumeration value="List"/>
+      <xsd:enumeration value="Movie"/>
+      <xsd:enumeration value="Note"/>
+      <xsd:enumeration value="Pict"/>
+      <xsd:enumeration value="Radio"/>
+      <xsd:enumeration value="RectA"/>
+      <xsd:enumeration value="Scroll"/>
+      <xsd:enumeration value="Spin"/>
+      <xsd:enumeration value="Shape"/>
+      <xsd:enumeration value="Group"/>
+      <xsd:enumeration value="Rect"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+</xsd:schema>

--- a/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/vml-wordprocessingDrawing.xsd
+++ b/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/vml-wordprocessingDrawing.xsd
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns="urn:schemas-microsoft-com:office:word"
+  targetNamespace="urn:schemas-microsoft-com:office:word" elementFormDefault="qualified"
+  attributeFormDefault="unqualified">
+  <xsd:element name="bordertop" type="CT_Border"/>
+  <xsd:element name="borderleft" type="CT_Border"/>
+  <xsd:element name="borderright" type="CT_Border"/>
+  <xsd:element name="borderbottom" type="CT_Border"/>
+  <xsd:complexType name="CT_Border">
+    <xsd:attribute name="type" type="ST_BorderType" use="optional"/>
+    <xsd:attribute name="width" type="xsd:positiveInteger" use="optional"/>
+    <xsd:attribute name="shadow" type="ST_BorderShadow" use="optional"/>
+  </xsd:complexType>
+  <xsd:element name="wrap" type="CT_Wrap"/>
+  <xsd:complexType name="CT_Wrap">
+    <xsd:attribute name="type" type="ST_WrapType" use="optional"/>
+    <xsd:attribute name="side" type="ST_WrapSide" use="optional"/>
+    <xsd:attribute name="anchorx" type="ST_HorizontalAnchor" use="optional"/>
+    <xsd:attribute name="anchory" type="ST_VerticalAnchor" use="optional"/>
+  </xsd:complexType>
+  <xsd:element name="anchorlock" type="CT_AnchorLock"/>
+  <xsd:complexType name="CT_AnchorLock"/>
+  <xsd:simpleType name="ST_BorderType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="single"/>
+      <xsd:enumeration value="thick"/>
+      <xsd:enumeration value="double"/>
+      <xsd:enumeration value="hairline"/>
+      <xsd:enumeration value="dot"/>
+      <xsd:enumeration value="dash"/>
+      <xsd:enumeration value="dotDash"/>
+      <xsd:enumeration value="dashDotDot"/>
+      <xsd:enumeration value="triple"/>
+      <xsd:enumeration value="thinThickSmall"/>
+      <xsd:enumeration value="thickThinSmall"/>
+      <xsd:enumeration value="thickBetweenThinSmall"/>
+      <xsd:enumeration value="thinThick"/>
+      <xsd:enumeration value="thickThin"/>
+      <xsd:enumeration value="thickBetweenThin"/>
+      <xsd:enumeration value="thinThickLarge"/>
+      <xsd:enumeration value="thickThinLarge"/>
+      <xsd:enumeration value="thickBetweenThinLarge"/>
+      <xsd:enumeration value="wave"/>
+      <xsd:enumeration value="doubleWave"/>
+      <xsd:enumeration value="dashedSmall"/>
+      <xsd:enumeration value="dashDotStroked"/>
+      <xsd:enumeration value="threeDEmboss"/>
+      <xsd:enumeration value="threeDEngrave"/>
+      <xsd:enumeration value="HTMLOutset"/>
+      <xsd:enumeration value="HTMLInset"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_BorderShadow">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="t"/>
+      <xsd:enumeration value="true"/>
+      <xsd:enumeration value="f"/>
+      <xsd:enumeration value="false"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_WrapType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="topAndBottom"/>
+      <xsd:enumeration value="square"/>
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="tight"/>
+      <xsd:enumeration value="through"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_WrapSide">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="both"/>
+      <xsd:enumeration value="left"/>
+      <xsd:enumeration value="right"/>
+      <xsd:enumeration value="largest"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_HorizontalAnchor">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="margin"/>
+      <xsd:enumeration value="page"/>
+      <xsd:enumeration value="text"/>
+      <xsd:enumeration value="char"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_VerticalAnchor">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="margin"/>
+      <xsd:enumeration value="page"/>
+      <xsd:enumeration value="text"/>
+      <xsd:enumeration value="line"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+</xsd:schema>

--- a/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/wml.xsd
+++ b/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/wml.xsd
@@ -1,0 +1,3646 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math"
+  xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+  xmlns:sl="http://schemas.openxmlformats.org/schemaLibrary/2006/main"
+  xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+  xmlns="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+  xmlns:s="http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+  elementFormDefault="qualified" attributeFormDefault="qualified" blockDefault="#all"
+  targetNamespace="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <xsd:import namespace="http://schemas.openxmlformats.org/markup-compatibility/2006" schemaLocation="../mce/mc.xsd"/>
+  <xsd:import namespace="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+    schemaLocation="dml-wordprocessingDrawing.xsd"/>
+  <xsd:import namespace="http://schemas.openxmlformats.org/officeDocument/2006/math"
+    schemaLocation="shared-math.xsd"/>
+  <xsd:import namespace="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+    schemaLocation="shared-relationshipReference.xsd"/>
+  <xsd:import namespace="http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"
+    schemaLocation="shared-commonSimpleTypes.xsd"/>
+  <xsd:import namespace="http://schemas.openxmlformats.org/schemaLibrary/2006/main"
+    schemaLocation="shared-customXmlSchemaProperties.xsd"/>
+  <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+  <xsd:complexType name="CT_Empty"/>
+  <xsd:complexType name="CT_OnOff">
+    <xsd:attribute name="val" type="s:ST_OnOff"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_LongHexNumber">
+    <xsd:restriction base="xsd:hexBinary">
+      <xsd:length value="4"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_LongHexNumber">
+    <xsd:attribute name="val" type="ST_LongHexNumber" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_ShortHexNumber">
+    <xsd:restriction base="xsd:hexBinary">
+      <xsd:length value="2"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_UcharHexNumber">
+    <xsd:restriction base="xsd:hexBinary">
+      <xsd:length value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Charset">
+    <xsd:attribute name="val" type="ST_UcharHexNumber" use="optional"/>
+    <xsd:attribute name="characterSet" type="s:ST_String" use="optional" default="ISO-8859-1"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_DecimalNumberOrPercent">
+    <xsd:union memberTypes="ST_UnqualifiedPercentage s:ST_Percentage"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_UnqualifiedPercentage">
+    <xsd:restriction base="xsd:decimal"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_DecimalNumber">
+    <xsd:restriction base="xsd:integer"/>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_DecimalNumber">
+    <xsd:attribute name="val" type="ST_DecimalNumber" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_UnsignedDecimalNumber">
+    <xsd:attribute name="val" type="s:ST_UnsignedDecimalNumber" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DecimalNumberOrPrecent">
+    <xsd:attribute name="val" type="ST_DecimalNumberOrPercent" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TwipsMeasure">
+    <xsd:attribute name="val" type="s:ST_TwipsMeasure" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_SignedTwipsMeasure">
+    <xsd:union memberTypes="xsd:integer s:ST_UniversalMeasure"/>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_SignedTwipsMeasure">
+    <xsd:attribute name="val" type="ST_SignedTwipsMeasure" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_PixelsMeasure">
+    <xsd:restriction base="s:ST_UnsignedDecimalNumber"/>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_PixelsMeasure">
+    <xsd:attribute name="val" type="ST_PixelsMeasure" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_HpsMeasure">
+    <xsd:union memberTypes="s:ST_UnsignedDecimalNumber s:ST_PositiveUniversalMeasure"/>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_HpsMeasure">
+    <xsd:attribute name="val" type="ST_HpsMeasure" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_SignedHpsMeasure">
+    <xsd:union memberTypes="xsd:integer s:ST_UniversalMeasure"/>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_SignedHpsMeasure">
+    <xsd:attribute name="val" type="ST_SignedHpsMeasure" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_DateTime">
+    <xsd:restriction base="xsd:dateTime"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_MacroName">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="33"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_MacroName">
+    <xsd:attribute name="val" use="required" type="ST_MacroName"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_EighthPointMeasure">
+    <xsd:restriction base="s:ST_UnsignedDecimalNumber"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_PointMeasure">
+    <xsd:restriction base="s:ST_UnsignedDecimalNumber"/>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_String">
+    <xsd:attribute name="val" type="s:ST_String" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TextScale">
+    <xsd:union memberTypes="ST_TextScalePercent ST_TextScaleDecimal"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TextScalePercent">
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="0*(600|([0-5]?[0-9]?[0-9]))%"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TextScaleDecimal">
+    <xsd:restriction base="xsd:integer">
+      <xsd:minInclusive value="0"/>
+      <xsd:maxInclusive value="600"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TextScale">
+    <xsd:attribute name="val" type="ST_TextScale"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_HighlightColor">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="black"/>
+      <xsd:enumeration value="blue"/>
+      <xsd:enumeration value="cyan"/>
+      <xsd:enumeration value="green"/>
+      <xsd:enumeration value="magenta"/>
+      <xsd:enumeration value="red"/>
+      <xsd:enumeration value="yellow"/>
+      <xsd:enumeration value="white"/>
+      <xsd:enumeration value="darkBlue"/>
+      <xsd:enumeration value="darkCyan"/>
+      <xsd:enumeration value="darkGreen"/>
+      <xsd:enumeration value="darkMagenta"/>
+      <xsd:enumeration value="darkRed"/>
+      <xsd:enumeration value="darkYellow"/>
+      <xsd:enumeration value="darkGray"/>
+      <xsd:enumeration value="lightGray"/>
+      <xsd:enumeration value="none"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Highlight">
+    <xsd:attribute name="val" type="ST_HighlightColor" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_HexColorAuto">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="auto"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_HexColor">
+    <xsd:union memberTypes="ST_HexColorAuto s:ST_HexColorRGB"/>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Color">
+    <xsd:attribute name="val" type="ST_HexColor" use="required"/>
+    <xsd:attribute name="themeColor" type="ST_ThemeColor" use="optional"/>
+    <xsd:attribute name="themeTint" type="ST_UcharHexNumber" use="optional"/>
+    <xsd:attribute name="themeShade" type="ST_UcharHexNumber" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Lang">
+    <xsd:attribute name="val" type="s:ST_Lang" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Guid">
+    <xsd:attribute name="val" type="s:ST_Guid"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_Underline">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="single"/>
+      <xsd:enumeration value="words"/>
+      <xsd:enumeration value="double"/>
+      <xsd:enumeration value="thick"/>
+      <xsd:enumeration value="dotted"/>
+      <xsd:enumeration value="dottedHeavy"/>
+      <xsd:enumeration value="dash"/>
+      <xsd:enumeration value="dashedHeavy"/>
+      <xsd:enumeration value="dashLong"/>
+      <xsd:enumeration value="dashLongHeavy"/>
+      <xsd:enumeration value="dotDash"/>
+      <xsd:enumeration value="dashDotHeavy"/>
+      <xsd:enumeration value="dotDotDash"/>
+      <xsd:enumeration value="dashDotDotHeavy"/>
+      <xsd:enumeration value="wave"/>
+      <xsd:enumeration value="wavyHeavy"/>
+      <xsd:enumeration value="wavyDouble"/>
+      <xsd:enumeration value="none"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Underline">
+    <xsd:attribute name="val" type="ST_Underline" use="optional"/>
+    <xsd:attribute name="color" type="ST_HexColor" use="optional" default="auto"/>
+    <xsd:attribute name="themeColor" type="ST_ThemeColor" use="optional"/>
+    <xsd:attribute name="themeTint" type="ST_UcharHexNumber" use="optional"/>
+    <xsd:attribute name="themeShade" type="ST_UcharHexNumber" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TextEffect">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="blinkBackground"/>
+      <xsd:enumeration value="lights"/>
+      <xsd:enumeration value="antsBlack"/>
+      <xsd:enumeration value="antsRed"/>
+      <xsd:enumeration value="shimmer"/>
+      <xsd:enumeration value="sparkle"/>
+      <xsd:enumeration value="none"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TextEffect">
+    <xsd:attribute name="val" type="ST_TextEffect" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_Border">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="nil"/>
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="single"/>
+      <xsd:enumeration value="thick"/>
+      <xsd:enumeration value="double"/>
+      <xsd:enumeration value="dotted"/>
+      <xsd:enumeration value="dashed"/>
+      <xsd:enumeration value="dotDash"/>
+      <xsd:enumeration value="dotDotDash"/>
+      <xsd:enumeration value="triple"/>
+      <xsd:enumeration value="thinThickSmallGap"/>
+      <xsd:enumeration value="thickThinSmallGap"/>
+      <xsd:enumeration value="thinThickThinSmallGap"/>
+      <xsd:enumeration value="thinThickMediumGap"/>
+      <xsd:enumeration value="thickThinMediumGap"/>
+      <xsd:enumeration value="thinThickThinMediumGap"/>
+      <xsd:enumeration value="thinThickLargeGap"/>
+      <xsd:enumeration value="thickThinLargeGap"/>
+      <xsd:enumeration value="thinThickThinLargeGap"/>
+      <xsd:enumeration value="wave"/>
+      <xsd:enumeration value="doubleWave"/>
+      <xsd:enumeration value="dashSmallGap"/>
+      <xsd:enumeration value="dashDotStroked"/>
+      <xsd:enumeration value="threeDEmboss"/>
+      <xsd:enumeration value="threeDEngrave"/>
+      <xsd:enumeration value="outset"/>
+      <xsd:enumeration value="inset"/>
+      <xsd:enumeration value="apples"/>
+      <xsd:enumeration value="archedScallops"/>
+      <xsd:enumeration value="babyPacifier"/>
+      <xsd:enumeration value="babyRattle"/>
+      <xsd:enumeration value="balloons3Colors"/>
+      <xsd:enumeration value="balloonsHotAir"/>
+      <xsd:enumeration value="basicBlackDashes"/>
+      <xsd:enumeration value="basicBlackDots"/>
+      <xsd:enumeration value="basicBlackSquares"/>
+      <xsd:enumeration value="basicThinLines"/>
+      <xsd:enumeration value="basicWhiteDashes"/>
+      <xsd:enumeration value="basicWhiteDots"/>
+      <xsd:enumeration value="basicWhiteSquares"/>
+      <xsd:enumeration value="basicWideInline"/>
+      <xsd:enumeration value="basicWideMidline"/>
+      <xsd:enumeration value="basicWideOutline"/>
+      <xsd:enumeration value="bats"/>
+      <xsd:enumeration value="birds"/>
+      <xsd:enumeration value="birdsFlight"/>
+      <xsd:enumeration value="cabins"/>
+      <xsd:enumeration value="cakeSlice"/>
+      <xsd:enumeration value="candyCorn"/>
+      <xsd:enumeration value="celticKnotwork"/>
+      <xsd:enumeration value="certificateBanner"/>
+      <xsd:enumeration value="chainLink"/>
+      <xsd:enumeration value="champagneBottle"/>
+      <xsd:enumeration value="checkedBarBlack"/>
+      <xsd:enumeration value="checkedBarColor"/>
+      <xsd:enumeration value="checkered"/>
+      <xsd:enumeration value="christmasTree"/>
+      <xsd:enumeration value="circlesLines"/>
+      <xsd:enumeration value="circlesRectangles"/>
+      <xsd:enumeration value="classicalWave"/>
+      <xsd:enumeration value="clocks"/>
+      <xsd:enumeration value="compass"/>
+      <xsd:enumeration value="confetti"/>
+      <xsd:enumeration value="confettiGrays"/>
+      <xsd:enumeration value="confettiOutline"/>
+      <xsd:enumeration value="confettiStreamers"/>
+      <xsd:enumeration value="confettiWhite"/>
+      <xsd:enumeration value="cornerTriangles"/>
+      <xsd:enumeration value="couponCutoutDashes"/>
+      <xsd:enumeration value="couponCutoutDots"/>
+      <xsd:enumeration value="crazyMaze"/>
+      <xsd:enumeration value="creaturesButterfly"/>
+      <xsd:enumeration value="creaturesFish"/>
+      <xsd:enumeration value="creaturesInsects"/>
+      <xsd:enumeration value="creaturesLadyBug"/>
+      <xsd:enumeration value="crossStitch"/>
+      <xsd:enumeration value="cup"/>
+      <xsd:enumeration value="decoArch"/>
+      <xsd:enumeration value="decoArchColor"/>
+      <xsd:enumeration value="decoBlocks"/>
+      <xsd:enumeration value="diamondsGray"/>
+      <xsd:enumeration value="doubleD"/>
+      <xsd:enumeration value="doubleDiamonds"/>
+      <xsd:enumeration value="earth1"/>
+      <xsd:enumeration value="earth2"/>
+      <xsd:enumeration value="earth3"/>
+      <xsd:enumeration value="eclipsingSquares1"/>
+      <xsd:enumeration value="eclipsingSquares2"/>
+      <xsd:enumeration value="eggsBlack"/>
+      <xsd:enumeration value="fans"/>
+      <xsd:enumeration value="film"/>
+      <xsd:enumeration value="firecrackers"/>
+      <xsd:enumeration value="flowersBlockPrint"/>
+      <xsd:enumeration value="flowersDaisies"/>
+      <xsd:enumeration value="flowersModern1"/>
+      <xsd:enumeration value="flowersModern2"/>
+      <xsd:enumeration value="flowersPansy"/>
+      <xsd:enumeration value="flowersRedRose"/>
+      <xsd:enumeration value="flowersRoses"/>
+      <xsd:enumeration value="flowersTeacup"/>
+      <xsd:enumeration value="flowersTiny"/>
+      <xsd:enumeration value="gems"/>
+      <xsd:enumeration value="gingerbreadMan"/>
+      <xsd:enumeration value="gradient"/>
+      <xsd:enumeration value="handmade1"/>
+      <xsd:enumeration value="handmade2"/>
+      <xsd:enumeration value="heartBalloon"/>
+      <xsd:enumeration value="heartGray"/>
+      <xsd:enumeration value="hearts"/>
+      <xsd:enumeration value="heebieJeebies"/>
+      <xsd:enumeration value="holly"/>
+      <xsd:enumeration value="houseFunky"/>
+      <xsd:enumeration value="hypnotic"/>
+      <xsd:enumeration value="iceCreamCones"/>
+      <xsd:enumeration value="lightBulb"/>
+      <xsd:enumeration value="lightning1"/>
+      <xsd:enumeration value="lightning2"/>
+      <xsd:enumeration value="mapPins"/>
+      <xsd:enumeration value="mapleLeaf"/>
+      <xsd:enumeration value="mapleMuffins"/>
+      <xsd:enumeration value="marquee"/>
+      <xsd:enumeration value="marqueeToothed"/>
+      <xsd:enumeration value="moons"/>
+      <xsd:enumeration value="mosaic"/>
+      <xsd:enumeration value="musicNotes"/>
+      <xsd:enumeration value="northwest"/>
+      <xsd:enumeration value="ovals"/>
+      <xsd:enumeration value="packages"/>
+      <xsd:enumeration value="palmsBlack"/>
+      <xsd:enumeration value="palmsColor"/>
+      <xsd:enumeration value="paperClips"/>
+      <xsd:enumeration value="papyrus"/>
+      <xsd:enumeration value="partyFavor"/>
+      <xsd:enumeration value="partyGlass"/>
+      <xsd:enumeration value="pencils"/>
+      <xsd:enumeration value="people"/>
+      <xsd:enumeration value="peopleWaving"/>
+      <xsd:enumeration value="peopleHats"/>
+      <xsd:enumeration value="poinsettias"/>
+      <xsd:enumeration value="postageStamp"/>
+      <xsd:enumeration value="pumpkin1"/>
+      <xsd:enumeration value="pushPinNote2"/>
+      <xsd:enumeration value="pushPinNote1"/>
+      <xsd:enumeration value="pyramids"/>
+      <xsd:enumeration value="pyramidsAbove"/>
+      <xsd:enumeration value="quadrants"/>
+      <xsd:enumeration value="rings"/>
+      <xsd:enumeration value="safari"/>
+      <xsd:enumeration value="sawtooth"/>
+      <xsd:enumeration value="sawtoothGray"/>
+      <xsd:enumeration value="scaredCat"/>
+      <xsd:enumeration value="seattle"/>
+      <xsd:enumeration value="shadowedSquares"/>
+      <xsd:enumeration value="sharksTeeth"/>
+      <xsd:enumeration value="shorebirdTracks"/>
+      <xsd:enumeration value="skyrocket"/>
+      <xsd:enumeration value="snowflakeFancy"/>
+      <xsd:enumeration value="snowflakes"/>
+      <xsd:enumeration value="sombrero"/>
+      <xsd:enumeration value="southwest"/>
+      <xsd:enumeration value="stars"/>
+      <xsd:enumeration value="starsTop"/>
+      <xsd:enumeration value="stars3d"/>
+      <xsd:enumeration value="starsBlack"/>
+      <xsd:enumeration value="starsShadowed"/>
+      <xsd:enumeration value="sun"/>
+      <xsd:enumeration value="swirligig"/>
+      <xsd:enumeration value="tornPaper"/>
+      <xsd:enumeration value="tornPaperBlack"/>
+      <xsd:enumeration value="trees"/>
+      <xsd:enumeration value="triangleParty"/>
+      <xsd:enumeration value="triangles"/>
+      <xsd:enumeration value="triangle1"/>
+      <xsd:enumeration value="triangle2"/>
+      <xsd:enumeration value="triangleCircle1"/>
+      <xsd:enumeration value="triangleCircle2"/>
+      <xsd:enumeration value="shapes1"/>
+      <xsd:enumeration value="shapes2"/>
+      <xsd:enumeration value="twistedLines1"/>
+      <xsd:enumeration value="twistedLines2"/>
+      <xsd:enumeration value="vine"/>
+      <xsd:enumeration value="waveline"/>
+      <xsd:enumeration value="weavingAngles"/>
+      <xsd:enumeration value="weavingBraid"/>
+      <xsd:enumeration value="weavingRibbon"/>
+      <xsd:enumeration value="weavingStrips"/>
+      <xsd:enumeration value="whiteFlowers"/>
+      <xsd:enumeration value="woodwork"/>
+      <xsd:enumeration value="xIllusions"/>
+      <xsd:enumeration value="zanyTriangles"/>
+      <xsd:enumeration value="zigZag"/>
+      <xsd:enumeration value="zigZagStitch"/>
+      <xsd:enumeration value="custom"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Border">
+    <xsd:attribute name="val" type="ST_Border" use="required"/>
+    <xsd:attribute name="color" type="ST_HexColor" use="optional" default="auto"/>
+    <xsd:attribute name="themeColor" type="ST_ThemeColor" use="optional"/>
+    <xsd:attribute name="themeTint" type="ST_UcharHexNumber" use="optional"/>
+    <xsd:attribute name="themeShade" type="ST_UcharHexNumber" use="optional"/>
+    <xsd:attribute name="sz" type="ST_EighthPointMeasure" use="optional"/>
+    <xsd:attribute name="space" type="ST_PointMeasure" use="optional" default="0"/>
+    <xsd:attribute name="shadow" type="s:ST_OnOff" use="optional"/>
+    <xsd:attribute name="frame" type="s:ST_OnOff" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_Shd">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="nil"/>
+      <xsd:enumeration value="clear"/>
+      <xsd:enumeration value="solid"/>
+      <xsd:enumeration value="horzStripe"/>
+      <xsd:enumeration value="vertStripe"/>
+      <xsd:enumeration value="reverseDiagStripe"/>
+      <xsd:enumeration value="diagStripe"/>
+      <xsd:enumeration value="horzCross"/>
+      <xsd:enumeration value="diagCross"/>
+      <xsd:enumeration value="thinHorzStripe"/>
+      <xsd:enumeration value="thinVertStripe"/>
+      <xsd:enumeration value="thinReverseDiagStripe"/>
+      <xsd:enumeration value="thinDiagStripe"/>
+      <xsd:enumeration value="thinHorzCross"/>
+      <xsd:enumeration value="thinDiagCross"/>
+      <xsd:enumeration value="pct5"/>
+      <xsd:enumeration value="pct10"/>
+      <xsd:enumeration value="pct12"/>
+      <xsd:enumeration value="pct15"/>
+      <xsd:enumeration value="pct20"/>
+      <xsd:enumeration value="pct25"/>
+      <xsd:enumeration value="pct30"/>
+      <xsd:enumeration value="pct35"/>
+      <xsd:enumeration value="pct37"/>
+      <xsd:enumeration value="pct40"/>
+      <xsd:enumeration value="pct45"/>
+      <xsd:enumeration value="pct50"/>
+      <xsd:enumeration value="pct55"/>
+      <xsd:enumeration value="pct60"/>
+      <xsd:enumeration value="pct62"/>
+      <xsd:enumeration value="pct65"/>
+      <xsd:enumeration value="pct70"/>
+      <xsd:enumeration value="pct75"/>
+      <xsd:enumeration value="pct80"/>
+      <xsd:enumeration value="pct85"/>
+      <xsd:enumeration value="pct87"/>
+      <xsd:enumeration value="pct90"/>
+      <xsd:enumeration value="pct95"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Shd">
+    <xsd:attribute name="val" type="ST_Shd" use="required"/>
+    <xsd:attribute name="color" type="ST_HexColor" use="optional"/>
+    <xsd:attribute name="themeColor" type="ST_ThemeColor" use="optional"/>
+    <xsd:attribute name="themeTint" type="ST_UcharHexNumber" use="optional"/>
+    <xsd:attribute name="themeShade" type="ST_UcharHexNumber" use="optional"/>
+    <xsd:attribute name="fill" type="ST_HexColor" use="optional"/>
+    <xsd:attribute name="themeFill" type="ST_ThemeColor" use="optional"/>
+    <xsd:attribute name="themeFillTint" type="ST_UcharHexNumber" use="optional"/>
+    <xsd:attribute name="themeFillShade" type="ST_UcharHexNumber" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_VerticalAlignRun">
+    <xsd:attribute name="val" type="s:ST_VerticalAlignRun" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_FitText">
+    <xsd:attribute name="val" type="s:ST_TwipsMeasure" use="required"/>
+    <xsd:attribute name="id" type="ST_DecimalNumber" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_Em">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="dot"/>
+      <xsd:enumeration value="comma"/>
+      <xsd:enumeration value="circle"/>
+      <xsd:enumeration value="underDot"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Em">
+    <xsd:attribute name="val" type="ST_Em" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Language">
+    <xsd:attribute name="val" type="s:ST_Lang" use="optional"/>
+    <xsd:attribute name="eastAsia" type="s:ST_Lang" use="optional"/>
+    <xsd:attribute name="bidi" type="s:ST_Lang" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_CombineBrackets">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="round"/>
+      <xsd:enumeration value="square"/>
+      <xsd:enumeration value="angle"/>
+      <xsd:enumeration value="curly"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_EastAsianLayout">
+    <xsd:attribute name="id" type="ST_DecimalNumber" use="optional"/>
+    <xsd:attribute name="combine" type="s:ST_OnOff" use="optional"/>
+    <xsd:attribute name="combineBrackets" type="ST_CombineBrackets" use="optional"/>
+    <xsd:attribute name="vert" type="s:ST_OnOff" use="optional"/>
+    <xsd:attribute name="vertCompress" type="s:ST_OnOff" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_HeightRule">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="auto"/>
+      <xsd:enumeration value="exact"/>
+      <xsd:enumeration value="atLeast"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_Wrap">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="auto"/>
+      <xsd:enumeration value="notBeside"/>
+      <xsd:enumeration value="around"/>
+      <xsd:enumeration value="tight"/>
+      <xsd:enumeration value="through"/>
+      <xsd:enumeration value="none"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_VAnchor">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="text"/>
+      <xsd:enumeration value="margin"/>
+      <xsd:enumeration value="page"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_HAnchor">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="text"/>
+      <xsd:enumeration value="margin"/>
+      <xsd:enumeration value="page"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_DropCap">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="drop"/>
+      <xsd:enumeration value="margin"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_FramePr">
+    <xsd:attribute name="dropCap" type="ST_DropCap" use="optional"/>
+    <xsd:attribute name="lines" type="ST_DecimalNumber" use="optional"/>
+    <xsd:attribute name="w" type="s:ST_TwipsMeasure" use="optional"/>
+    <xsd:attribute name="h" type="s:ST_TwipsMeasure" use="optional"/>
+    <xsd:attribute name="vSpace" type="s:ST_TwipsMeasure" use="optional"/>
+    <xsd:attribute name="hSpace" type="s:ST_TwipsMeasure" use="optional"/>
+    <xsd:attribute name="wrap" type="ST_Wrap" use="optional"/>
+    <xsd:attribute name="hAnchor" type="ST_HAnchor" use="optional"/>
+    <xsd:attribute name="vAnchor" type="ST_VAnchor" use="optional"/>
+    <xsd:attribute name="x" type="ST_SignedTwipsMeasure" use="optional"/>
+    <xsd:attribute name="xAlign" type="s:ST_XAlign" use="optional"/>
+    <xsd:attribute name="y" type="ST_SignedTwipsMeasure" use="optional"/>
+    <xsd:attribute name="yAlign" type="s:ST_YAlign" use="optional"/>
+    <xsd:attribute name="hRule" type="ST_HeightRule" use="optional"/>
+    <xsd:attribute name="anchorLock" type="s:ST_OnOff" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TabJc">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="clear"/>
+      <xsd:enumeration value="start"/>
+      <xsd:enumeration value="center"/>
+      <xsd:enumeration value="end"/>
+      <xsd:enumeration value="decimal"/>
+      <xsd:enumeration value="bar"/>
+      <xsd:enumeration value="num"/>
+      <xsd:enumeration value="left"/>
+      <xsd:enumeration value="right"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_TabTlc">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="dot"/>
+      <xsd:enumeration value="hyphen"/>
+      <xsd:enumeration value="underscore"/>
+      <xsd:enumeration value="heavy"/>
+      <xsd:enumeration value="middleDot"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TabStop">
+    <xsd:attribute name="val" type="ST_TabJc" use="required"/>
+    <xsd:attribute name="leader" type="ST_TabTlc" use="optional"/>
+    <xsd:attribute name="pos" type="ST_SignedTwipsMeasure" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_LineSpacingRule">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="auto"/>
+      <xsd:enumeration value="exact"/>
+      <xsd:enumeration value="atLeast"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Spacing">
+    <xsd:attribute name="before" type="s:ST_TwipsMeasure" use="optional" default="0"/>
+    <xsd:attribute name="beforeLines" type="ST_DecimalNumber" use="optional" default="0"/>
+    <xsd:attribute name="beforeAutospacing" type="s:ST_OnOff" use="optional" default="off"/>
+    <xsd:attribute name="after" type="s:ST_TwipsMeasure" use="optional" default="0"/>
+    <xsd:attribute name="afterLines" type="ST_DecimalNumber" use="optional" default="0"/>
+    <xsd:attribute name="afterAutospacing" type="s:ST_OnOff" use="optional" default="off"/>
+    <xsd:attribute name="line" type="ST_SignedTwipsMeasure" use="optional" default="0"/>
+    <xsd:attribute name="lineRule" type="ST_LineSpacingRule" use="optional" default="auto"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Ind">
+    <xsd:attribute name="start" type="ST_SignedTwipsMeasure" use="optional"/>
+    <xsd:attribute name="startChars" type="ST_DecimalNumber" use="optional"/>
+    <xsd:attribute name="end" type="ST_SignedTwipsMeasure" use="optional"/>
+    <xsd:attribute name="endChars" type="ST_DecimalNumber" use="optional"/>
+    <xsd:attribute name="left" type="ST_SignedTwipsMeasure" use="optional"/>
+    <xsd:attribute name="leftChars" type="ST_DecimalNumber" use="optional"/>
+    <xsd:attribute name="right" type="ST_SignedTwipsMeasure" use="optional"/>
+    <xsd:attribute name="rightChars" type="ST_DecimalNumber" use="optional"/>
+    <xsd:attribute name="hanging" type="s:ST_TwipsMeasure" use="optional"/>
+    <xsd:attribute name="hangingChars" type="ST_DecimalNumber" use="optional"/>
+    <xsd:attribute name="firstLine" type="s:ST_TwipsMeasure" use="optional"/>
+    <xsd:attribute name="firstLineChars" type="ST_DecimalNumber" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_Jc">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="start"/>
+      <xsd:enumeration value="center"/>
+      <xsd:enumeration value="end"/>
+      <xsd:enumeration value="both"/>
+      <xsd:enumeration value="mediumKashida"/>
+      <xsd:enumeration value="distribute"/>
+      <xsd:enumeration value="numTab"/>
+      <xsd:enumeration value="highKashida"/>
+      <xsd:enumeration value="lowKashida"/>
+      <xsd:enumeration value="thaiDistribute"/>
+      <xsd:enumeration value="left"/>
+      <xsd:enumeration value="right"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_JcTable">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="center"/>
+      <xsd:enumeration value="end"/>
+      <xsd:enumeration value="left"/>
+      <xsd:enumeration value="right"/>
+      <xsd:enumeration value="start"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Jc">
+    <xsd:attribute name="val" type="ST_Jc" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_JcTable">
+    <xsd:attribute name="val" type="ST_JcTable" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_View">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="print"/>
+      <xsd:enumeration value="outline"/>
+      <xsd:enumeration value="masterPages"/>
+      <xsd:enumeration value="normal"/>
+      <xsd:enumeration value="web"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_View">
+    <xsd:attribute name="val" type="ST_View" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_Zoom">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="fullPage"/>
+      <xsd:enumeration value="bestFit"/>
+      <xsd:enumeration value="textFit"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Zoom">
+    <xsd:attribute name="val" type="ST_Zoom" use="optional"/>
+    <xsd:attribute name="percent" type="ST_DecimalNumberOrPercent" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_WritingStyle">
+    <xsd:attribute name="lang" type="s:ST_Lang" use="required"/>
+    <xsd:attribute name="vendorID" type="s:ST_String" use="required"/>
+    <xsd:attribute name="dllVersion" type="s:ST_String" use="required"/>
+    <xsd:attribute name="nlCheck" type="s:ST_OnOff" use="optional" default="off"/>
+    <xsd:attribute name="checkStyle" type="s:ST_OnOff" use="required"/>
+    <xsd:attribute name="appName" type="s:ST_String" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_Proof">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="clean"/>
+      <xsd:enumeration value="dirty"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Proof">
+    <xsd:attribute name="spelling" type="ST_Proof" use="optional"/>
+    <xsd:attribute name="grammar" type="ST_Proof" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_DocType">
+    <xsd:restriction base="xsd:string"/>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_DocType">
+    <xsd:attribute name="val" type="ST_DocType" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_DocProtect">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="readOnly"/>
+      <xsd:enumeration value="comments"/>
+      <xsd:enumeration value="trackedChanges"/>
+      <xsd:enumeration value="forms"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:attributeGroup name="AG_Password">
+    <xsd:attribute name="algorithmName" type="s:ST_String" use="optional"/>
+    <xsd:attribute name="hashValue" type="xsd:base64Binary" use="optional"/>
+    <xsd:attribute name="saltValue" type="xsd:base64Binary" use="optional"/>
+    <xsd:attribute name="spinCount" type="ST_DecimalNumber" use="optional"/>
+  </xsd:attributeGroup>
+  <xsd:attributeGroup name="AG_TransitionalPassword">
+    <xsd:attribute name="cryptProviderType" type="s:ST_CryptProv"/>
+    <xsd:attribute name="cryptAlgorithmClass" type="s:ST_AlgClass"/>
+    <xsd:attribute name="cryptAlgorithmType" type="s:ST_AlgType"/>
+    <xsd:attribute name="cryptAlgorithmSid" type="ST_DecimalNumber"/>
+    <xsd:attribute name="cryptSpinCount" type="ST_DecimalNumber"/>
+    <xsd:attribute name="cryptProvider" type="s:ST_String"/>
+    <xsd:attribute name="algIdExt" type="ST_LongHexNumber"/>
+    <xsd:attribute name="algIdExtSource" type="s:ST_String"/>
+    <xsd:attribute name="cryptProviderTypeExt" type="ST_LongHexNumber"/>
+    <xsd:attribute name="cryptProviderTypeExtSource" type="s:ST_String"/>
+    <xsd:attribute name="hash" type="xsd:base64Binary"/>
+    <xsd:attribute name="salt" type="xsd:base64Binary"/>
+  </xsd:attributeGroup>
+  <xsd:complexType name="CT_DocProtect">
+    <xsd:attribute name="edit" type="ST_DocProtect" use="optional"/>
+    <xsd:attribute name="formatting" type="s:ST_OnOff" use="optional"/>
+    <xsd:attribute name="enforcement" type="s:ST_OnOff"/>
+    <xsd:attributeGroup ref="AG_Password"/>
+    <xsd:attributeGroup ref="AG_TransitionalPassword"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_MailMergeDocType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="catalog"/>
+      <xsd:enumeration value="envelopes"/>
+      <xsd:enumeration value="mailingLabels"/>
+      <xsd:enumeration value="formLetters"/>
+      <xsd:enumeration value="email"/>
+      <xsd:enumeration value="fax"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_MailMergeDocType">
+    <xsd:attribute name="val" type="ST_MailMergeDocType" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_MailMergeDataType">
+    <xsd:restriction base="xsd:string"/>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_MailMergeDataType">
+    <xsd:attribute name="val" type="ST_MailMergeDataType" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_MailMergeDest">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="newDocument"/>
+      <xsd:enumeration value="printer"/>
+      <xsd:enumeration value="email"/>
+      <xsd:enumeration value="fax"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_MailMergeDest">
+    <xsd:attribute name="val" type="ST_MailMergeDest" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_MailMergeOdsoFMDFieldType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="null"/>
+      <xsd:enumeration value="dbColumn"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_MailMergeOdsoFMDFieldType">
+    <xsd:attribute name="val" type="ST_MailMergeOdsoFMDFieldType" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TrackChangesView">
+    <xsd:attribute name="markup" type="s:ST_OnOff" use="optional"/>
+    <xsd:attribute name="comments" type="s:ST_OnOff" use="optional"/>
+    <xsd:attribute name="insDel" type="s:ST_OnOff" use="optional"/>
+    <xsd:attribute name="formatting" type="s:ST_OnOff" use="optional"/>
+    <xsd:attribute name="inkAnnotations" type="s:ST_OnOff" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Kinsoku">
+    <xsd:attribute name="lang" type="s:ST_Lang" use="required"/>
+    <xsd:attribute name="val" type="s:ST_String" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TextDirection">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="tb"/>
+      <xsd:enumeration value="rl"/>
+      <xsd:enumeration value="lr"/>
+      <xsd:enumeration value="tbV"/>
+      <xsd:enumeration value="rlV"/>
+      <xsd:enumeration value="lrV"/>
+      <xsd:enumeration value="btLr"/>
+      <xsd:enumeration value="lrTb"/>
+      <xsd:enumeration value="lrTbV"/>
+      <xsd:enumeration value="tbLrV"/>
+      <xsd:enumeration value="tbRl"/>
+      <xsd:enumeration value="tbRlV"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TextDirection">
+    <xsd:attribute name="val" type="ST_TextDirection" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TextAlignment">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="top"/>
+      <xsd:enumeration value="center"/>
+      <xsd:enumeration value="baseline"/>
+      <xsd:enumeration value="bottom"/>
+      <xsd:enumeration value="auto"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TextAlignment">
+    <xsd:attribute name="val" type="ST_TextAlignment" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_DisplacedByCustomXml">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="next"/>
+      <xsd:enumeration value="prev"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_AnnotationVMerge">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="cont"/>
+      <xsd:enumeration value="rest"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Markup">
+    <xsd:attribute name="id" type="ST_DecimalNumber" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TrackChange">
+    <xsd:complexContent>
+      <xsd:extension base="CT_Markup">
+        <xsd:attribute name="author" type="s:ST_String" use="required"/>
+        <xsd:attribute name="date" type="ST_DateTime" use="optional"/>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CellMergeTrackChange">
+    <xsd:complexContent>
+      <xsd:extension base="CT_TrackChange">
+        <xsd:attribute name="vMerge" type="ST_AnnotationVMerge" use="optional"/>
+        <xsd:attribute name="vMergeOrig" type="ST_AnnotationVMerge" use="optional"/>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TrackChangeRange">
+    <xsd:complexContent>
+      <xsd:extension base="CT_TrackChange">
+        <xsd:attribute name="displacedByCustomXml" type="ST_DisplacedByCustomXml" use="optional"/>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="CT_MarkupRange">
+    <xsd:complexContent>
+      <xsd:extension base="CT_Markup">
+        <xsd:attribute name="displacedByCustomXml" type="ST_DisplacedByCustomXml" use="optional"/>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="CT_BookmarkRange">
+    <xsd:complexContent>
+      <xsd:extension base="CT_MarkupRange">
+        <xsd:attribute name="colFirst" type="ST_DecimalNumber" use="optional"/>
+        <xsd:attribute name="colLast" type="ST_DecimalNumber" use="optional"/>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Bookmark">
+    <xsd:complexContent>
+      <xsd:extension base="CT_BookmarkRange">
+        <xsd:attribute name="name" type="s:ST_String" use="required"/>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="CT_MoveBookmark">
+    <xsd:complexContent>
+      <xsd:extension base="CT_Bookmark">
+        <xsd:attribute name="author" type="s:ST_String" use="required"/>
+        <xsd:attribute name="date" type="ST_DateTime" use="required"/>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Comment">
+    <xsd:complexContent>
+      <xsd:extension base="CT_TrackChange">
+        <xsd:sequence>
+          <xsd:group ref="EG_BlockLevelElts" minOccurs="0" maxOccurs="unbounded"/>
+        </xsd:sequence>
+        <xsd:attribute name="initials" type="s:ST_String" use="optional"/>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TrackChangeNumbering">
+    <xsd:complexContent>
+      <xsd:extension base="CT_TrackChange">
+        <xsd:attribute name="original" type="s:ST_String" use="optional"/>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TblPrExChange">
+    <xsd:complexContent>
+      <xsd:extension base="CT_TrackChange">
+        <xsd:sequence>
+          <xsd:element name="tblPrEx" type="CT_TblPrExBase" minOccurs="1"/>
+        </xsd:sequence>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TcPrChange">
+    <xsd:complexContent>
+      <xsd:extension base="CT_TrackChange">
+        <xsd:sequence>
+          <xsd:element name="tcPr" type="CT_TcPrInner" minOccurs="1"/>
+        </xsd:sequence>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TrPrChange">
+    <xsd:complexContent>
+      <xsd:extension base="CT_TrackChange">
+        <xsd:sequence>
+          <xsd:element name="trPr" type="CT_TrPrBase" minOccurs="1"/>
+        </xsd:sequence>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TblGridChange">
+    <xsd:complexContent>
+      <xsd:extension base="CT_Markup">
+        <xsd:sequence>
+          <xsd:element name="tblGrid" type="CT_TblGridBase"/>
+        </xsd:sequence>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TblPrChange">
+    <xsd:complexContent>
+      <xsd:extension base="CT_TrackChange">
+        <xsd:sequence>
+          <xsd:element name="tblPr" type="CT_TblPrBase"/>
+        </xsd:sequence>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SectPrChange">
+    <xsd:complexContent>
+      <xsd:extension base="CT_TrackChange">
+        <xsd:sequence>
+          <xsd:element name="sectPr" type="CT_SectPrBase" minOccurs="0"/>
+        </xsd:sequence>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PPrChange">
+    <xsd:complexContent>
+      <xsd:extension base="CT_TrackChange">
+        <xsd:sequence>
+          <xsd:element name="pPr" type="CT_PPrBase" minOccurs="1"/>
+        </xsd:sequence>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="CT_RPrChange">
+    <xsd:complexContent>
+      <xsd:extension base="CT_TrackChange">
+        <xsd:sequence>
+          <xsd:element name="rPr" type="CT_RPrOriginal" minOccurs="1"/>
+        </xsd:sequence>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ParaRPrChange">
+    <xsd:complexContent>
+      <xsd:extension base="CT_TrackChange">
+        <xsd:sequence>
+          <xsd:element name="rPr" type="CT_ParaRPrOriginal" minOccurs="1"/>
+        </xsd:sequence>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="CT_RunTrackChange">
+    <xsd:complexContent>
+      <xsd:extension base="CT_TrackChange">
+        <xsd:choice minOccurs="0" maxOccurs="unbounded">
+          <xsd:group ref="EG_ContentRunContent"/>
+          <xsd:group ref="m:EG_OMathMathElements"/>
+        </xsd:choice>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:group name="EG_PContentMath">
+    <xsd:choice>
+      <xsd:group ref="EG_PContentBase" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:group ref="EG_ContentRunContentBase" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:group name="EG_PContentBase">
+    <xsd:choice>
+      <xsd:element name="customXml" type="CT_CustomXmlRun"/>
+      <xsd:element name="fldSimple" type="CT_SimpleField" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="hyperlink" type="CT_Hyperlink"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:group name="EG_ContentRunContentBase">
+    <xsd:choice>
+      <xsd:element name="smartTag" type="CT_SmartTagRun"/>
+      <xsd:element name="sdt" type="CT_SdtRun"/>
+      <xsd:group ref="EG_RunLevelElts" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:group name="EG_CellMarkupElements">
+    <xsd:choice>
+      <xsd:element name="cellIns" type="CT_TrackChange" minOccurs="0"/>
+      <xsd:element name="cellDel" type="CT_TrackChange" minOccurs="0"/>
+      <xsd:element name="cellMerge" type="CT_CellMergeTrackChange" minOccurs="0"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:group name="EG_RangeMarkupElements">
+    <xsd:choice>
+      <xsd:element name="bookmarkStart" type="CT_Bookmark"/>
+      <xsd:element name="bookmarkEnd" type="CT_MarkupRange"/>
+      <xsd:element name="moveFromRangeStart" type="CT_MoveBookmark"/>
+      <xsd:element name="moveFromRangeEnd" type="CT_MarkupRange"/>
+      <xsd:element name="moveToRangeStart" type="CT_MoveBookmark"/>
+      <xsd:element name="moveToRangeEnd" type="CT_MarkupRange"/>
+      <xsd:element name="commentRangeStart" type="CT_MarkupRange"/>
+      <xsd:element name="commentRangeEnd" type="CT_MarkupRange"/>
+      <xsd:element name="customXmlInsRangeStart" type="CT_TrackChange"/>
+      <xsd:element name="customXmlInsRangeEnd" type="CT_Markup"/>
+      <xsd:element name="customXmlDelRangeStart" type="CT_TrackChange"/>
+      <xsd:element name="customXmlDelRangeEnd" type="CT_Markup"/>
+      <xsd:element name="customXmlMoveFromRangeStart" type="CT_TrackChange"/>
+      <xsd:element name="customXmlMoveFromRangeEnd" type="CT_Markup"/>
+      <xsd:element name="customXmlMoveToRangeStart" type="CT_TrackChange"/>
+      <xsd:element name="customXmlMoveToRangeEnd" type="CT_Markup"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:complexType name="CT_NumPr">
+    <xsd:sequence>
+      <xsd:element name="ilvl" type="CT_DecimalNumber" minOccurs="0"/>
+      <xsd:element name="numId" type="CT_DecimalNumber" minOccurs="0"/>
+      <xsd:element name="numberingChange" type="CT_TrackChangeNumbering" minOccurs="0"/>
+      <xsd:element name="ins" type="CT_TrackChange" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PBdr">
+    <xsd:sequence>
+      <xsd:element name="top" type="CT_Border" minOccurs="0"/>
+      <xsd:element name="left" type="CT_Border" minOccurs="0"/>
+      <xsd:element name="bottom" type="CT_Border" minOccurs="0"/>
+      <xsd:element name="right" type="CT_Border" minOccurs="0"/>
+      <xsd:element name="between" type="CT_Border" minOccurs="0"/>
+      <xsd:element name="bar" type="CT_Border" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Tabs">
+    <xsd:sequence>
+      <xsd:element name="tab" type="CT_TabStop" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TextboxTightWrap">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="allLines"/>
+      <xsd:enumeration value="firstAndLastLine"/>
+      <xsd:enumeration value="firstLineOnly"/>
+      <xsd:enumeration value="lastLineOnly"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TextboxTightWrap">
+    <xsd:attribute name="val" type="ST_TextboxTightWrap" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PPrBase">
+    <xsd:sequence>
+      <xsd:element name="pStyle" type="CT_String" minOccurs="0"/>
+      <xsd:element name="keepNext" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="keepLines" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="pageBreakBefore" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="framePr" type="CT_FramePr" minOccurs="0"/>
+      <xsd:element name="widowControl" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="numPr" type="CT_NumPr" minOccurs="0"/>
+      <xsd:element name="suppressLineNumbers" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="pBdr" type="CT_PBdr" minOccurs="0"/>
+      <xsd:element name="shd" type="CT_Shd" minOccurs="0"/>
+      <xsd:element name="tabs" type="CT_Tabs" minOccurs="0"/>
+      <xsd:element name="suppressAutoHyphens" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="kinsoku" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="wordWrap" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="overflowPunct" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="topLinePunct" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="autoSpaceDE" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="autoSpaceDN" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="bidi" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="adjustRightInd" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="snapToGrid" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="spacing" type="CT_Spacing" minOccurs="0"/>
+      <xsd:element name="ind" type="CT_Ind" minOccurs="0"/>
+      <xsd:element name="contextualSpacing" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="mirrorIndents" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="suppressOverlap" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="jc" type="CT_Jc" minOccurs="0"/>
+      <xsd:element name="textDirection" type="CT_TextDirection" minOccurs="0"/>
+      <xsd:element name="textAlignment" type="CT_TextAlignment" minOccurs="0"/>
+      <xsd:element name="textboxTightWrap" type="CT_TextboxTightWrap" minOccurs="0"/>
+      <xsd:element name="outlineLvl" type="CT_DecimalNumber" minOccurs="0"/>
+      <xsd:element name="divId" type="CT_DecimalNumber" minOccurs="0"/>
+      <xsd:element name="cnfStyle" type="CT_Cnf" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PPr">
+    <xsd:complexContent>
+      <xsd:extension base="CT_PPrBase">
+        <xsd:sequence>
+          <xsd:element name="rPr" type="CT_ParaRPr" minOccurs="0"/>
+          <xsd:element name="sectPr" type="CT_SectPr" minOccurs="0"/>
+          <xsd:element name="pPrChange" type="CT_PPrChange" minOccurs="0"/>
+        </xsd:sequence>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PPrGeneral">
+    <xsd:complexContent>
+      <xsd:extension base="CT_PPrBase">
+        <xsd:sequence>
+          <xsd:element name="pPrChange" type="CT_PPrChange" minOccurs="0"/>
+        </xsd:sequence>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Control">
+    <xsd:attribute name="name" type="s:ST_String" use="optional"/>
+    <xsd:attribute name="shapeid" type="s:ST_String" use="optional"/>
+    <xsd:attribute ref="r:id" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Background">
+    <xsd:sequence>
+      <xsd:sequence maxOccurs="unbounded">
+        <xsd:any processContents="lax" namespace="urn:schemas-microsoft-com:vml" minOccurs="0"
+          maxOccurs="unbounded"/>
+        <xsd:any processContents="lax" namespace="urn:schemas-microsoft-com:office:office"
+          minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:element name="drawing" type="CT_Drawing" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="color" type="ST_HexColor" use="optional" default="auto"/>
+    <xsd:attribute name="themeColor" type="ST_ThemeColor" use="optional"/>
+    <xsd:attribute name="themeTint" type="ST_UcharHexNumber" use="optional"/>
+    <xsd:attribute name="themeShade" type="ST_UcharHexNumber" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Rel">
+    <xsd:attribute ref="r:id" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Object">
+    <xsd:sequence>
+      <xsd:sequence maxOccurs="unbounded">
+        <xsd:any processContents="lax" namespace="urn:schemas-microsoft-com:vml" minOccurs="0"
+          maxOccurs="unbounded"/>
+        <xsd:any processContents="lax" namespace="urn:schemas-microsoft-com:office:office"
+          minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:element name="drawing" type="CT_Drawing" minOccurs="0"/>
+      <xsd:choice minOccurs="0">
+        <xsd:element name="control" type="CT_Control"/>
+        <xsd:element name="objectLink" type="CT_ObjectLink"/>
+        <xsd:element name="objectEmbed" type="CT_ObjectEmbed"/>
+        <xsd:element name="movie" type="CT_Rel"/>
+      </xsd:choice>
+    </xsd:sequence>
+    <xsd:attribute name="dxaOrig" type="s:ST_TwipsMeasure" use="optional"/>
+    <xsd:attribute name="dyaOrig" type="s:ST_TwipsMeasure" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Picture">
+    <xsd:sequence>
+      <xsd:sequence maxOccurs="unbounded">
+        <xsd:any processContents="lax" namespace="urn:schemas-microsoft-com:vml" minOccurs="0"
+          maxOccurs="unbounded"/>
+        <xsd:any processContents="lax" namespace="urn:schemas-microsoft-com:office:office"
+          minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:element name="movie" type="CT_Rel" minOccurs="0"/>
+      <xsd:element name="control" type="CT_Control" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ObjectEmbed">
+    <xsd:attribute name="drawAspect" type="ST_ObjectDrawAspect" use="optional"/>
+    <xsd:attribute ref="r:id" use="required"/>
+    <xsd:attribute name="progId" type="s:ST_String" use="optional"/>
+    <xsd:attribute name="shapeId" type="s:ST_String" use="optional"/>
+    <xsd:attribute name="fieldCodes" type="s:ST_String" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_ObjectDrawAspect">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="content"/>
+      <xsd:enumeration value="icon"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_ObjectLink">
+    <xsd:complexContent>
+      <xsd:extension base="CT_ObjectEmbed">
+        <xsd:attribute name="updateMode" type="ST_ObjectUpdateMode" use="required"/>
+        <xsd:attribute name="lockedField" type="s:ST_OnOff" use="optional"/>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_ObjectUpdateMode">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="always"/>
+      <xsd:enumeration value="onCall"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Drawing">
+    <xsd:choice minOccurs="1" maxOccurs="unbounded">
+      <xsd:element ref="wp:anchor" minOccurs="0"/>
+      <xsd:element ref="wp:inline" minOccurs="0"/>
+    </xsd:choice>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SimpleField">
+    <xsd:sequence>
+      <xsd:element name="fldData" type="CT_Text" minOccurs="0" maxOccurs="1"/>
+      <xsd:group ref="EG_PContent" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="instr" type="s:ST_String" use="required"/>
+    <xsd:attribute name="fldLock" type="s:ST_OnOff"/>
+    <xsd:attribute name="dirty" type="s:ST_OnOff"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_FldCharType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="begin"/>
+      <xsd:enumeration value="separate"/>
+      <xsd:enumeration value="end"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_InfoTextType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="text"/>
+      <xsd:enumeration value="autoText"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_FFHelpTextVal">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="256"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_FFStatusTextVal">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="140"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_FFName">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="65"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_FFTextType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="regular"/>
+      <xsd:enumeration value="number"/>
+      <xsd:enumeration value="date"/>
+      <xsd:enumeration value="currentTime"/>
+      <xsd:enumeration value="currentDate"/>
+      <xsd:enumeration value="calculated"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_FFTextType">
+    <xsd:attribute name="val" type="ST_FFTextType" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_FFName">
+    <xsd:attribute name="val" type="ST_FFName"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_FldChar">
+    <xsd:choice>
+      <xsd:element name="fldData" type="CT_Text" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="ffData" type="CT_FFData" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="numberingChange" type="CT_TrackChangeNumbering" minOccurs="0"/>
+    </xsd:choice>
+    <xsd:attribute name="fldCharType" type="ST_FldCharType" use="required"/>
+    <xsd:attribute name="fldLock" type="s:ST_OnOff"/>
+    <xsd:attribute name="dirty" type="s:ST_OnOff"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Hyperlink">
+    <xsd:group ref="EG_PContent" minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:attribute name="tgtFrame" type="s:ST_String" use="optional"/>
+    <xsd:attribute name="tooltip" type="s:ST_String" use="optional"/>
+    <xsd:attribute name="docLocation" type="s:ST_String" use="optional"/>
+    <xsd:attribute name="history" type="s:ST_OnOff" use="optional"/>
+    <xsd:attribute name="anchor" type="s:ST_String" use="optional"/>
+    <xsd:attribute ref="r:id"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_FFData">
+    <xsd:choice maxOccurs="unbounded">
+      <xsd:element name="name" type="CT_FFName"/>
+      <xsd:element name="label" type="CT_DecimalNumber" minOccurs="0"/>
+      <xsd:element name="tabIndex" type="CT_UnsignedDecimalNumber" minOccurs="0"/>
+      <xsd:element name="enabled" type="CT_OnOff"/>
+      <xsd:element name="calcOnExit" type="CT_OnOff"/>
+      <xsd:element name="entryMacro" type="CT_MacroName" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="exitMacro" type="CT_MacroName" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="helpText" type="CT_FFHelpText" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="statusText" type="CT_FFStatusText" minOccurs="0" maxOccurs="1"/>
+      <xsd:choice>
+        <xsd:element name="checkBox" type="CT_FFCheckBox"/>
+        <xsd:element name="ddList" type="CT_FFDDList"/>
+        <xsd:element name="textInput" type="CT_FFTextInput"/>
+      </xsd:choice>
+    </xsd:choice>
+  </xsd:complexType>
+  <xsd:complexType name="CT_FFHelpText">
+    <xsd:attribute name="type" type="ST_InfoTextType"/>
+    <xsd:attribute name="val" type="ST_FFHelpTextVal"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_FFStatusText">
+    <xsd:attribute name="type" type="ST_InfoTextType"/>
+    <xsd:attribute name="val" type="ST_FFStatusTextVal"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_FFCheckBox">
+    <xsd:sequence>
+      <xsd:choice>
+        <xsd:element name="size" type="CT_HpsMeasure"/>
+        <xsd:element name="sizeAuto" type="CT_OnOff"/>
+      </xsd:choice>
+      <xsd:element name="default" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="checked" type="CT_OnOff" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_FFDDList">
+    <xsd:sequence>
+      <xsd:element name="result" type="CT_DecimalNumber" minOccurs="0"/>
+      <xsd:element name="default" type="CT_DecimalNumber" minOccurs="0"/>
+      <xsd:element name="listEntry" type="CT_String" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_FFTextInput">
+    <xsd:sequence>
+      <xsd:element name="type" type="CT_FFTextType" minOccurs="0"/>
+      <xsd:element name="default" type="CT_String" minOccurs="0"/>
+      <xsd:element name="maxLength" type="CT_DecimalNumber" minOccurs="0"/>
+      <xsd:element name="format" type="CT_String" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_SectionMark">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="nextPage"/>
+      <xsd:enumeration value="nextColumn"/>
+      <xsd:enumeration value="continuous"/>
+      <xsd:enumeration value="evenPage"/>
+      <xsd:enumeration value="oddPage"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_SectType">
+    <xsd:attribute name="val" type="ST_SectionMark"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PaperSource">
+    <xsd:attribute name="first" type="ST_DecimalNumber"/>
+    <xsd:attribute name="other" type="ST_DecimalNumber"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_NumberFormat">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="decimal"/>
+      <xsd:enumeration value="upperRoman"/>
+      <xsd:enumeration value="lowerRoman"/>
+      <xsd:enumeration value="upperLetter"/>
+      <xsd:enumeration value="lowerLetter"/>
+      <xsd:enumeration value="ordinal"/>
+      <xsd:enumeration value="cardinalText"/>
+      <xsd:enumeration value="ordinalText"/>
+      <xsd:enumeration value="hex"/>
+      <xsd:enumeration value="chicago"/>
+      <xsd:enumeration value="ideographDigital"/>
+      <xsd:enumeration value="japaneseCounting"/>
+      <xsd:enumeration value="aiueo"/>
+      <xsd:enumeration value="iroha"/>
+      <xsd:enumeration value="decimalFullWidth"/>
+      <xsd:enumeration value="decimalHalfWidth"/>
+      <xsd:enumeration value="japaneseLegal"/>
+      <xsd:enumeration value="japaneseDigitalTenThousand"/>
+      <xsd:enumeration value="decimalEnclosedCircle"/>
+      <xsd:enumeration value="decimalFullWidth2"/>
+      <xsd:enumeration value="aiueoFullWidth"/>
+      <xsd:enumeration value="irohaFullWidth"/>
+      <xsd:enumeration value="decimalZero"/>
+      <xsd:enumeration value="bullet"/>
+      <xsd:enumeration value="ganada"/>
+      <xsd:enumeration value="chosung"/>
+      <xsd:enumeration value="decimalEnclosedFullstop"/>
+      <xsd:enumeration value="decimalEnclosedParen"/>
+      <xsd:enumeration value="decimalEnclosedCircleChinese"/>
+      <xsd:enumeration value="ideographEnclosedCircle"/>
+      <xsd:enumeration value="ideographTraditional"/>
+      <xsd:enumeration value="ideographZodiac"/>
+      <xsd:enumeration value="ideographZodiacTraditional"/>
+      <xsd:enumeration value="taiwaneseCounting"/>
+      <xsd:enumeration value="ideographLegalTraditional"/>
+      <xsd:enumeration value="taiwaneseCountingThousand"/>
+      <xsd:enumeration value="taiwaneseDigital"/>
+      <xsd:enumeration value="chineseCounting"/>
+      <xsd:enumeration value="chineseLegalSimplified"/>
+      <xsd:enumeration value="chineseCountingThousand"/>
+      <xsd:enumeration value="koreanDigital"/>
+      <xsd:enumeration value="koreanCounting"/>
+      <xsd:enumeration value="koreanLegal"/>
+      <xsd:enumeration value="koreanDigital2"/>
+      <xsd:enumeration value="vietnameseCounting"/>
+      <xsd:enumeration value="russianLower"/>
+      <xsd:enumeration value="russianUpper"/>
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="numberInDash"/>
+      <xsd:enumeration value="hebrew1"/>
+      <xsd:enumeration value="hebrew2"/>
+      <xsd:enumeration value="arabicAlpha"/>
+      <xsd:enumeration value="arabicAbjad"/>
+      <xsd:enumeration value="hindiVowels"/>
+      <xsd:enumeration value="hindiConsonants"/>
+      <xsd:enumeration value="hindiNumbers"/>
+      <xsd:enumeration value="hindiCounting"/>
+      <xsd:enumeration value="thaiLetters"/>
+      <xsd:enumeration value="thaiNumbers"/>
+      <xsd:enumeration value="thaiCounting"/>
+      <xsd:enumeration value="bahtText"/>
+      <xsd:enumeration value="dollarText"/>
+      <xsd:enumeration value="custom"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_PageOrientation">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="portrait"/>
+      <xsd:enumeration value="landscape"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_PageSz">
+    <xsd:attribute name="w" type="s:ST_TwipsMeasure"/>
+    <xsd:attribute name="h" type="s:ST_TwipsMeasure"/>
+    <xsd:attribute name="orient" type="ST_PageOrientation" use="optional"/>
+    <xsd:attribute name="code" type="ST_DecimalNumber" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PageMar">
+    <xsd:attribute name="top" type="ST_SignedTwipsMeasure" use="required"/>
+    <xsd:attribute name="right" type="s:ST_TwipsMeasure" use="required"/>
+    <xsd:attribute name="bottom" type="ST_SignedTwipsMeasure" use="required"/>
+    <xsd:attribute name="left" type="s:ST_TwipsMeasure" use="required"/>
+    <xsd:attribute name="header" type="s:ST_TwipsMeasure" use="required"/>
+    <xsd:attribute name="footer" type="s:ST_TwipsMeasure" use="required"/>
+    <xsd:attribute name="gutter" type="s:ST_TwipsMeasure" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_PageBorderZOrder">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="front"/>
+      <xsd:enumeration value="back"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_PageBorderDisplay">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="allPages"/>
+      <xsd:enumeration value="firstPage"/>
+      <xsd:enumeration value="notFirstPage"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_PageBorderOffset">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="page"/>
+      <xsd:enumeration value="text"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_PageBorders">
+    <xsd:sequence>
+      <xsd:element name="top" type="CT_TopPageBorder" minOccurs="0"/>
+      <xsd:element name="left" type="CT_PageBorder" minOccurs="0"/>
+      <xsd:element name="bottom" type="CT_BottomPageBorder" minOccurs="0"/>
+      <xsd:element name="right" type="CT_PageBorder" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="zOrder" type="ST_PageBorderZOrder" use="optional" default="front"/>
+    <xsd:attribute name="display" type="ST_PageBorderDisplay" use="optional"/>
+    <xsd:attribute name="offsetFrom" type="ST_PageBorderOffset" use="optional" default="text"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PageBorder">
+    <xsd:complexContent>
+      <xsd:extension base="CT_Border">
+        <xsd:attribute ref="r:id" use="optional"/>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="CT_BottomPageBorder">
+    <xsd:complexContent>
+      <xsd:extension base="CT_PageBorder">
+        <xsd:attribute ref="r:bottomLeft" use="optional"/>
+        <xsd:attribute ref="r:bottomRight" use="optional"/>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TopPageBorder">
+    <xsd:complexContent>
+      <xsd:extension base="CT_PageBorder">
+        <xsd:attribute ref="r:topLeft" use="optional"/>
+        <xsd:attribute ref="r:topRight" use="optional"/>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_ChapterSep">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="hyphen"/>
+      <xsd:enumeration value="period"/>
+      <xsd:enumeration value="colon"/>
+      <xsd:enumeration value="emDash"/>
+      <xsd:enumeration value="enDash"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_LineNumberRestart">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="newPage"/>
+      <xsd:enumeration value="newSection"/>
+      <xsd:enumeration value="continuous"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_LineNumber">
+    <xsd:attribute name="countBy" type="ST_DecimalNumber" use="optional"/>
+    <xsd:attribute name="start" type="ST_DecimalNumber" use="optional" default="1"/>
+    <xsd:attribute name="distance" type="s:ST_TwipsMeasure" use="optional"/>
+    <xsd:attribute name="restart" type="ST_LineNumberRestart" use="optional" default="newPage"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PageNumber">
+    <xsd:attribute name="fmt" type="ST_NumberFormat" use="optional" default="decimal"/>
+    <xsd:attribute name="start" type="ST_DecimalNumber" use="optional"/>
+    <xsd:attribute name="chapStyle" type="ST_DecimalNumber" use="optional"/>
+    <xsd:attribute name="chapSep" type="ST_ChapterSep" use="optional" default="hyphen"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Column">
+    <xsd:attribute name="w" type="s:ST_TwipsMeasure" use="optional"/>
+    <xsd:attribute name="space" type="s:ST_TwipsMeasure" use="optional" default="0"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Columns">
+    <xsd:sequence minOccurs="0">
+      <xsd:element name="col" type="CT_Column" maxOccurs="45"/>
+    </xsd:sequence>
+    <xsd:attribute name="equalWidth" type="s:ST_OnOff" use="optional"/>
+    <xsd:attribute name="space" type="s:ST_TwipsMeasure" use="optional" default="720"/>
+    <xsd:attribute name="num" type="ST_DecimalNumber" use="optional" default="1"/>
+    <xsd:attribute name="sep" type="s:ST_OnOff" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_VerticalJc">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="top"/>
+      <xsd:enumeration value="center"/>
+      <xsd:enumeration value="both"/>
+      <xsd:enumeration value="bottom"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_VerticalJc">
+    <xsd:attribute name="val" type="ST_VerticalJc" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_DocGrid">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="default"/>
+      <xsd:enumeration value="lines"/>
+      <xsd:enumeration value="linesAndChars"/>
+      <xsd:enumeration value="snapToChars"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_DocGrid">
+    <xsd:attribute name="type" type="ST_DocGrid"/>
+    <xsd:attribute name="linePitch" type="ST_DecimalNumber"/>
+    <xsd:attribute name="charSpace" type="ST_DecimalNumber"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_HdrFtr">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="even"/>
+      <xsd:enumeration value="default"/>
+      <xsd:enumeration value="first"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_FtnEdn">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="normal"/>
+      <xsd:enumeration value="separator"/>
+      <xsd:enumeration value="continuationSeparator"/>
+      <xsd:enumeration value="continuationNotice"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_HdrFtrRef">
+    <xsd:complexContent>
+      <xsd:extension base="CT_Rel">
+        <xsd:attribute name="type" type="ST_HdrFtr" use="required"/>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:group name="EG_HdrFtrReferences">
+    <xsd:choice>
+      <xsd:element name="headerReference" type="CT_HdrFtrRef" minOccurs="0"/>
+      <xsd:element name="footerReference" type="CT_HdrFtrRef" minOccurs="0"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:complexType name="CT_HdrFtr">
+    <xsd:group ref="EG_BlockLevelElts" minOccurs="1" maxOccurs="unbounded"/>
+  </xsd:complexType>
+  <xsd:group name="EG_SectPrContents">
+    <xsd:sequence>
+      <xsd:element name="footnotePr" type="CT_FtnProps" minOccurs="0"/>
+      <xsd:element name="endnotePr" type="CT_EdnProps" minOccurs="0"/>
+      <xsd:element name="type" type="CT_SectType" minOccurs="0"/>
+      <xsd:element name="pgSz" type="CT_PageSz" minOccurs="0"/>
+      <xsd:element name="pgMar" type="CT_PageMar" minOccurs="0"/>
+      <xsd:element name="paperSrc" type="CT_PaperSource" minOccurs="0"/>
+      <xsd:element name="pgBorders" type="CT_PageBorders" minOccurs="0"/>
+      <xsd:element name="lnNumType" type="CT_LineNumber" minOccurs="0"/>
+      <xsd:element name="pgNumType" type="CT_PageNumber" minOccurs="0"/>
+      <xsd:element name="cols" type="CT_Columns" minOccurs="0"/>
+      <xsd:element name="formProt" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="vAlign" type="CT_VerticalJc" minOccurs="0"/>
+      <xsd:element name="noEndnote" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="titlePg" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="textDirection" type="CT_TextDirection" minOccurs="0"/>
+      <xsd:element name="bidi" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="rtlGutter" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="docGrid" type="CT_DocGrid" minOccurs="0"/>
+      <xsd:element name="printerSettings" type="CT_Rel" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:group>
+  <xsd:attributeGroup name="AG_SectPrAttributes">
+    <xsd:attribute name="rsidRPr" type="ST_LongHexNumber"/>
+    <xsd:attribute name="rsidDel" type="ST_LongHexNumber"/>
+    <xsd:attribute name="rsidR" type="ST_LongHexNumber"/>
+    <xsd:attribute name="rsidSect" type="ST_LongHexNumber"/>
+  </xsd:attributeGroup>
+  <xsd:complexType name="CT_SectPrBase">
+    <xsd:sequence>
+      <xsd:group ref="EG_SectPrContents" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attributeGroup ref="AG_SectPrAttributes"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SectPr">
+    <xsd:sequence>
+      <xsd:group ref="EG_HdrFtrReferences" minOccurs="0" maxOccurs="6"/>
+      <xsd:group ref="EG_SectPrContents" minOccurs="0"/>
+      <xsd:element name="sectPrChange" type="CT_SectPrChange" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attributeGroup ref="AG_SectPrAttributes"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_BrType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="page"/>
+      <xsd:enumeration value="column"/>
+      <xsd:enumeration value="textWrapping"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_BrClear">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="left"/>
+      <xsd:enumeration value="right"/>
+      <xsd:enumeration value="all"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Br">
+    <xsd:attribute name="type" type="ST_BrType" use="optional"/>
+    <xsd:attribute name="clear" type="ST_BrClear" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_PTabAlignment">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="left"/>
+      <xsd:enumeration value="center"/>
+      <xsd:enumeration value="right"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_PTabRelativeTo">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="margin"/>
+      <xsd:enumeration value="indent"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_PTabLeader">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="dot"/>
+      <xsd:enumeration value="hyphen"/>
+      <xsd:enumeration value="underscore"/>
+      <xsd:enumeration value="middleDot"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_PTab">
+    <xsd:attribute name="alignment" type="ST_PTabAlignment" use="required"/>
+    <xsd:attribute name="relativeTo" type="ST_PTabRelativeTo" use="required"/>
+    <xsd:attribute name="leader" type="ST_PTabLeader" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Sym">
+    <xsd:attribute name="font" type="s:ST_String"/>
+    <xsd:attribute name="char" type="ST_ShortHexNumber"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_ProofErr">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="spellStart"/>
+      <xsd:enumeration value="spellEnd"/>
+      <xsd:enumeration value="gramStart"/>
+      <xsd:enumeration value="gramEnd"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_ProofErr">
+    <xsd:attribute name="type" type="ST_ProofErr" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_EdGrp">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="everyone"/>
+      <xsd:enumeration value="administrators"/>
+      <xsd:enumeration value="contributors"/>
+      <xsd:enumeration value="editors"/>
+      <xsd:enumeration value="owners"/>
+      <xsd:enumeration value="current"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Perm">
+    <xsd:attribute name="id" type="s:ST_String" use="required"/>
+    <xsd:attribute name="displacedByCustomXml" type="ST_DisplacedByCustomXml" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PermStart">
+    <xsd:complexContent>
+      <xsd:extension base="CT_Perm">
+        <xsd:attribute name="edGrp" type="ST_EdGrp" use="optional"/>
+        <xsd:attribute name="ed" type="s:ST_String" use="optional"/>
+        <xsd:attribute name="colFirst" type="ST_DecimalNumber" use="optional"/>
+        <xsd:attribute name="colLast" type="ST_DecimalNumber" use="optional"/>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Text">
+    <xsd:simpleContent>
+      <xsd:extension base="s:ST_String">
+        <xsd:attribute ref="xml:space" use="optional"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:group name="EG_RunInnerContent">
+    <xsd:choice>
+      <xsd:element name="br" type="CT_Br"/>
+      <xsd:element name="t" type="CT_Text"/>
+      <xsd:element name="contentPart" type="CT_Rel"/>
+      <xsd:element name="delText" type="CT_Text"/>
+      <xsd:element name="instrText" type="CT_Text"/>
+      <xsd:element name="delInstrText" type="CT_Text"/>
+      <xsd:element name="noBreakHyphen" type="CT_Empty"/>
+      <xsd:element name="softHyphen" type="CT_Empty" minOccurs="0"/>
+      <xsd:element name="dayShort" type="CT_Empty" minOccurs="0"/>
+      <xsd:element name="monthShort" type="CT_Empty" minOccurs="0"/>
+      <xsd:element name="yearShort" type="CT_Empty" minOccurs="0"/>
+      <xsd:element name="dayLong" type="CT_Empty" minOccurs="0"/>
+      <xsd:element name="monthLong" type="CT_Empty" minOccurs="0"/>
+      <xsd:element name="yearLong" type="CT_Empty" minOccurs="0"/>
+      <xsd:element name="annotationRef" type="CT_Empty" minOccurs="0"/>
+      <xsd:element name="footnoteRef" type="CT_Empty" minOccurs="0"/>
+      <xsd:element name="endnoteRef" type="CT_Empty" minOccurs="0"/>
+      <xsd:element name="separator" type="CT_Empty" minOccurs="0"/>
+      <xsd:element name="continuationSeparator" type="CT_Empty" minOccurs="0"/>
+      <xsd:element name="sym" type="CT_Sym" minOccurs="0"/>
+      <xsd:element name="pgNum" type="CT_Empty" minOccurs="0"/>
+      <xsd:element name="cr" type="CT_Empty" minOccurs="0"/>
+      <xsd:element name="tab" type="CT_Empty" minOccurs="0"/>
+      <xsd:element name="object" type="CT_Object"/>
+      <xsd:element name="pict" type="CT_Picture"/>
+      <xsd:element name="fldChar" type="CT_FldChar"/>
+      <xsd:element name="ruby" type="CT_Ruby"/>
+      <xsd:element name="footnoteReference" type="CT_FtnEdnRef"/>
+      <xsd:element name="endnoteReference" type="CT_FtnEdnRef"/>
+      <xsd:element name="commentReference" type="CT_Markup"/>
+      <xsd:element name="drawing" type="CT_Drawing"/>
+      <xsd:element name="ptab" type="CT_PTab" minOccurs="0"/>
+      <xsd:element name="lastRenderedPageBreak" type="CT_Empty" minOccurs="0" maxOccurs="1"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:complexType name="CT_R">
+    <xsd:sequence>
+      <xsd:group ref="EG_RPr" minOccurs="0"/>
+      <xsd:group ref="EG_RunInnerContent" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="rsidRPr" type="ST_LongHexNumber"/>
+    <xsd:attribute name="rsidDel" type="ST_LongHexNumber"/>
+    <xsd:attribute name="rsidR" type="ST_LongHexNumber"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_Hint">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="default"/>
+      <xsd:enumeration value="eastAsia"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_Theme">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="majorEastAsia"/>
+      <xsd:enumeration value="majorBidi"/>
+      <xsd:enumeration value="majorAscii"/>
+      <xsd:enumeration value="majorHAnsi"/>
+      <xsd:enumeration value="minorEastAsia"/>
+      <xsd:enumeration value="minorBidi"/>
+      <xsd:enumeration value="minorAscii"/>
+      <xsd:enumeration value="minorHAnsi"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Fonts">
+    <xsd:attribute name="hint" type="ST_Hint"/>
+    <xsd:attribute name="ascii" type="s:ST_String"/>
+    <xsd:attribute name="hAnsi" type="s:ST_String"/>
+    <xsd:attribute name="eastAsia" type="s:ST_String"/>
+    <xsd:attribute name="cs" type="s:ST_String"/>
+    <xsd:attribute name="asciiTheme" type="ST_Theme"/>
+    <xsd:attribute name="hAnsiTheme" type="ST_Theme"/>
+    <xsd:attribute name="eastAsiaTheme" type="ST_Theme"/>
+    <xsd:attribute name="cstheme" type="ST_Theme"/>
+  </xsd:complexType>
+  <xsd:group name="EG_RPrBase">
+    <xsd:choice>
+      <xsd:element name="rStyle" type="CT_String"/>
+      <xsd:element name="rFonts" type="CT_Fonts"/>
+      <xsd:element name="b" type="CT_OnOff"/>
+      <xsd:element name="bCs" type="CT_OnOff"/>
+      <xsd:element name="i" type="CT_OnOff"/>
+      <xsd:element name="iCs" type="CT_OnOff"/>
+      <xsd:element name="caps" type="CT_OnOff"/>
+      <xsd:element name="smallCaps" type="CT_OnOff"/>
+      <xsd:element name="strike" type="CT_OnOff"/>
+      <xsd:element name="dstrike" type="CT_OnOff"/>
+      <xsd:element name="outline" type="CT_OnOff"/>
+      <xsd:element name="shadow" type="CT_OnOff"/>
+      <xsd:element name="emboss" type="CT_OnOff"/>
+      <xsd:element name="imprint" type="CT_OnOff"/>
+      <xsd:element name="noProof" type="CT_OnOff"/>
+      <xsd:element name="snapToGrid" type="CT_OnOff"/>
+      <xsd:element name="vanish" type="CT_OnOff"/>
+      <xsd:element name="webHidden" type="CT_OnOff"/>
+      <xsd:element name="color" type="CT_Color"/>
+      <xsd:element name="spacing" type="CT_SignedTwipsMeasure"/>
+      <xsd:element name="w" type="CT_TextScale"/>
+      <xsd:element name="kern" type="CT_HpsMeasure"/>
+      <xsd:element name="position" type="CT_SignedHpsMeasure"/>
+      <xsd:element name="sz" type="CT_HpsMeasure"/>
+      <xsd:element name="szCs" type="CT_HpsMeasure"/>
+      <xsd:element name="highlight" type="CT_Highlight"/>
+      <xsd:element name="u" type="CT_Underline"/>
+      <xsd:element name="effect" type="CT_TextEffect"/>
+      <xsd:element name="bdr" type="CT_Border"/>
+      <xsd:element name="shd" type="CT_Shd"/>
+      <xsd:element name="fitText" type="CT_FitText"/>
+      <xsd:element name="vertAlign" type="CT_VerticalAlignRun"/>
+      <xsd:element name="rtl" type="CT_OnOff"/>
+      <xsd:element name="cs" type="CT_OnOff"/>
+      <xsd:element name="em" type="CT_Em"/>
+      <xsd:element name="lang" type="CT_Language"/>
+      <xsd:element name="eastAsianLayout" type="CT_EastAsianLayout"/>
+      <xsd:element name="specVanish" type="CT_OnOff"/>
+      <xsd:element name="oMath" type="CT_OnOff"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:group name="EG_RPrContent">
+    <xsd:sequence>
+      <xsd:group ref="EG_RPrBase" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="rPrChange" type="CT_RPrChange" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:group>
+  <xsd:complexType name="CT_RPr">
+    <xsd:sequence>
+      <xsd:group ref="EG_RPrContent" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:group name="EG_RPr">
+    <xsd:sequence>
+      <xsd:element name="rPr" type="CT_RPr" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:group>
+  <xsd:group name="EG_RPrMath">
+    <xsd:choice>
+      <xsd:group ref="EG_RPr"/>
+      <xsd:element name="ins" type="CT_MathCtrlIns"/>
+      <xsd:element name="del" type="CT_MathCtrlDel"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:complexType name="CT_MathCtrlIns">
+    <xsd:complexContent>
+      <xsd:extension base="CT_TrackChange">
+        <xsd:choice minOccurs="0">
+          <xsd:element name="del" type="CT_RPrChange" minOccurs="1"/>
+          <xsd:element name="rPr" type="CT_RPr" minOccurs="1"/>
+        </xsd:choice>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="CT_MathCtrlDel">
+    <xsd:complexContent>
+      <xsd:extension base="CT_TrackChange">
+        <xsd:choice minOccurs="0">
+          <xsd:element name="rPr" type="CT_RPr" minOccurs="1"/>
+        </xsd:choice>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="CT_RPrOriginal">
+    <xsd:sequence>
+      <xsd:group ref="EG_RPrBase" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ParaRPrOriginal">
+    <xsd:sequence>
+      <xsd:group ref="EG_ParaRPrTrackChanges" minOccurs="0"/>
+      <xsd:group ref="EG_RPrBase" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ParaRPr">
+    <xsd:sequence>
+      <xsd:group ref="EG_ParaRPrTrackChanges" minOccurs="0"/>
+      <xsd:group ref="EG_RPrBase" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="rPrChange" type="CT_ParaRPrChange" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:group name="EG_ParaRPrTrackChanges">
+    <xsd:sequence>
+      <xsd:element name="ins" type="CT_TrackChange" minOccurs="0"/>
+      <xsd:element name="del" type="CT_TrackChange" minOccurs="0"/>
+      <xsd:element name="moveFrom" type="CT_TrackChange" minOccurs="0"/>
+      <xsd:element name="moveTo" type="CT_TrackChange" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:group>
+  <xsd:complexType name="CT_AltChunk">
+    <xsd:sequence>
+      <xsd:element name="altChunkPr" type="CT_AltChunkPr" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute ref="r:id" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_AltChunkPr">
+    <xsd:sequence>
+      <xsd:element name="matchSrc" type="CT_OnOff" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_RubyAlign">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="center"/>
+      <xsd:enumeration value="distributeLetter"/>
+      <xsd:enumeration value="distributeSpace"/>
+      <xsd:enumeration value="left"/>
+      <xsd:enumeration value="right"/>
+      <xsd:enumeration value="rightVertical"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_RubyAlign">
+    <xsd:attribute name="val" type="ST_RubyAlign" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_RubyPr">
+    <xsd:sequence>
+      <xsd:element name="rubyAlign" type="CT_RubyAlign"/>
+      <xsd:element name="hps" type="CT_HpsMeasure"/>
+      <xsd:element name="hpsRaise" type="CT_HpsMeasure"/>
+      <xsd:element name="hpsBaseText" type="CT_HpsMeasure"/>
+      <xsd:element name="lid" type="CT_Lang"/>
+      <xsd:element name="dirty" type="CT_OnOff" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:group name="EG_RubyContent">
+    <xsd:choice>
+      <xsd:element name="r" type="CT_R"/>
+      <xsd:group ref="EG_RunLevelElts" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:complexType name="CT_RubyContent">
+    <xsd:group ref="EG_RubyContent" minOccurs="0" maxOccurs="unbounded"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Ruby">
+    <xsd:sequence>
+      <xsd:element name="rubyPr" type="CT_RubyPr"/>
+      <xsd:element name="rt" type="CT_RubyContent"/>
+      <xsd:element name="rubyBase" type="CT_RubyContent"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_Lock">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="sdtLocked"/>
+      <xsd:enumeration value="contentLocked"/>
+      <xsd:enumeration value="unlocked"/>
+      <xsd:enumeration value="sdtContentLocked"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Lock">
+    <xsd:attribute name="val" type="ST_Lock"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SdtListItem">
+    <xsd:attribute name="displayText" type="s:ST_String"/>
+    <xsd:attribute name="value" type="s:ST_String"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_SdtDateMappingType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="text"/>
+      <xsd:enumeration value="date"/>
+      <xsd:enumeration value="dateTime"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_SdtDateMappingType">
+    <xsd:attribute name="val" type="ST_SdtDateMappingType"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CalendarType">
+    <xsd:attribute name="val" type="s:ST_CalendarType"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SdtDate">
+    <xsd:sequence>
+      <xsd:element name="dateFormat" type="CT_String" minOccurs="0"/>
+      <xsd:element name="lid" type="CT_Lang" minOccurs="0"/>
+      <xsd:element name="storeMappedDataAs" type="CT_SdtDateMappingType" minOccurs="0"/>
+      <xsd:element name="calendar" type="CT_CalendarType" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="fullDate" type="ST_DateTime" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SdtComboBox">
+    <xsd:sequence>
+      <xsd:element name="listItem" type="CT_SdtListItem" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="lastValue" type="s:ST_String" use="optional" default=""/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SdtDocPart">
+    <xsd:sequence>
+      <xsd:element name="docPartGallery" type="CT_String" minOccurs="0"/>
+      <xsd:element name="docPartCategory" type="CT_String" minOccurs="0"/>
+      <xsd:element name="docPartUnique" type="CT_OnOff" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SdtDropDownList">
+    <xsd:sequence>
+      <xsd:element name="listItem" type="CT_SdtListItem" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="lastValue" type="s:ST_String" use="optional" default=""/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Placeholder">
+    <xsd:sequence>
+      <xsd:element name="docPart" type="CT_String"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SdtText">
+    <xsd:attribute name="multiLine" type="s:ST_OnOff"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DataBinding">
+    <xsd:attribute name="prefixMappings" type="s:ST_String"/>
+    <xsd:attribute name="xpath" type="s:ST_String" use="required"/>
+    <xsd:attribute name="storeItemID" type="s:ST_String" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SdtPr">
+    <xsd:sequence>
+      <xsd:element name="rPr" type="CT_RPr" minOccurs="0"/>
+      <xsd:element name="alias" type="CT_String" minOccurs="0"/>
+      <xsd:element name="tag" type="CT_String" minOccurs="0"/>
+      <xsd:element name="id" type="CT_DecimalNumber" minOccurs="0"/>
+      <xsd:element name="lock" type="CT_Lock" minOccurs="0"/>
+      <xsd:element name="placeholder" type="CT_Placeholder" minOccurs="0"/>
+      <xsd:element name="temporary" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="showingPlcHdr" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="dataBinding" type="CT_DataBinding" minOccurs="0"/>
+      <xsd:element name="label" type="CT_DecimalNumber" minOccurs="0"/>
+      <xsd:element name="tabIndex" type="CT_UnsignedDecimalNumber" minOccurs="0"/>
+      <xsd:choice minOccurs="0" maxOccurs="1">
+        <xsd:element name="equation" type="CT_Empty"/>
+        <xsd:element name="comboBox" type="CT_SdtComboBox"/>
+        <xsd:element name="date" type="CT_SdtDate"/>
+        <xsd:element name="docPartObj" type="CT_SdtDocPart"/>
+        <xsd:element name="docPartList" type="CT_SdtDocPart"/>
+        <xsd:element name="dropDownList" type="CT_SdtDropDownList"/>
+        <xsd:element name="picture" type="CT_Empty"/>
+        <xsd:element name="richText" type="CT_Empty"/>
+        <xsd:element name="text" type="CT_SdtText"/>
+        <xsd:element name="citation" type="CT_Empty"/>
+        <xsd:element name="group" type="CT_Empty"/>
+        <xsd:element name="bibliography" type="CT_Empty"/>
+      </xsd:choice>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SdtEndPr">
+    <xsd:choice maxOccurs="unbounded">
+      <xsd:element name="rPr" type="CT_RPr" minOccurs="0"/>
+    </xsd:choice>
+  </xsd:complexType>
+  <xsd:group name="EG_ContentRunContent">
+    <xsd:choice>
+      <xsd:element name="customXml" type="CT_CustomXmlRun"/>
+      <xsd:element name="smartTag" type="CT_SmartTagRun"/>
+      <xsd:element name="sdt" type="CT_SdtRun"/>
+      <xsd:element name="dir" type="CT_DirContentRun"/>
+      <xsd:element name="bdo" type="CT_BdoContentRun"/>
+      <xsd:element name="r" type="CT_R"/>
+      <xsd:group ref="EG_RunLevelElts" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:complexType name="CT_DirContentRun">
+    <xsd:group ref="EG_PContent" minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:attribute name="val" type="ST_Direction" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_BdoContentRun">
+    <xsd:group ref="EG_PContent" minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:attribute name="val" type="ST_Direction" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_Direction">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="ltr"/>
+      <xsd:enumeration value="rtl"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_SdtContentRun">
+    <xsd:group ref="EG_PContent" minOccurs="0" maxOccurs="unbounded"/>
+  </xsd:complexType>
+  <xsd:group name="EG_ContentBlockContent">
+    <xsd:choice>
+      <xsd:element name="customXml" type="CT_CustomXmlBlock"/>
+      <xsd:element name="sdt" type="CT_SdtBlock"/>
+      <xsd:element name="p" type="CT_P" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="tbl" type="CT_Tbl" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:group ref="EG_RunLevelElts" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:complexType name="CT_SdtContentBlock">
+    <xsd:group ref="EG_ContentBlockContent" minOccurs="0" maxOccurs="unbounded"/>
+  </xsd:complexType>
+  <xsd:group name="EG_ContentRowContent">
+    <xsd:choice>
+      <xsd:element name="tr" type="CT_Row" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="customXml" type="CT_CustomXmlRow"/>
+      <xsd:element name="sdt" type="CT_SdtRow"/>
+      <xsd:group ref="EG_RunLevelElts" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:complexType name="CT_SdtContentRow">
+    <xsd:group ref="EG_ContentRowContent" minOccurs="0" maxOccurs="unbounded"/>
+  </xsd:complexType>
+  <xsd:group name="EG_ContentCellContent">
+    <xsd:choice>
+      <xsd:element name="tc" type="CT_Tc" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="customXml" type="CT_CustomXmlCell"/>
+      <xsd:element name="sdt" type="CT_SdtCell"/>
+      <xsd:group ref="EG_RunLevelElts" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:complexType name="CT_SdtContentCell">
+    <xsd:group ref="EG_ContentCellContent" minOccurs="0" maxOccurs="unbounded"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SdtBlock">
+    <xsd:sequence>
+      <xsd:element name="sdtPr" type="CT_SdtPr" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="sdtEndPr" type="CT_SdtEndPr" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="sdtContent" type="CT_SdtContentBlock" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SdtRun">
+    <xsd:sequence>
+      <xsd:element name="sdtPr" type="CT_SdtPr" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="sdtEndPr" type="CT_SdtEndPr" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="sdtContent" type="CT_SdtContentRun" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SdtCell">
+    <xsd:sequence>
+      <xsd:element name="sdtPr" type="CT_SdtPr" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="sdtEndPr" type="CT_SdtEndPr" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="sdtContent" type="CT_SdtContentCell" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SdtRow">
+    <xsd:sequence>
+      <xsd:element name="sdtPr" type="CT_SdtPr" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="sdtEndPr" type="CT_SdtEndPr" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="sdtContent" type="CT_SdtContentRow" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Attr">
+    <xsd:attribute name="uri" type="s:ST_String"/>
+    <xsd:attribute name="name" type="s:ST_String" use="required"/>
+    <xsd:attribute name="val" type="s:ST_String" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CustomXmlRun">
+    <xsd:sequence>
+      <xsd:element name="customXmlPr" type="CT_CustomXmlPr" minOccurs="0" maxOccurs="1"/>
+      <xsd:group ref="EG_PContent" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="uri" type="s:ST_String"/>
+    <xsd:attribute name="element" type="s:ST_XmlName" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SmartTagRun">
+    <xsd:sequence>
+      <xsd:element name="smartTagPr" type="CT_SmartTagPr" minOccurs="0" maxOccurs="1"/>
+      <xsd:group ref="EG_PContent" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="uri" type="s:ST_String"/>
+    <xsd:attribute name="element" type="s:ST_XmlName" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CustomXmlBlock">
+    <xsd:sequence>
+      <xsd:element name="customXmlPr" type="CT_CustomXmlPr" minOccurs="0" maxOccurs="1"/>
+      <xsd:group ref="EG_ContentBlockContent" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="uri" type="s:ST_String"/>
+    <xsd:attribute name="element" type="s:ST_XmlName" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CustomXmlPr">
+    <xsd:sequence>
+      <xsd:element name="placeholder" type="CT_String" minOccurs="0"/>
+      <xsd:element name="attr" type="CT_Attr" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CustomXmlRow">
+    <xsd:sequence>
+      <xsd:element name="customXmlPr" type="CT_CustomXmlPr" minOccurs="0" maxOccurs="1"/>
+      <xsd:group ref="EG_ContentRowContent" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="uri" type="s:ST_String"/>
+    <xsd:attribute name="element" type="s:ST_XmlName" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CustomXmlCell">
+    <xsd:sequence>
+      <xsd:element name="customXmlPr" type="CT_CustomXmlPr" minOccurs="0" maxOccurs="1"/>
+      <xsd:group ref="EG_ContentCellContent" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="uri" type="s:ST_String"/>
+    <xsd:attribute name="element" type="s:ST_XmlName" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SmartTagPr">
+    <xsd:sequence>
+      <xsd:element name="attr" type="CT_Attr" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:group name="EG_PContent">
+    <xsd:choice>
+      <xsd:group ref="EG_ContentRunContent" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="fldSimple" type="CT_SimpleField" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="hyperlink" type="CT_Hyperlink"/>
+      <xsd:element name="subDoc" type="CT_Rel"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:complexType name="CT_P">
+    <xsd:sequence>
+      <xsd:element name="pPr" type="CT_PPr" minOccurs="0"/>
+      <xsd:group ref="EG_PContent" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="rsidRPr" type="ST_LongHexNumber"/>
+    <xsd:attribute name="rsidR" type="ST_LongHexNumber"/>
+    <xsd:attribute name="rsidDel" type="ST_LongHexNumber"/>
+    <xsd:attribute name="rsidP" type="ST_LongHexNumber"/>
+    <xsd:attribute name="rsidRDefault" type="ST_LongHexNumber"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TblWidth">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="nil"/>
+      <xsd:enumeration value="pct"/>
+      <xsd:enumeration value="dxa"/>
+      <xsd:enumeration value="auto"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Height">
+    <xsd:attribute name="val" type="s:ST_TwipsMeasure"/>
+    <xsd:attribute name="hRule" type="ST_HeightRule"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_MeasurementOrPercent">
+    <xsd:union memberTypes="ST_DecimalNumberOrPercent s:ST_UniversalMeasure"/>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TblWidth">
+    <xsd:attribute name="w" type="ST_MeasurementOrPercent"/>
+    <xsd:attribute name="type" type="ST_TblWidth"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TblGridCol">
+    <xsd:attribute name="w" type="s:ST_TwipsMeasure"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TblGridBase">
+    <xsd:sequence>
+      <xsd:element name="gridCol" type="CT_TblGridCol" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TblGrid">
+    <xsd:complexContent>
+      <xsd:extension base="CT_TblGridBase">
+        <xsd:sequence>
+          <xsd:element name="tblGridChange" type="CT_TblGridChange" minOccurs="0"/>
+        </xsd:sequence>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TcBorders">
+    <xsd:sequence>
+      <xsd:element name="top" type="CT_Border" minOccurs="0"/>
+      <xsd:element name="start" type="CT_Border" minOccurs="0"/>
+      <xsd:element name="left" type="CT_Border" minOccurs="0"/>
+      <xsd:element name="bottom" type="CT_Border" minOccurs="0"/>
+      <xsd:element name="end" type="CT_Border" minOccurs="0"/>
+      <xsd:element name="right" type="CT_Border" minOccurs="0"/>
+      <xsd:element name="insideH" type="CT_Border" minOccurs="0"/>
+      <xsd:element name="insideV" type="CT_Border" minOccurs="0"/>
+      <xsd:element name="tl2br" type="CT_Border" minOccurs="0"/>
+      <xsd:element name="tr2bl" type="CT_Border" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TcMar">
+    <xsd:sequence>
+      <xsd:element name="top" type="CT_TblWidth" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="start" type="CT_TblWidth" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="left" type="CT_TblWidth" minOccurs="0"/>
+      <xsd:element name="bottom" type="CT_TblWidth" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="end" type="CT_TblWidth" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="right" type="CT_TblWidth" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_Merge">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="continue"/>
+      <xsd:enumeration value="restart"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_VMerge">
+    <xsd:attribute name="val" type="ST_Merge"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_HMerge">
+    <xsd:attribute name="val" type="ST_Merge"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TcPrBase">
+    <xsd:sequence>
+      <xsd:element name="cnfStyle" type="CT_Cnf" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tcW" type="CT_TblWidth" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="gridSpan" type="CT_DecimalNumber" minOccurs="0"/>
+      <xsd:element name="hMerge" type="CT_HMerge" minOccurs="0"/>
+      <xsd:element name="vMerge" type="CT_VMerge" minOccurs="0"/>
+      <xsd:element name="tcBorders" type="CT_TcBorders" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="shd" type="CT_Shd" minOccurs="0"/>
+      <xsd:element name="noWrap" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="tcMar" type="CT_TcMar" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="textDirection" type="CT_TextDirection" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tcFitText" type="CT_OnOff" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="vAlign" type="CT_VerticalJc" minOccurs="0"/>
+      <xsd:element name="hideMark" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="headers" type="CT_Headers" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TcPr">
+    <xsd:complexContent>
+      <xsd:extension base="CT_TcPrInner">
+        <xsd:sequence>
+          <xsd:element name="tcPrChange" type="CT_TcPrChange" minOccurs="0"/>
+        </xsd:sequence>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TcPrInner">
+    <xsd:complexContent>
+      <xsd:extension base="CT_TcPrBase">
+        <xsd:sequence>
+          <xsd:group ref="EG_CellMarkupElements" minOccurs="0" maxOccurs="1"/>
+        </xsd:sequence>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Tc">
+    <xsd:sequence>
+      <xsd:element name="tcPr" type="CT_TcPr" minOccurs="0" maxOccurs="1"/>
+      <xsd:group ref="EG_BlockLevelElts" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="s:ST_String" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_Cnf">
+    <xsd:restriction base="xsd:string">
+      <xsd:length value="12"/>
+      <xsd:pattern value="[01]*"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Cnf">
+    <xsd:attribute name="val" type="ST_Cnf"/>
+    <xsd:attribute name="firstRow" type="s:ST_OnOff"/>
+    <xsd:attribute name="lastRow" type="s:ST_OnOff"/>
+    <xsd:attribute name="firstColumn" type="s:ST_OnOff"/>
+    <xsd:attribute name="lastColumn" type="s:ST_OnOff"/>
+    <xsd:attribute name="oddVBand" type="s:ST_OnOff"/>
+    <xsd:attribute name="evenVBand" type="s:ST_OnOff"/>
+    <xsd:attribute name="oddHBand" type="s:ST_OnOff"/>
+    <xsd:attribute name="evenHBand" type="s:ST_OnOff"/>
+    <xsd:attribute name="firstRowFirstColumn" type="s:ST_OnOff"/>
+    <xsd:attribute name="firstRowLastColumn" type="s:ST_OnOff"/>
+    <xsd:attribute name="lastRowFirstColumn" type="s:ST_OnOff"/>
+    <xsd:attribute name="lastRowLastColumn" type="s:ST_OnOff"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Headers">
+    <xsd:sequence minOccurs="0" maxOccurs="unbounded">
+      <xsd:element name="header" type="CT_String"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TrPrBase">
+    <xsd:choice maxOccurs="unbounded">
+      <xsd:element name="cnfStyle" type="CT_Cnf" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="divId" type="CT_DecimalNumber" minOccurs="0"/>
+      <xsd:element name="gridBefore" type="CT_DecimalNumber" minOccurs="0"/>
+      <xsd:element name="gridAfter" type="CT_DecimalNumber" minOccurs="0"/>
+      <xsd:element name="wBefore" type="CT_TblWidth" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="wAfter" type="CT_TblWidth" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="cantSplit" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="trHeight" type="CT_Height" minOccurs="0"/>
+      <xsd:element name="tblHeader" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="tblCellSpacing" type="CT_TblWidth" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="jc" type="CT_JcTable" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="hidden" type="CT_OnOff" minOccurs="0"/>
+    </xsd:choice>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TrPr">
+    <xsd:complexContent>
+      <xsd:extension base="CT_TrPrBase">
+        <xsd:sequence>
+          <xsd:element name="ins" type="CT_TrackChange" minOccurs="0"/>
+          <xsd:element name="del" type="CT_TrackChange" minOccurs="0"/>
+          <xsd:element name="trPrChange" type="CT_TrPrChange" minOccurs="0"/>
+        </xsd:sequence>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Row">
+    <xsd:sequence>
+      <xsd:element name="tblPrEx" type="CT_TblPrEx" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="trPr" type="CT_TrPr" minOccurs="0" maxOccurs="1"/>
+      <xsd:group ref="EG_ContentCellContent" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="rsidRPr" type="ST_LongHexNumber"/>
+    <xsd:attribute name="rsidR" type="ST_LongHexNumber"/>
+    <xsd:attribute name="rsidDel" type="ST_LongHexNumber"/>
+    <xsd:attribute name="rsidTr" type="ST_LongHexNumber"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TblLayoutType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="fixed"/>
+      <xsd:enumeration value="autofit"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TblLayoutType">
+    <xsd:attribute name="type" type="ST_TblLayoutType"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TblOverlap">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="never"/>
+      <xsd:enumeration value="overlap"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TblOverlap">
+    <xsd:attribute name="val" type="ST_TblOverlap" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TblPPr">
+    <xsd:attribute name="leftFromText" type="s:ST_TwipsMeasure"/>
+    <xsd:attribute name="rightFromText" type="s:ST_TwipsMeasure"/>
+    <xsd:attribute name="topFromText" type="s:ST_TwipsMeasure"/>
+    <xsd:attribute name="bottomFromText" type="s:ST_TwipsMeasure"/>
+    <xsd:attribute name="vertAnchor" type="ST_VAnchor"/>
+    <xsd:attribute name="horzAnchor" type="ST_HAnchor"/>
+    <xsd:attribute name="tblpXSpec" type="s:ST_XAlign"/>
+    <xsd:attribute name="tblpX" type="ST_SignedTwipsMeasure"/>
+    <xsd:attribute name="tblpYSpec" type="s:ST_YAlign"/>
+    <xsd:attribute name="tblpY" type="ST_SignedTwipsMeasure"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TblCellMar">
+    <xsd:sequence>
+      <xsd:element name="top" type="CT_TblWidth" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="start" type="CT_TblWidth" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="left" type="CT_TblWidth" minOccurs="0"/>
+      <xsd:element name="bottom" type="CT_TblWidth" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="end" type="CT_TblWidth" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="right" type="CT_TblWidth" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TblBorders">
+    <xsd:sequence>
+      <xsd:element name="top" type="CT_Border" minOccurs="0"/>
+      <xsd:element name="start" type="CT_Border" minOccurs="0"/>
+      <xsd:element name="left" type="CT_Border" minOccurs="0"/>
+      <xsd:element name="bottom" type="CT_Border" minOccurs="0"/>
+      <xsd:element name="end" type="CT_Border" minOccurs="0"/>
+      <xsd:element name="right" type="CT_Border" minOccurs="0"/>
+      <xsd:element name="insideH" type="CT_Border" minOccurs="0"/>
+      <xsd:element name="insideV" type="CT_Border" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TblPrBase">
+    <xsd:sequence>
+      <xsd:element name="tblStyle" type="CT_String" minOccurs="0"/>
+      <xsd:element name="tblpPr" type="CT_TblPPr" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tblOverlap" type="CT_TblOverlap" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="bidiVisual" type="CT_OnOff" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tblStyleRowBandSize" type="CT_DecimalNumber" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tblStyleColBandSize" type="CT_DecimalNumber" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tblW" type="CT_TblWidth" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="jc" type="CT_JcTable" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tblCellSpacing" type="CT_TblWidth" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tblInd" type="CT_TblWidth" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tblBorders" type="CT_TblBorders" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="shd" type="CT_Shd" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tblLayout" type="CT_TblLayoutType" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tblCellMar" type="CT_TblCellMar" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tblLook" type="CT_TblLook" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tblCaption" type="CT_String" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tblDescription" type="CT_String" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TblPr">
+    <xsd:complexContent>
+      <xsd:extension base="CT_TblPrBase">
+        <xsd:sequence>
+          <xsd:element name="tblPrChange" type="CT_TblPrChange" minOccurs="0"/>
+        </xsd:sequence>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TblPrExBase">
+    <xsd:sequence>
+      <xsd:element name="tblW" type="CT_TblWidth" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="jc" type="CT_JcTable" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tblCellSpacing" type="CT_TblWidth" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tblInd" type="CT_TblWidth" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tblBorders" type="CT_TblBorders" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="shd" type="CT_Shd" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tblLayout" type="CT_TblLayoutType" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tblCellMar" type="CT_TblCellMar" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tblLook" type="CT_TblLook" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TblPrEx">
+    <xsd:complexContent>
+      <xsd:extension base="CT_TblPrExBase">
+        <xsd:sequence>
+          <xsd:element name="tblPrExChange" type="CT_TblPrExChange" minOccurs="0"/>
+        </xsd:sequence>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Tbl">
+    <xsd:sequence>
+      <xsd:group ref="EG_RangeMarkupElements" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="tblPr" type="CT_TblPr"/>
+      <xsd:element name="tblGrid" type="CT_TblGrid"/>
+      <xsd:group ref="EG_ContentRowContent" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TblLook">
+    <xsd:attribute name="firstRow" type="s:ST_OnOff"/>
+    <xsd:attribute name="lastRow" type="s:ST_OnOff"/>
+    <xsd:attribute name="firstColumn" type="s:ST_OnOff"/>
+    <xsd:attribute name="lastColumn" type="s:ST_OnOff"/>
+    <xsd:attribute name="noHBand" type="s:ST_OnOff"/>
+    <xsd:attribute name="noVBand" type="s:ST_OnOff"/>
+    <xsd:attribute name="val" type="ST_ShortHexNumber"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_FtnPos">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="pageBottom"/>
+      <xsd:enumeration value="beneathText"/>
+      <xsd:enumeration value="sectEnd"/>
+      <xsd:enumeration value="docEnd"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_FtnPos">
+    <xsd:attribute name="val" type="ST_FtnPos" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_EdnPos">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="sectEnd"/>
+      <xsd:enumeration value="docEnd"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_EdnPos">
+    <xsd:attribute name="val" type="ST_EdnPos" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_NumFmt">
+    <xsd:attribute name="val" type="ST_NumberFormat" use="required"/>
+    <xsd:attribute name="format" type="s:ST_String" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_RestartNumber">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="continuous"/>
+      <xsd:enumeration value="eachSect"/>
+      <xsd:enumeration value="eachPage"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_NumRestart">
+    <xsd:attribute name="val" type="ST_RestartNumber" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_FtnEdnRef">
+    <xsd:attribute name="customMarkFollows" type="s:ST_OnOff" use="optional"/>
+    <xsd:attribute name="id" use="required" type="ST_DecimalNumber"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_FtnEdnSepRef">
+    <xsd:attribute name="id" type="ST_DecimalNumber" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_FtnEdn">
+    <xsd:sequence>
+      <xsd:group ref="EG_BlockLevelElts" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="type" type="ST_FtnEdn" use="optional"/>
+    <xsd:attribute name="id" type="ST_DecimalNumber" use="required"/>
+  </xsd:complexType>
+  <xsd:group name="EG_FtnEdnNumProps">
+    <xsd:sequence>
+      <xsd:element name="numStart" type="CT_DecimalNumber" minOccurs="0"/>
+      <xsd:element name="numRestart" type="CT_NumRestart" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:group>
+  <xsd:complexType name="CT_FtnProps">
+    <xsd:sequence>
+      <xsd:element name="pos" type="CT_FtnPos" minOccurs="0"/>
+      <xsd:element name="numFmt" type="CT_NumFmt" minOccurs="0"/>
+      <xsd:group ref="EG_FtnEdnNumProps" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_EdnProps">
+    <xsd:sequence>
+      <xsd:element name="pos" type="CT_EdnPos" minOccurs="0"/>
+      <xsd:element name="numFmt" type="CT_NumFmt" minOccurs="0"/>
+      <xsd:group ref="EG_FtnEdnNumProps" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_FtnDocProps">
+    <xsd:complexContent>
+      <xsd:extension base="CT_FtnProps">
+        <xsd:sequence>
+          <xsd:element name="footnote" type="CT_FtnEdnSepRef" minOccurs="0" maxOccurs="3"/>
+        </xsd:sequence>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="CT_EdnDocProps">
+    <xsd:complexContent>
+      <xsd:extension base="CT_EdnProps">
+        <xsd:sequence>
+          <xsd:element name="endnote" type="CT_FtnEdnSepRef" minOccurs="0" maxOccurs="3"/>
+        </xsd:sequence>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="CT_RecipientData">
+    <xsd:sequence>
+      <xsd:element name="active" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="column" type="CT_DecimalNumber" minOccurs="1"/>
+      <xsd:element name="uniqueTag" type="CT_Base64Binary" minOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Base64Binary">
+    <xsd:attribute name="val" type="xsd:base64Binary" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Recipients">
+    <xsd:sequence>
+      <xsd:element name="recipientData" type="CT_RecipientData" minOccurs="1" maxOccurs="unbounded"
+      />
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="recipients" type="CT_Recipients"/>
+  <xsd:complexType name="CT_OdsoFieldMapData">
+    <xsd:sequence>
+      <xsd:element name="type" type="CT_MailMergeOdsoFMDFieldType" minOccurs="0"/>
+      <xsd:element name="name" type="CT_String" minOccurs="0"/>
+      <xsd:element name="mappedName" type="CT_String" minOccurs="0"/>
+      <xsd:element name="column" type="CT_DecimalNumber" minOccurs="0"/>
+      <xsd:element name="lid" type="CT_Lang" minOccurs="0"/>
+      <xsd:element name="dynamicAddress" type="CT_OnOff" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_MailMergeSourceType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="database"/>
+      <xsd:enumeration value="addressBook"/>
+      <xsd:enumeration value="document1"/>
+      <xsd:enumeration value="document2"/>
+      <xsd:enumeration value="text"/>
+      <xsd:enumeration value="email"/>
+      <xsd:enumeration value="native"/>
+      <xsd:enumeration value="legacy"/>
+      <xsd:enumeration value="master"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_MailMergeSourceType">
+    <xsd:attribute name="val" use="required" type="ST_MailMergeSourceType"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Odso">
+    <xsd:sequence>
+      <xsd:element name="udl" type="CT_String" minOccurs="0"/>
+      <xsd:element name="table" type="CT_String" minOccurs="0"/>
+      <xsd:element name="src" type="CT_Rel" minOccurs="0"/>
+      <xsd:element name="colDelim" type="CT_DecimalNumber" minOccurs="0"/>
+      <xsd:element name="type" type="CT_MailMergeSourceType" minOccurs="0"/>
+      <xsd:element name="fHdr" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="fieldMapData" type="CT_OdsoFieldMapData" minOccurs="0"
+        maxOccurs="unbounded"/>
+      <xsd:element name="recipientData" type="CT_Rel" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_MailMerge">
+    <xsd:sequence>
+      <xsd:element name="mainDocumentType" type="CT_MailMergeDocType" minOccurs="1"/>
+      <xsd:element name="linkToQuery" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="dataType" type="CT_MailMergeDataType" minOccurs="1"/>
+      <xsd:element name="connectString" type="CT_String" minOccurs="0"/>
+      <xsd:element name="query" type="CT_String" minOccurs="0"/>
+      <xsd:element name="dataSource" type="CT_Rel" minOccurs="0"/>
+      <xsd:element name="headerSource" type="CT_Rel" minOccurs="0"/>
+      <xsd:element name="doNotSuppressBlankLines" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="destination" type="CT_MailMergeDest" minOccurs="0"/>
+      <xsd:element name="addressFieldName" type="CT_String" minOccurs="0"/>
+      <xsd:element name="mailSubject" type="CT_String" minOccurs="0"/>
+      <xsd:element name="mailAsAttachment" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="viewMergedData" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="activeRecord" type="CT_DecimalNumber" minOccurs="0"/>
+      <xsd:element name="checkErrors" type="CT_DecimalNumber" minOccurs="0"/>
+      <xsd:element name="odso" type="CT_Odso" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TargetScreenSz">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="544x376"/>
+      <xsd:enumeration value="640x480"/>
+      <xsd:enumeration value="720x512"/>
+      <xsd:enumeration value="800x600"/>
+      <xsd:enumeration value="1024x768"/>
+      <xsd:enumeration value="1152x882"/>
+      <xsd:enumeration value="1152x900"/>
+      <xsd:enumeration value="1280x1024"/>
+      <xsd:enumeration value="1600x1200"/>
+      <xsd:enumeration value="1800x1440"/>
+      <xsd:enumeration value="1920x1200"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TargetScreenSz">
+    <xsd:attribute name="val" type="ST_TargetScreenSz" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Compat">
+    <xsd:sequence>
+      <xsd:element name="useSingleBorderforContiguousCells" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="wpJustification" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="noTabHangInd" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="noLeading" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="spaceForUL" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="noColumnBalance" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="balanceSingleByteDoubleByteWidth" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="noExtraLineSpacing" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="doNotLeaveBackslashAlone" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="ulTrailSpace" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="doNotExpandShiftReturn" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="spacingInWholePoints" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="lineWrapLikeWord6" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="printBodyTextBeforeHeader" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="printColBlack" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="wpSpaceWidth" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="showBreaksInFrames" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="subFontBySize" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="suppressBottomSpacing" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="suppressTopSpacing" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="suppressSpacingAtTopOfPage" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="suppressTopSpacingWP" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="suppressSpBfAfterPgBrk" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="swapBordersFacingPages" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="convMailMergeEsc" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="truncateFontHeightsLikeWP6" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="mwSmallCaps" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="usePrinterMetrics" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="doNotSuppressParagraphBorders" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="wrapTrailSpaces" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="footnoteLayoutLikeWW8" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="shapeLayoutLikeWW8" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="alignTablesRowByRow" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="forgetLastTabAlignment" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="adjustLineHeightInTable" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="autoSpaceLikeWord95" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="noSpaceRaiseLower" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="doNotUseHTMLParagraphAutoSpacing" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="layoutRawTableWidth" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="layoutTableRowsApart" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="useWord97LineBreakRules" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="doNotBreakWrappedTables" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="doNotSnapToGridInCell" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="selectFldWithFirstOrLastChar" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="applyBreakingRules" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="doNotWrapTextWithPunct" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="doNotUseEastAsianBreakRules" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="useWord2002TableStyleRules" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="growAutofit" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="useFELayout" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="useNormalStyleForList" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="doNotUseIndentAsNumberingTabStop" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="useAltKinsokuLineBreakRules" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="allowSpaceOfSameStyleInTable" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="doNotSuppressIndentation" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="doNotAutofitConstrainedTables" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="autofitToFirstFixedWidthCell" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="underlineTabInNumList" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="displayHangulFixedWidth" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="splitPgBreakAndParaMark" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="doNotVertAlignCellWithSp" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="doNotBreakConstrainedForcedTable" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="doNotVertAlignInTxbx" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="useAnsiKerningPairs" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="cachedColBalance" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="compatSetting" type="CT_CompatSetting" minOccurs="0" maxOccurs="unbounded"
+      />
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_CompatSetting">
+    <xsd:attribute name="name" type="s:ST_String"/>
+    <xsd:attribute name="uri" type="s:ST_String"/>
+    <xsd:attribute name="val" type="s:ST_String"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DocVar">
+    <xsd:attribute name="name" type="s:ST_String" use="required"/>
+    <xsd:attribute name="val" type="s:ST_String" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DocVars">
+    <xsd:sequence>
+      <xsd:element name="docVar" type="CT_DocVar" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DocRsids">
+    <xsd:sequence>
+      <xsd:element name="rsidRoot" type="CT_LongHexNumber" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="rsid" type="CT_LongHexNumber" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_CharacterSpacing">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="doNotCompress"/>
+      <xsd:enumeration value="compressPunctuation"/>
+      <xsd:enumeration value="compressPunctuationAndJapaneseKana"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_CharacterSpacing">
+    <xsd:attribute name="val" type="ST_CharacterSpacing" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_SaveThroughXslt">
+    <xsd:attribute ref="r:id" use="optional"/>
+    <xsd:attribute name="solutionID" type="s:ST_String" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_RPrDefault">
+    <xsd:sequence>
+      <xsd:element name="rPr" type="CT_RPr" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_PPrDefault">
+    <xsd:sequence>
+      <xsd:element name="pPr" type="CT_PPrGeneral" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DocDefaults">
+    <xsd:sequence>
+      <xsd:element name="rPrDefault" type="CT_RPrDefault" minOccurs="0"/>
+      <xsd:element name="pPrDefault" type="CT_PPrDefault" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_WmlColorSchemeIndex">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="dark1"/>
+      <xsd:enumeration value="light1"/>
+      <xsd:enumeration value="dark2"/>
+      <xsd:enumeration value="light2"/>
+      <xsd:enumeration value="accent1"/>
+      <xsd:enumeration value="accent2"/>
+      <xsd:enumeration value="accent3"/>
+      <xsd:enumeration value="accent4"/>
+      <xsd:enumeration value="accent5"/>
+      <xsd:enumeration value="accent6"/>
+      <xsd:enumeration value="hyperlink"/>
+      <xsd:enumeration value="followedHyperlink"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_ColorSchemeMapping">
+    <xsd:attribute name="bg1" type="ST_WmlColorSchemeIndex"/>
+    <xsd:attribute name="t1" type="ST_WmlColorSchemeIndex"/>
+    <xsd:attribute name="bg2" type="ST_WmlColorSchemeIndex"/>
+    <xsd:attribute name="t2" type="ST_WmlColorSchemeIndex"/>
+    <xsd:attribute name="accent1" type="ST_WmlColorSchemeIndex"/>
+    <xsd:attribute name="accent2" type="ST_WmlColorSchemeIndex"/>
+    <xsd:attribute name="accent3" type="ST_WmlColorSchemeIndex"/>
+    <xsd:attribute name="accent4" type="ST_WmlColorSchemeIndex"/>
+    <xsd:attribute name="accent5" type="ST_WmlColorSchemeIndex"/>
+    <xsd:attribute name="accent6" type="ST_WmlColorSchemeIndex"/>
+    <xsd:attribute name="hyperlink" type="ST_WmlColorSchemeIndex"/>
+    <xsd:attribute name="followedHyperlink" type="ST_WmlColorSchemeIndex"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ReadingModeInkLockDown">
+    <xsd:attribute name="actualPg" type="s:ST_OnOff" use="required"/>
+    <xsd:attribute name="w" type="ST_PixelsMeasure" use="required"/>
+    <xsd:attribute name="h" type="ST_PixelsMeasure" use="required"/>
+    <xsd:attribute name="fontSz" type="ST_DecimalNumberOrPercent" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_WriteProtection">
+    <xsd:attribute name="recommended" type="s:ST_OnOff" use="optional"/>
+    <xsd:attributeGroup ref="AG_Password"/>
+    <xsd:attributeGroup ref="AG_TransitionalPassword"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Settings">
+    <xsd:sequence>
+      <xsd:element name="writeProtection" type="CT_WriteProtection" minOccurs="0"/>
+      <xsd:element name="view" type="CT_View" minOccurs="0"/>
+      <xsd:element name="zoom" type="CT_Zoom" minOccurs="0"/>
+      <xsd:element name="removePersonalInformation" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="removeDateAndTime" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="doNotDisplayPageBoundaries" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="displayBackgroundShape" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="printPostScriptOverText" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="printFractionalCharacterWidth" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="printFormsData" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="embedTrueTypeFonts" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="embedSystemFonts" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="saveSubsetFonts" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="saveFormsData" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="mirrorMargins" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="alignBordersAndEdges" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="bordersDoNotSurroundHeader" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="bordersDoNotSurroundFooter" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="gutterAtTop" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="hideSpellingErrors" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="hideGrammaticalErrors" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="activeWritingStyle" type="CT_WritingStyle" minOccurs="0"
+        maxOccurs="unbounded"/>
+      <xsd:element name="proofState" type="CT_Proof" minOccurs="0"/>
+      <xsd:element name="formsDesign" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="attachedTemplate" type="CT_Rel" minOccurs="0"/>
+      <xsd:element name="linkStyles" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="stylePaneFormatFilter" type="CT_StylePaneFilter" minOccurs="0"/>
+      <xsd:element name="stylePaneSortMethod" type="CT_StyleSort" minOccurs="0"/>
+      <xsd:element name="documentType" type="CT_DocType" minOccurs="0"/>
+      <xsd:element name="mailMerge" type="CT_MailMerge" minOccurs="0"/>
+      <xsd:element name="revisionView" type="CT_TrackChangesView" minOccurs="0"/>
+      <xsd:element name="trackRevisions" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="doNotTrackMoves" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="doNotTrackFormatting" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="documentProtection" type="CT_DocProtect" minOccurs="0"/>
+      <xsd:element name="autoFormatOverride" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="styleLockTheme" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="styleLockQFSet" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="defaultTabStop" type="CT_TwipsMeasure" minOccurs="0"/>
+      <xsd:element name="autoHyphenation" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="consecutiveHyphenLimit" type="CT_DecimalNumber" minOccurs="0"/>
+      <xsd:element name="hyphenationZone" type="CT_TwipsMeasure" minOccurs="0"/>
+      <xsd:element name="doNotHyphenateCaps" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="showEnvelope" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="summaryLength" type="CT_DecimalNumberOrPrecent" minOccurs="0"/>
+      <xsd:element name="clickAndTypeStyle" type="CT_String" minOccurs="0"/>
+      <xsd:element name="defaultTableStyle" type="CT_String" minOccurs="0"/>
+      <xsd:element name="evenAndOddHeaders" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="bookFoldRevPrinting" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="bookFoldPrinting" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="bookFoldPrintingSheets" type="CT_DecimalNumber" minOccurs="0"/>
+      <xsd:element name="drawingGridHorizontalSpacing" type="CT_TwipsMeasure" minOccurs="0"/>
+      <xsd:element name="drawingGridVerticalSpacing" type="CT_TwipsMeasure" minOccurs="0"/>
+      <xsd:element name="displayHorizontalDrawingGridEvery" type="CT_DecimalNumber" minOccurs="0"/>
+      <xsd:element name="displayVerticalDrawingGridEvery" type="CT_DecimalNumber" minOccurs="0"/>
+      <xsd:element name="doNotUseMarginsForDrawingGridOrigin" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="drawingGridHorizontalOrigin" type="CT_TwipsMeasure" minOccurs="0"/>
+      <xsd:element name="drawingGridVerticalOrigin" type="CT_TwipsMeasure" minOccurs="0"/>
+      <xsd:element name="doNotShadeFormData" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="noPunctuationKerning" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="characterSpacingControl" type="CT_CharacterSpacing" minOccurs="0"/>
+      <xsd:element name="printTwoOnOne" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="strictFirstAndLastChars" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="noLineBreaksAfter" type="CT_Kinsoku" minOccurs="0"/>
+      <xsd:element name="noLineBreaksBefore" type="CT_Kinsoku" minOccurs="0"/>
+      <xsd:element name="savePreviewPicture" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="doNotValidateAgainstSchema" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="saveInvalidXml" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="ignoreMixedContent" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="alwaysShowPlaceholderText" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="doNotDemarcateInvalidXml" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="saveXmlDataOnly" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="useXSLTWhenSaving" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="saveThroughXslt" type="CT_SaveThroughXslt" minOccurs="0"/>
+      <xsd:element name="showXMLTags" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="alwaysMergeEmptyNamespace" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="updateFields" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="hdrShapeDefaults" type="CT_ShapeDefaults" minOccurs="0"/>
+      <xsd:element name="footnotePr" type="CT_FtnDocProps" minOccurs="0"/>
+      <xsd:element name="endnotePr" type="CT_EdnDocProps" minOccurs="0"/>
+      <xsd:element name="compat" type="CT_Compat" minOccurs="0"/>
+      <xsd:element name="docVars" type="CT_DocVars" minOccurs="0"/>
+      <xsd:element name="rsids" type="CT_DocRsids" minOccurs="0"/>
+      <xsd:element ref="m:mathPr" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="attachedSchema" type="CT_String" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="themeFontLang" type="CT_Language" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="clrSchemeMapping" type="CT_ColorSchemeMapping" minOccurs="0"/>
+      <xsd:element name="doNotIncludeSubdocsInStats" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="doNotAutoCompressPictures" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="forceUpgrade" type="CT_Empty" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="captions" type="CT_Captions" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="readModeInkLockDown" type="CT_ReadingModeInkLockDown" minOccurs="0"/>
+      <xsd:element name="smartTagType" type="CT_SmartTagType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element ref="sl:schemaLibrary" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="shapeDefaults" type="CT_ShapeDefaults" minOccurs="0"/>
+      <xsd:element name="doNotEmbedSmartTags" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="decimalSymbol" type="CT_String" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="listSeparator" type="CT_String" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_StyleSort">
+    <xsd:attribute name="val" type="ST_StyleSort" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_StylePaneFilter">
+    <xsd:attribute name="allStyles" type="s:ST_OnOff"/>
+    <xsd:attribute name="customStyles" type="s:ST_OnOff"/>
+    <xsd:attribute name="latentStyles" type="s:ST_OnOff"/>
+    <xsd:attribute name="stylesInUse" type="s:ST_OnOff"/>
+    <xsd:attribute name="headingStyles" type="s:ST_OnOff"/>
+    <xsd:attribute name="numberingStyles" type="s:ST_OnOff"/>
+    <xsd:attribute name="tableStyles" type="s:ST_OnOff"/>
+    <xsd:attribute name="directFormattingOnRuns" type="s:ST_OnOff"/>
+    <xsd:attribute name="directFormattingOnParagraphs" type="s:ST_OnOff"/>
+    <xsd:attribute name="directFormattingOnNumbering" type="s:ST_OnOff"/>
+    <xsd:attribute name="directFormattingOnTables" type="s:ST_OnOff"/>
+    <xsd:attribute name="clearFormatting" type="s:ST_OnOff"/>
+    <xsd:attribute name="top3HeadingStyles" type="s:ST_OnOff"/>
+    <xsd:attribute name="visibleStyles" type="s:ST_OnOff"/>
+    <xsd:attribute name="alternateStyleNames" type="s:ST_OnOff"/>
+    <xsd:attribute name="val" type="ST_ShortHexNumber"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_StyleSort">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="name"/>
+      <xsd:enumeration value="priority"/>
+      <xsd:enumeration value="default"/>
+      <xsd:enumeration value="font"/>
+      <xsd:enumeration value="basedOn"/>
+      <xsd:enumeration value="type"/>
+      <xsd:enumeration value="0000"/>
+      <xsd:enumeration value="0001"/>
+      <xsd:enumeration value="0002"/>
+      <xsd:enumeration value="0003"/>
+      <xsd:enumeration value="0004"/>
+      <xsd:enumeration value="0005"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_WebSettings">
+    <xsd:sequence>
+      <xsd:element name="frameset" type="CT_Frameset" minOccurs="0"/>
+      <xsd:element name="divs" type="CT_Divs" minOccurs="0"/>
+      <xsd:element name="encoding" type="CT_String" minOccurs="0"/>
+      <xsd:element name="optimizeForBrowser" type="CT_OptimizeForBrowser" minOccurs="0"/>
+      <xsd:element name="relyOnVML" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="allowPNG" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="doNotRelyOnCSS" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="doNotSaveAsSingleFile" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="doNotOrganizeInFolder" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="doNotUseLongFileNames" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="pixelsPerInch" type="CT_DecimalNumber" minOccurs="0"/>
+      <xsd:element name="targetScreenSz" type="CT_TargetScreenSz" minOccurs="0"/>
+      <xsd:element name="saveSmartTagsAsXml" type="CT_OnOff" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_FrameScrollbar">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="on"/>
+      <xsd:enumeration value="off"/>
+      <xsd:enumeration value="auto"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_FrameScrollbar">
+    <xsd:attribute name="val" type="ST_FrameScrollbar" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_OptimizeForBrowser">
+    <xsd:complexContent>
+      <xsd:extension base="CT_OnOff">
+        <xsd:attribute name="target" type="s:ST_String" use="optional"/>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Frame">
+    <xsd:sequence>
+      <xsd:element name="sz" type="CT_String" minOccurs="0"/>
+      <xsd:element name="name" type="CT_String" minOccurs="0"/>
+      <xsd:element name="title" type="CT_String" minOccurs="0"/>
+      <xsd:element name="longDesc" type="CT_Rel" minOccurs="0"/>
+      <xsd:element name="sourceFileName" type="CT_Rel" minOccurs="0"/>
+      <xsd:element name="marW" type="CT_PixelsMeasure" minOccurs="0"/>
+      <xsd:element name="marH" type="CT_PixelsMeasure" minOccurs="0"/>
+      <xsd:element name="scrollbar" type="CT_FrameScrollbar" minOccurs="0"/>
+      <xsd:element name="noResizeAllowed" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="linkedToFile" type="CT_OnOff" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_FrameLayout">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="rows"/>
+      <xsd:enumeration value="cols"/>
+      <xsd:enumeration value="none"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_FrameLayout">
+    <xsd:attribute name="val" type="ST_FrameLayout" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_FramesetSplitbar">
+    <xsd:sequence>
+      <xsd:element name="w" type="CT_TwipsMeasure" minOccurs="0"/>
+      <xsd:element name="color" type="CT_Color" minOccurs="0"/>
+      <xsd:element name="noBorder" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="flatBorders" type="CT_OnOff" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Frameset">
+    <xsd:sequence>
+      <xsd:element name="sz" type="CT_String" minOccurs="0"/>
+      <xsd:element name="framesetSplitbar" type="CT_FramesetSplitbar" minOccurs="0"/>
+      <xsd:element name="frameLayout" type="CT_FrameLayout" minOccurs="0"/>
+      <xsd:element name="title" type="CT_String" minOccurs="0"/>
+      <xsd:choice minOccurs="0" maxOccurs="unbounded">
+        <xsd:element name="frameset" type="CT_Frameset" minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element name="frame" type="CT_Frame" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:choice>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_NumPicBullet">
+    <xsd:choice>
+      <xsd:element name="pict" type="CT_Picture"/>
+      <xsd:element name="drawing" type="CT_Drawing"/>
+    </xsd:choice>
+    <xsd:attribute name="numPicBulletId" type="ST_DecimalNumber" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_LevelSuffix">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="tab"/>
+      <xsd:enumeration value="space"/>
+      <xsd:enumeration value="nothing"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_LevelSuffix">
+    <xsd:attribute name="val" type="ST_LevelSuffix" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_LevelText">
+    <xsd:attribute name="val" type="s:ST_String" use="optional"/>
+    <xsd:attribute name="null" type="s:ST_OnOff" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_LvlLegacy">
+    <xsd:attribute name="legacy" type="s:ST_OnOff" use="optional"/>
+    <xsd:attribute name="legacySpace" type="s:ST_TwipsMeasure" use="optional"/>
+    <xsd:attribute name="legacyIndent" type="ST_SignedTwipsMeasure" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Lvl">
+    <xsd:sequence>
+      <xsd:element name="start" type="CT_DecimalNumber" minOccurs="0"/>
+      <xsd:element name="numFmt" type="CT_NumFmt" minOccurs="0"/>
+      <xsd:element name="lvlRestart" type="CT_DecimalNumber" minOccurs="0"/>
+      <xsd:element name="pStyle" type="CT_String" minOccurs="0"/>
+      <xsd:element name="isLgl" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="suff" type="CT_LevelSuffix" minOccurs="0"/>
+      <xsd:element name="lvlText" type="CT_LevelText" minOccurs="0"/>
+      <xsd:element name="lvlPicBulletId" type="CT_DecimalNumber" minOccurs="0"/>
+      <xsd:element name="legacy" type="CT_LvlLegacy" minOccurs="0"/>
+      <xsd:element name="lvlJc" type="CT_Jc" minOccurs="0"/>
+      <xsd:element name="pPr" type="CT_PPrGeneral" minOccurs="0"/>
+      <xsd:element name="rPr" type="CT_RPr" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="ilvl" type="ST_DecimalNumber" use="required"/>
+    <xsd:attribute name="tplc" type="ST_LongHexNumber" use="optional"/>
+    <xsd:attribute name="tentative" type="s:ST_OnOff" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_MultiLevelType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="singleLevel"/>
+      <xsd:enumeration value="multilevel"/>
+      <xsd:enumeration value="hybridMultilevel"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_MultiLevelType">
+    <xsd:attribute name="val" type="ST_MultiLevelType" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_AbstractNum">
+    <xsd:sequence>
+      <xsd:element name="nsid" type="CT_LongHexNumber" minOccurs="0"/>
+      <xsd:element name="multiLevelType" type="CT_MultiLevelType" minOccurs="0"/>
+      <xsd:element name="tmpl" type="CT_LongHexNumber" minOccurs="0"/>
+      <xsd:element name="name" type="CT_String" minOccurs="0"/>
+      <xsd:element name="styleLink" type="CT_String" minOccurs="0"/>
+      <xsd:element name="numStyleLink" type="CT_String" minOccurs="0"/>
+      <xsd:element name="lvl" type="CT_Lvl" minOccurs="0" maxOccurs="9"/>
+    </xsd:sequence>
+    <xsd:attribute name="abstractNumId" type="ST_DecimalNumber" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_NumLvl">
+    <xsd:sequence>
+      <xsd:element name="startOverride" type="CT_DecimalNumber" minOccurs="0"/>
+      <xsd:element name="lvl" type="CT_Lvl" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="ilvl" type="ST_DecimalNumber" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Num">
+    <xsd:sequence>
+      <xsd:element name="abstractNumId" type="CT_DecimalNumber" minOccurs="1"/>
+      <xsd:element name="lvlOverride" type="CT_NumLvl" minOccurs="0" maxOccurs="9"/>
+    </xsd:sequence>
+    <xsd:attribute name="numId" type="ST_DecimalNumber" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Numbering">
+    <xsd:sequence>
+      <xsd:element name="numPicBullet" type="CT_NumPicBullet" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="abstractNum" type="CT_AbstractNum" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="num" type="CT_Num" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="numIdMacAtCleanup" type="CT_DecimalNumber" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_TblStyleOverrideType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="wholeTable"/>
+      <xsd:enumeration value="firstRow"/>
+      <xsd:enumeration value="lastRow"/>
+      <xsd:enumeration value="firstCol"/>
+      <xsd:enumeration value="lastCol"/>
+      <xsd:enumeration value="band1Vert"/>
+      <xsd:enumeration value="band2Vert"/>
+      <xsd:enumeration value="band1Horz"/>
+      <xsd:enumeration value="band2Horz"/>
+      <xsd:enumeration value="neCell"/>
+      <xsd:enumeration value="nwCell"/>
+      <xsd:enumeration value="seCell"/>
+      <xsd:enumeration value="swCell"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_TblStylePr">
+    <xsd:sequence>
+      <xsd:element name="pPr" type="CT_PPrGeneral" minOccurs="0"/>
+      <xsd:element name="rPr" type="CT_RPr" minOccurs="0"/>
+      <xsd:element name="tblPr" type="CT_TblPrBase" minOccurs="0"/>
+      <xsd:element name="trPr" type="CT_TrPr" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tcPr" type="CT_TcPr" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="type" type="ST_TblStyleOverrideType" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_StyleType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="paragraph"/>
+      <xsd:enumeration value="character"/>
+      <xsd:enumeration value="table"/>
+      <xsd:enumeration value="numbering"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Style">
+    <xsd:sequence>
+      <xsd:element name="name" type="CT_String" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="aliases" type="CT_String" minOccurs="0"/>
+      <xsd:element name="basedOn" type="CT_String" minOccurs="0"/>
+      <xsd:element name="next" type="CT_String" minOccurs="0"/>
+      <xsd:element name="link" type="CT_String" minOccurs="0"/>
+      <xsd:element name="autoRedefine" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="hidden" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="uiPriority" type="CT_DecimalNumber" minOccurs="0"/>
+      <xsd:element name="semiHidden" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="unhideWhenUsed" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="qFormat" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="locked" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="personal" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="personalCompose" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="personalReply" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="rsid" type="CT_LongHexNumber" minOccurs="0"/>
+      <xsd:element name="pPr" type="CT_PPrGeneral" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="rPr" type="CT_RPr" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tblPr" type="CT_TblPrBase" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="trPr" type="CT_TrPr" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tcPr" type="CT_TcPr" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="tblStylePr" type="CT_TblStylePr" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="type" type="ST_StyleType" use="optional"/>
+    <xsd:attribute name="styleId" type="s:ST_String" use="optional"/>
+    <xsd:attribute name="default" type="s:ST_OnOff" use="optional"/>
+    <xsd:attribute name="customStyle" type="s:ST_OnOff" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_LsdException">
+    <xsd:attribute name="name" type="s:ST_String" use="required"/>
+    <xsd:attribute name="locked" type="s:ST_OnOff"/>
+    <xsd:attribute name="uiPriority" type="ST_DecimalNumber"/>
+    <xsd:attribute name="semiHidden" type="s:ST_OnOff"/>
+    <xsd:attribute name="unhideWhenUsed" type="s:ST_OnOff"/>
+    <xsd:attribute name="qFormat" type="s:ST_OnOff"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_LatentStyles">
+    <xsd:sequence>
+      <xsd:element name="lsdException" type="CT_LsdException" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="defLockedState" type="s:ST_OnOff"/>
+    <xsd:attribute name="defUIPriority" type="ST_DecimalNumber"/>
+    <xsd:attribute name="defSemiHidden" type="s:ST_OnOff"/>
+    <xsd:attribute name="defUnhideWhenUsed" type="s:ST_OnOff"/>
+    <xsd:attribute name="defQFormat" type="s:ST_OnOff"/>
+    <xsd:attribute name="count" type="ST_DecimalNumber"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Styles">
+    <xsd:sequence>
+      <xsd:element name="docDefaults" type="CT_DocDefaults" minOccurs="0"/>
+      <xsd:element name="latentStyles" type="CT_LatentStyles" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="style" type="CT_Style" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Panose">
+    <xsd:attribute name="val" type="s:ST_Panose" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_FontFamily">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="decorative"/>
+      <xsd:enumeration value="modern"/>
+      <xsd:enumeration value="roman"/>
+      <xsd:enumeration value="script"/>
+      <xsd:enumeration value="swiss"/>
+      <xsd:enumeration value="auto"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_FontFamily">
+    <xsd:attribute name="val" type="ST_FontFamily" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_Pitch">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="fixed"/>
+      <xsd:enumeration value="variable"/>
+      <xsd:enumeration value="default"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Pitch">
+    <xsd:attribute name="val" type="ST_Pitch" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_FontSig">
+    <xsd:attribute name="usb0" use="required" type="ST_LongHexNumber"/>
+    <xsd:attribute name="usb1" use="required" type="ST_LongHexNumber"/>
+    <xsd:attribute name="usb2" use="required" type="ST_LongHexNumber"/>
+    <xsd:attribute name="usb3" use="required" type="ST_LongHexNumber"/>
+    <xsd:attribute name="csb0" use="required" type="ST_LongHexNumber"/>
+    <xsd:attribute name="csb1" use="required" type="ST_LongHexNumber"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_FontRel">
+    <xsd:complexContent>
+      <xsd:extension base="CT_Rel">
+        <xsd:attribute name="fontKey" type="s:ST_Guid"/>
+        <xsd:attribute name="subsetted" type="s:ST_OnOff"/>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Font">
+    <xsd:sequence>
+      <xsd:element name="altName" type="CT_String" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="panose1" type="CT_Panose" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="charset" type="CT_Charset" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="family" type="CT_FontFamily" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="notTrueType" type="CT_OnOff" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="pitch" type="CT_Pitch" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="sig" type="CT_FontSig" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="embedRegular" type="CT_FontRel" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="embedBold" type="CT_FontRel" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="embedItalic" type="CT_FontRel" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="embedBoldItalic" type="CT_FontRel" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="s:ST_String" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_FontsList">
+    <xsd:sequence>
+      <xsd:element name="font" type="CT_Font" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DivBdr">
+    <xsd:sequence>
+      <xsd:element name="top" type="CT_Border" minOccurs="0"/>
+      <xsd:element name="left" type="CT_Border" minOccurs="0"/>
+      <xsd:element name="bottom" type="CT_Border" minOccurs="0"/>
+      <xsd:element name="right" type="CT_Border" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Div">
+    <xsd:sequence>
+      <xsd:element name="blockQuote" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="bodyDiv" type="CT_OnOff" minOccurs="0"/>
+      <xsd:element name="marLeft" type="CT_SignedTwipsMeasure"/>
+      <xsd:element name="marRight" type="CT_SignedTwipsMeasure"/>
+      <xsd:element name="marTop" type="CT_SignedTwipsMeasure"/>
+      <xsd:element name="marBottom" type="CT_SignedTwipsMeasure"/>
+      <xsd:element name="divBdr" type="CT_DivBdr" minOccurs="0"/>
+      <xsd:element name="divsChild" type="CT_Divs" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="ST_DecimalNumber" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Divs">
+    <xsd:sequence minOccurs="1" maxOccurs="unbounded">
+      <xsd:element name="div" type="CT_Div"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_TxbxContent">
+    <xsd:group ref="EG_BlockLevelElts" minOccurs="1" maxOccurs="unbounded"/>
+  </xsd:complexType>
+  <xsd:element name="txbxContent" type="CT_TxbxContent"/>
+  <xsd:group name="EG_MathContent">
+    <xsd:choice>
+      <xsd:element ref="m:oMathPara"/>
+      <xsd:element ref="m:oMath"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:group name="EG_BlockLevelChunkElts">
+    <xsd:choice>
+      <xsd:group ref="EG_ContentBlockContent" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:group name="EG_BlockLevelElts">
+    <xsd:choice>
+      <xsd:group ref="EG_BlockLevelChunkElts" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="altChunk" type="CT_AltChunk" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:group name="EG_RunLevelElts">
+    <xsd:choice>
+      <xsd:element name="proofErr" minOccurs="0" type="CT_ProofErr"/>
+      <xsd:element name="permStart" minOccurs="0" type="CT_PermStart"/>
+      <xsd:element name="permEnd" minOccurs="0" type="CT_Perm"/>
+      <xsd:group ref="EG_RangeMarkupElements" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="ins" type="CT_RunTrackChange" minOccurs="0"/>
+      <xsd:element name="del" type="CT_RunTrackChange" minOccurs="0"/>
+      <xsd:element name="moveFrom" type="CT_RunTrackChange"/>
+      <xsd:element name="moveTo" type="CT_RunTrackChange"/>
+      <xsd:group ref="EG_MathContent" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:complexType name="CT_Body">
+    <xsd:sequence>
+      <xsd:group ref="EG_BlockLevelElts" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="sectPr" minOccurs="0" maxOccurs="1" type="CT_SectPr"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_ShapeDefaults">
+    <xsd:choice maxOccurs="unbounded">
+      <xsd:any processContents="lax" namespace="urn:schemas-microsoft-com:office:office"
+        minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:choice>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Comments">
+    <xsd:sequence>
+      <xsd:element name="comment" type="CT_Comment" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="comments" type="CT_Comments"/>
+  <xsd:complexType name="CT_Footnotes">
+    <xsd:sequence maxOccurs="unbounded">
+      <xsd:element name="footnote" type="CT_FtnEdn" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="footnotes" type="CT_Footnotes"/>
+  <xsd:complexType name="CT_Endnotes">
+    <xsd:sequence maxOccurs="unbounded">
+      <xsd:element name="endnote" type="CT_FtnEdn" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="endnotes" type="CT_Endnotes"/>
+  <xsd:element name="hdr" type="CT_HdrFtr"/>
+  <xsd:element name="ftr" type="CT_HdrFtr"/>
+  <xsd:complexType name="CT_SmartTagType">
+    <xsd:attribute name="namespaceuri" type="s:ST_String"/>
+    <xsd:attribute name="name" type="s:ST_String"/>
+    <xsd:attribute name="url" type="s:ST_String"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_ThemeColor">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="dark1"/>
+      <xsd:enumeration value="light1"/>
+      <xsd:enumeration value="dark2"/>
+      <xsd:enumeration value="light2"/>
+      <xsd:enumeration value="accent1"/>
+      <xsd:enumeration value="accent2"/>
+      <xsd:enumeration value="accent3"/>
+      <xsd:enumeration value="accent4"/>
+      <xsd:enumeration value="accent5"/>
+      <xsd:enumeration value="accent6"/>
+      <xsd:enumeration value="hyperlink"/>
+      <xsd:enumeration value="followedHyperlink"/>
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="background1"/>
+      <xsd:enumeration value="text1"/>
+      <xsd:enumeration value="background2"/>
+      <xsd:enumeration value="text2"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ST_DocPartBehavior">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="content"/>
+      <xsd:enumeration value="p"/>
+      <xsd:enumeration value="pg"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_DocPartBehavior">
+    <xsd:attribute name="val" use="required" type="ST_DocPartBehavior"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DocPartBehaviors">
+    <xsd:choice>
+      <xsd:element name="behavior" type="CT_DocPartBehavior" maxOccurs="unbounded"/>
+    </xsd:choice>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_DocPartType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="normal"/>
+      <xsd:enumeration value="autoExp"/>
+      <xsd:enumeration value="toolbar"/>
+      <xsd:enumeration value="speller"/>
+      <xsd:enumeration value="formFld"/>
+      <xsd:enumeration value="bbPlcHdr"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_DocPartType">
+    <xsd:attribute name="val" use="required" type="ST_DocPartType"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DocPartTypes">
+    <xsd:choice>
+      <xsd:element name="type" type="CT_DocPartType" maxOccurs="unbounded"/>
+    </xsd:choice>
+    <xsd:attribute name="all" type="s:ST_OnOff" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="ST_DocPartGallery">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="placeholder"/>
+      <xsd:enumeration value="any"/>
+      <xsd:enumeration value="default"/>
+      <xsd:enumeration value="docParts"/>
+      <xsd:enumeration value="coverPg"/>
+      <xsd:enumeration value="eq"/>
+      <xsd:enumeration value="ftrs"/>
+      <xsd:enumeration value="hdrs"/>
+      <xsd:enumeration value="pgNum"/>
+      <xsd:enumeration value="tbls"/>
+      <xsd:enumeration value="watermarks"/>
+      <xsd:enumeration value="autoTxt"/>
+      <xsd:enumeration value="txtBox"/>
+      <xsd:enumeration value="pgNumT"/>
+      <xsd:enumeration value="pgNumB"/>
+      <xsd:enumeration value="pgNumMargins"/>
+      <xsd:enumeration value="tblOfContents"/>
+      <xsd:enumeration value="bib"/>
+      <xsd:enumeration value="custQuickParts"/>
+      <xsd:enumeration value="custCoverPg"/>
+      <xsd:enumeration value="custEq"/>
+      <xsd:enumeration value="custFtrs"/>
+      <xsd:enumeration value="custHdrs"/>
+      <xsd:enumeration value="custPgNum"/>
+      <xsd:enumeration value="custTbls"/>
+      <xsd:enumeration value="custWatermarks"/>
+      <xsd:enumeration value="custAutoTxt"/>
+      <xsd:enumeration value="custTxtBox"/>
+      <xsd:enumeration value="custPgNumT"/>
+      <xsd:enumeration value="custPgNumB"/>
+      <xsd:enumeration value="custPgNumMargins"/>
+      <xsd:enumeration value="custTblOfContents"/>
+      <xsd:enumeration value="custBib"/>
+      <xsd:enumeration value="custom1"/>
+      <xsd:enumeration value="custom2"/>
+      <xsd:enumeration value="custom3"/>
+      <xsd:enumeration value="custom4"/>
+      <xsd:enumeration value="custom5"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_DocPartGallery">
+    <xsd:attribute name="val" type="ST_DocPartGallery" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DocPartCategory">
+    <xsd:sequence>
+      <xsd:element name="name" type="CT_String" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="gallery" type="CT_DocPartGallery" minOccurs="1" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DocPartName">
+    <xsd:attribute name="val" type="s:ST_String" use="required"/>
+    <xsd:attribute name="decorated" type="s:ST_OnOff" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DocPartPr">
+    <xsd:all>
+      <xsd:element name="name" type="CT_DocPartName" minOccurs="1"/>
+      <xsd:element name="style" type="CT_String" minOccurs="0"/>
+      <xsd:element name="category" type="CT_DocPartCategory" minOccurs="0"/>
+      <xsd:element name="types" type="CT_DocPartTypes" minOccurs="0"/>
+      <xsd:element name="behaviors" type="CT_DocPartBehaviors" minOccurs="0"/>
+      <xsd:element name="description" type="CT_String" minOccurs="0"/>
+      <xsd:element name="guid" type="CT_Guid" minOccurs="0"/>
+    </xsd:all>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DocPart">
+    <xsd:sequence>
+      <xsd:element name="docPartPr" type="CT_DocPartPr" minOccurs="0"/>
+      <xsd:element name="docPartBody" type="CT_Body" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DocParts">
+    <xsd:choice>
+      <xsd:element name="docPart" type="CT_DocPart" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:choice>
+  </xsd:complexType>
+  <xsd:element name="settings" type="CT_Settings"/>
+  <xsd:element name="webSettings" type="CT_WebSettings"/>
+  <xsd:element name="fonts" type="CT_FontsList"/>
+  <xsd:element name="numbering" type="CT_Numbering"/>
+  <xsd:element name="styles" type="CT_Styles"/>
+  <xsd:simpleType name="ST_CaptionPos">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="above"/>
+      <xsd:enumeration value="below"/>
+      <xsd:enumeration value="left"/>
+      <xsd:enumeration value="right"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="CT_Caption">
+    <xsd:attribute name="name" type="s:ST_String" use="required"/>
+    <xsd:attribute name="pos" type="ST_CaptionPos" use="optional"/>
+    <xsd:attribute name="chapNum" type="s:ST_OnOff" use="optional"/>
+    <xsd:attribute name="heading" type="ST_DecimalNumber" use="optional"/>
+    <xsd:attribute name="noLabel" type="s:ST_OnOff" use="optional"/>
+    <xsd:attribute name="numFmt" type="ST_NumberFormat" use="optional"/>
+    <xsd:attribute name="sep" type="ST_ChapterSep" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_AutoCaption">
+    <xsd:attribute name="name" type="s:ST_String" use="required"/>
+    <xsd:attribute name="caption" type="s:ST_String" use="required"/>
+  </xsd:complexType>
+  <xsd:complexType name="CT_AutoCaptions">
+    <xsd:sequence>
+      <xsd:element name="autoCaption" type="CT_AutoCaption" minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Captions">
+    <xsd:sequence>
+      <xsd:element name="caption" type="CT_Caption" minOccurs="1" maxOccurs="unbounded"/>
+      <xsd:element name="autoCaptions" type="CT_AutoCaptions" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_DocumentBase">
+    <xsd:sequence>
+      <xsd:element name="background" type="CT_Background" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_Document">
+    <xsd:complexContent>
+      <xsd:extension base="CT_DocumentBase">
+        <xsd:sequence>
+          <xsd:element name="body" type="CT_Body" minOccurs="0" maxOccurs="1"/>
+        </xsd:sequence>
+        <xsd:attribute name="conformance" type="s:ST_ConformanceClass"/>
+        <xsd:attribute ref="mc:Ignorable" use="optional" />
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="CT_GlossaryDocument">
+    <xsd:complexContent>
+      <xsd:extension base="CT_DocumentBase">
+        <xsd:sequence>
+          <xsd:element name="docParts" type="CT_DocParts" minOccurs="0"/>
+        </xsd:sequence>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:element name="document" type="CT_Document"/>
+  <xsd:element name="glossaryDocument" type="CT_GlossaryDocument"/>
+</xsd:schema>

--- a/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/xml.xsd
+++ b/skills/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/xml.xsd
@@ -1,0 +1,116 @@
+<?xml version='1.0'?>
+<xs:schema targetNamespace="http://www.w3.org/XML/1998/namespace" xmlns:xs="http://www.w3.org/2001/XMLSchema" xml:lang="en">
+
+ <xs:annotation>
+  <xs:documentation>
+   See http://www.w3.org/XML/1998/namespace.html and
+   http://www.w3.org/TR/REC-xml for information about this namespace.
+
+    This schema document describes the XML namespace, in a form
+    suitable for import by other schema documents.  
+
+    Note that local names in this namespace are intended to be defined
+    only by the World Wide Web Consortium or its subgroups.  The
+    following names are currently defined in this namespace and should
+    not be used with conflicting semantics by any Working Group,
+    specification, or document instance:
+
+    base (as an attribute name): denotes an attribute whose value
+         provides a URI to be used as the base for interpreting any
+         relative URIs in the scope of the element on which it
+         appears; its value is inherited.  This name is reserved
+         by virtue of its definition in the XML Base specification.
+
+    lang (as an attribute name): denotes an attribute whose value
+         is a language code for the natural language of the content of
+         any element; its value is inherited.  This name is reserved
+         by virtue of its definition in the XML specification.
+  
+    space (as an attribute name): denotes an attribute whose
+         value is a keyword indicating what whitespace processing
+         discipline is intended for the content of the element; its
+         value is inherited.  This name is reserved by virtue of its
+         definition in the XML specification.
+
+    Father (in any context at all): denotes Jon Bosak, the chair of 
+         the original XML Working Group.  This name is reserved by 
+         the following decision of the W3C XML Plenary and 
+         XML Coordination groups:
+
+             In appreciation for his vision, leadership and dedication
+             the W3C XML Plenary on this 10th day of February, 2000
+             reserves for Jon Bosak in perpetuity the XML name
+             xml:Father
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>This schema defines attributes and an attribute group
+        suitable for use by
+        schemas wishing to allow xml:base, xml:lang or xml:space attributes
+        on elements they define.
+
+        To enable this, such a schema must import this schema
+        for the XML namespace, e.g. as follows:
+        &lt;schema . . .>
+         . . .
+         &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                    schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
+
+        Subsequently, qualified reference to any of the attributes
+        or the group defined below will have the desired effect, e.g.
+
+        &lt;type . . .>
+         . . .
+         &lt;attributeGroup ref="xml:specialAttrs"/>
+ 
+         will define a type which will schema-validate an instance
+         element with any of those attributes</xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>In keeping with the XML Schema WG's standard versioning
+   policy, this schema document will persist at
+   http://www.w3.org/2001/03/xml.xsd.
+   At the date of issue it can also be found at
+   http://www.w3.org/2001/xml.xsd.
+   The schema document at that URI may however change in the future,
+   in order to remain compatible with the latest version of XML Schema
+   itself.  In other words, if the XML Schema namespace changes, the version
+   of this document at
+   http://www.w3.org/2001/xml.xsd will change
+   accordingly; the version at
+   http://www.w3.org/2001/03/xml.xsd will not change.
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:attribute name="lang" type="xs:language">
+  <xs:annotation>
+   <xs:documentation>In due course, we should install the relevant ISO 2- and 3-letter
+         codes as the enumerated possible values . . .</xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+
+ <xs:attribute name="space" default="preserve">
+  <xs:simpleType>
+   <xs:restriction base="xs:NCName">
+    <xs:enumeration value="default"/>
+    <xs:enumeration value="preserve"/>
+   </xs:restriction>
+  </xs:simpleType>
+ </xs:attribute>
+
+ <xs:attribute name="base" type="xs:anyURI">
+  <xs:annotation>
+   <xs:documentation>See http://www.w3.org/TR/xmlbase/ for
+                     information about this attribute.</xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+
+ <xs:attributeGroup name="specialAttrs">
+  <xs:attribute ref="xml:base"/>
+  <xs:attribute ref="xml:lang"/>
+  <xs:attribute ref="xml:space"/>
+ </xs:attributeGroup>
+
+</xs:schema>

--- a/skills/xlsx/scripts/office/schemas/ecma/fouth-edition/opc-contentTypes.xsd
+++ b/skills/xlsx/scripts/office/schemas/ecma/fouth-edition/opc-contentTypes.xsd
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<xs:schema xmlns="http://schemas.openxmlformats.org/package/2006/content-types"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  targetNamespace="http://schemas.openxmlformats.org/package/2006/content-types"
+  elementFormDefault="qualified" attributeFormDefault="unqualified" blockDefault="#all">
+
+  <xs:element name="Types" type="CT_Types"/>
+  <xs:element name="Default" type="CT_Default"/>
+  <xs:element name="Override" type="CT_Override"/>
+
+  <xs:complexType name="CT_Types">
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:element ref="Default"/>
+      <xs:element ref="Override"/>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="CT_Default">
+    <xs:attribute name="Extension" type="ST_Extension" use="required"/>
+    <xs:attribute name="ContentType" type="ST_ContentType" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="CT_Override">
+    <xs:attribute name="ContentType" type="ST_ContentType" use="required"/>
+    <xs:attribute name="PartName" type="xs:anyURI" use="required"/>
+  </xs:complexType>
+
+  <xs:simpleType name="ST_ContentType">
+    <xs:restriction base="xs:string">
+      <xs:pattern
+        value="(((([\p{IsBasicLatin}-[\p{Cc}&#127;\(\)&lt;&gt;@,;:\\&quot;/\[\]\?=\{\}\s\t]])+))/((([\p{IsBasicLatin}-[\p{Cc}&#127;\(\)&lt;&gt;@,;:\\&quot;/\[\]\?=\{\}\s\t]])+))((\s+)*;(\s+)*(((([\p{IsBasicLatin}-[\p{Cc}&#127;\(\)&lt;&gt;@,;:\\&quot;/\[\]\?=\{\}\s\t]])+))=((([\p{IsBasicLatin}-[\p{Cc}&#127;\(\)&lt;&gt;@,;:\\&quot;/\[\]\?=\{\}\s\t]])+)|(&quot;(([\p{IsLatin-1Supplement}\p{IsBasicLatin}-[\p{Cc}&#127;&quot;\n\r]]|(\s+))|(\\[\p{IsBasicLatin}]))*&quot;))))*)"
+      />
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="ST_Extension">
+    <xs:restriction base="xs:string">
+      <xs:pattern
+        value="([!$&amp;'\(\)\*\+,:=]|(%[0-9a-fA-F][0-9a-fA-F])|[:@]|[a-zA-Z0-9\-_~])+"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/skills/xlsx/scripts/office/schemas/ecma/fouth-edition/opc-coreProperties.xsd
+++ b/skills/xlsx/scripts/office/schemas/ecma/fouth-edition/opc-coreProperties.xsd
@@ -1,0 +1,50 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://schemas.openxmlformats.org/package/2006/metadata/core-properties"
+  xmlns="http://schemas.openxmlformats.org/package/2006/metadata/core-properties"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:dcterms="http://purl.org/dc/terms/" elementFormDefault="qualified" blockDefault="#all">
+
+  <xs:import namespace="http://purl.org/dc/elements/1.1/"
+    schemaLocation="http://dublincore.org/schemas/xmls/qdc/2003/04/02/dc.xsd"/>
+  <xs:import namespace="http://purl.org/dc/terms/"
+    schemaLocation="http://dublincore.org/schemas/xmls/qdc/2003/04/02/dcterms.xsd"/>
+  <xs:import id="xml" namespace="http://www.w3.org/XML/1998/namespace"/>
+
+  <xs:element name="coreProperties" type="CT_CoreProperties"/>
+
+  <xs:complexType name="CT_CoreProperties">
+    <xs:all>
+      <xs:element name="category" minOccurs="0" maxOccurs="1" type="xs:string"/>
+      <xs:element name="contentStatus" minOccurs="0" maxOccurs="1" type="xs:string"/>
+      <xs:element ref="dcterms:created" minOccurs="0" maxOccurs="1"/>
+      <xs:element ref="dc:creator" minOccurs="0" maxOccurs="1"/>
+      <xs:element ref="dc:description" minOccurs="0" maxOccurs="1"/>
+      <xs:element ref="dc:identifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="keywords" minOccurs="0" maxOccurs="1" type="CT_Keywords"/>
+      <xs:element ref="dc:language" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="lastModifiedBy" minOccurs="0" maxOccurs="1" type="xs:string"/>
+      <xs:element name="lastPrinted" minOccurs="0" maxOccurs="1" type="xs:dateTime"/>
+      <xs:element ref="dcterms:modified" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="revision" minOccurs="0" maxOccurs="1" type="xs:string"/>
+      <xs:element ref="dc:subject" minOccurs="0" maxOccurs="1"/>
+      <xs:element ref="dc:title" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="version" minOccurs="0" maxOccurs="1" type="xs:string"/>
+    </xs:all>
+  </xs:complexType>
+
+  <xs:complexType name="CT_Keywords" mixed="true">
+    <xs:sequence>
+      <xs:element name="value" minOccurs="0" maxOccurs="unbounded" type="CT_Keyword"/>
+    </xs:sequence>
+    <xs:attribute ref="xml:lang" use="optional"/>
+  </xs:complexType>
+
+  <xs:complexType name="CT_Keyword">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute ref="xml:lang" use="optional"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+</xs:schema>

--- a/skills/xlsx/scripts/office/schemas/ecma/fouth-edition/opc-digSig.xsd
+++ b/skills/xlsx/scripts/office/schemas/ecma/fouth-edition/opc-digSig.xsd
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://schemas.openxmlformats.org/package/2006/digital-signature"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  targetNamespace="http://schemas.openxmlformats.org/package/2006/digital-signature"
+  elementFormDefault="qualified" attributeFormDefault="unqualified" blockDefault="#all">
+
+  <xsd:element name="SignatureTime" type="CT_SignatureTime"/>
+  <xsd:element name="RelationshipReference" type="CT_RelationshipReference"/>
+  <xsd:element name="RelationshipsGroupReference" type="CT_RelationshipsGroupReference"/>
+
+  <xsd:complexType name="CT_SignatureTime">
+    <xsd:sequence>
+      <xsd:element name="Format" type="ST_Format"/>
+      <xsd:element name="Value" type="ST_Value"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="CT_RelationshipReference">
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:string">
+        <xsd:attribute name="SourceId" type="xsd:string" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="CT_RelationshipsGroupReference">
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:string">
+        <xsd:attribute name="SourceType" type="xsd:anyURI" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:simpleType name="ST_Format">
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern
+        value="(YYYY)|(YYYY-MM)|(YYYY-MM-DD)|(YYYY-MM-DDThh:mmTZD)|(YYYY-MM-DDThh:mm:ssTZD)|(YYYY-MM-DDThh:mm:ss.sTZD)"
+      />
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="ST_Value">
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern
+        value="(([0-9][0-9][0-9][0-9]))|(([0-9][0-9][0-9][0-9])-((0[1-9])|(1(0|1|2))))|(([0-9][0-9][0-9][0-9])-((0[1-9])|(1(0|1|2)))-((0[1-9])|(1[0-9])|(2[0-9])|(3(0|1))))|(([0-9][0-9][0-9][0-9])-((0[1-9])|(1(0|1|2)))-((0[1-9])|(1[0-9])|(2[0-9])|(3(0|1)))T((0[0-9])|(1[0-9])|(2(0|1|2|3))):((0[0-9])|(1[0-9])|(2[0-9])|(3[0-9])|(4[0-9])|(5[0-9]))(((\+|-)((0[0-9])|(1[0-9])|(2(0|1|2|3))):((0[0-9])|(1[0-9])|(2[0-9])|(3[0-9])|(4[0-9])|(5[0-9])))|Z))|(([0-9][0-9][0-9][0-9])-((0[1-9])|(1(0|1|2)))-((0[1-9])|(1[0-9])|(2[0-9])|(3(0|1)))T((0[0-9])|(1[0-9])|(2(0|1|2|3))):((0[0-9])|(1[0-9])|(2[0-9])|(3[0-9])|(4[0-9])|(5[0-9])):((0[0-9])|(1[0-9])|(2[0-9])|(3[0-9])|(4[0-9])|(5[0-9]))(((\+|-)((0[0-9])|(1[0-9])|(2(0|1|2|3))):((0[0-9])|(1[0-9])|(2[0-9])|(3[0-9])|(4[0-9])|(5[0-9])))|Z))|(([0-9][0-9][0-9][0-9])-((0[1-9])|(1(0|1|2)))-((0[1-9])|(1[0-9])|(2[0-9])|(3(0|1)))T((0[0-9])|(1[0-9])|(2(0|1|2|3))):((0[0-9])|(1[0-9])|(2[0-9])|(3[0-9])|(4[0-9])|(5[0-9])):(((0[0-9])|(1[0-9])|(2[0-9])|(3[0-9])|(4[0-9])|(5[0-9]))\.[0-9])(((\+|-)((0[0-9])|(1[0-9])|(2(0|1|2|3))):((0[0-9])|(1[0-9])|(2[0-9])|(3[0-9])|(4[0-9])|(5[0-9])))|Z))"
+      />
+    </xsd:restriction>
+  </xsd:simpleType>
+</xsd:schema>

--- a/skills/xlsx/scripts/office/schemas/ecma/fouth-edition/opc-relationships.xsd
+++ b/skills/xlsx/scripts/office/schemas/ecma/fouth-edition/opc-relationships.xsd
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<xsd:schema xmlns="http://schemas.openxmlformats.org/package/2006/relationships"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  targetNamespace="http://schemas.openxmlformats.org/package/2006/relationships"
+  elementFormDefault="qualified" attributeFormDefault="unqualified" blockDefault="#all">
+
+  <xsd:element name="Relationships" type="CT_Relationships"/>
+  <xsd:element name="Relationship" type="CT_Relationship"/>
+
+  <xsd:complexType name="CT_Relationships">
+    <xsd:sequence>
+      <xsd:element ref="Relationship" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="CT_Relationship">
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:string">
+        <xsd:attribute name="TargetMode" type="ST_TargetMode" use="optional"/>
+        <xsd:attribute name="Target" type="xsd:anyURI" use="required"/>
+        <xsd:attribute name="Type" type="xsd:anyURI" use="required"/>
+        <xsd:attribute name="Id" type="xsd:ID" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:simpleType name="ST_TargetMode">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="External"/>
+      <xsd:enumeration value="Internal"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+</xsd:schema>

--- a/skills/xlsx/scripts/office/schemas/mce/mc.xsd
+++ b/skills/xlsx/scripts/office/schemas/mce/mc.xsd
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	attributeFormDefault="unqualified" elementFormDefault="qualified"
+	targetNamespace="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+  <!--
+    This XSD is a modified version of the one found at:
+    https://github.com/plutext/docx4j/blob/master/xsd/mce/markup-compatibility-2006-MINIMAL.xsd
+
+    This XSD has 2 objectives:
+
+        1. round tripping @mc:Ignorable
+
+			<w:document
+			            xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			            xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+			            mc:Ignorable="w14 w15 wp14">
+
+        2. enabling AlternateContent to be manipulated in certain elements
+           (in the unusual case where the content model is xsd:any, it doesn't have to be explicitly added)
+
+		See further ECMA-376, 4th Edition, Office Open XML File Formats
+		Part 3 : Markup Compatibility and Extensibility
+   -->
+
+  <!--  Objective 1 -->
+  <xsd:attribute name="Ignorable" type="xsd:string" />
+
+  <!--  Objective 2 -->
+	<xsd:attribute name="MustUnderstand" type="xsd:string"  />
+	<xsd:attribute name="ProcessContent" type="xsd:string"  />
+
+<!-- An AlternateContent element shall contain one or more Choice child elements, optionally followed by a
+Fallback child element. If present, there shall be only one Fallback element, and it shall follow all Choice
+elements. -->
+	<xsd:element name="AlternateContent">
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element name="Choice" minOccurs="0" maxOccurs="unbounded">
+					<xsd:complexType>
+						<xsd:sequence>
+							<xsd:any minOccurs="0" maxOccurs="unbounded"
+								processContents="strict">
+							</xsd:any>
+						</xsd:sequence>
+						<xsd:attribute name="Requires" type="xsd:string" use="required" />
+						<xsd:attribute ref="mc:Ignorable" use="optional" />
+						<xsd:attribute ref="mc:MustUnderstand" use="optional" />
+						<xsd:attribute ref="mc:ProcessContent" use="optional" />
+					</xsd:complexType>
+				</xsd:element>
+				<xsd:element name="Fallback" minOccurs="0" maxOccurs="1">
+					<xsd:complexType>
+						<xsd:sequence>
+							<xsd:any minOccurs="0" maxOccurs="unbounded"
+								processContents="strict">
+							</xsd:any>
+						</xsd:sequence>
+						<xsd:attribute ref="mc:Ignorable" use="optional" />
+						<xsd:attribute ref="mc:MustUnderstand" use="optional" />
+						<xsd:attribute ref="mc:ProcessContent" use="optional" />
+					</xsd:complexType>
+				</xsd:element>
+			</xsd:sequence>
+			<!-- AlternateContent elements might include the attributes Ignorable,
+				MustUnderstand and ProcessContent described in this Part of ECMA-376. These
+				attributes’ qualified names shall be prefixed when associated with an AlternateContent
+				element. -->
+			<xsd:attribute ref="mc:Ignorable" use="optional" />
+			<xsd:attribute ref="mc:MustUnderstand" use="optional" />
+			<xsd:attribute ref="mc:ProcessContent" use="optional" />
+		</xsd:complexType>
+	</xsd:element>
+</xsd:schema>

--- a/skills/xlsx/scripts/office/schemas/microsoft/wml-2010.xsd
+++ b/skills/xlsx/scripts/office/schemas/microsoft/wml-2010.xsd
@@ -1,0 +1,560 @@
+ <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:w12="http://schemas.openxmlformats.org/wordprocessingml/2006/main" elementFormDefault="qualified" attributeFormDefault="qualified" blockDefault="#all" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:s="http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns="http://schemas.microsoft.com/office/word/2010/wordml" targetNamespace="http://schemas.microsoft.com/office/word/2010/wordml">
+   <!-- <xsd:import id="rel" namespace="http://schemas.openxmlformats.org/officeDocument/2006/relationships" schemaLocation="orel.xsd"/> -->
+   <xsd:import id="w" namespace="http://schemas.openxmlformats.org/wordprocessingml/2006/main" schemaLocation="../ISO-IEC29500-4_2016/wml.xsd"/>
+   <!-- <xsd:import namespace="http://schemas.openxmlformats.org/drawingml/2006/main" schemaLocation="oartbasetypes.xsd"/>
+   <xsd:import namespace="http://schemas.openxmlformats.org/drawingml/2006/main" schemaLocation="oartsplineproperties.xsd"/> -->
+   <xsd:complexType name="CT_LongHexNumber">
+     <xsd:attribute name="val" type="w:ST_LongHexNumber" use="required"/>
+   </xsd:complexType>
+   <xsd:simpleType name="ST_OnOff">
+     <xsd:restriction base="xsd:string">
+       <xsd:enumeration value="true"/>
+       <xsd:enumeration value="false"/>
+       <xsd:enumeration value="0"/>
+       <xsd:enumeration value="1"/>
+     </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="CT_OnOff">
+     <xsd:attribute name="val" type="ST_OnOff"/>
+   </xsd:complexType>
+   <xsd:element name="docId" type="CT_LongHexNumber"/>
+   <xsd:element name="conflictMode" type="CT_OnOff"/>
+   <xsd:attributeGroup name="AG_Parids">
+     <xsd:attribute name="paraId" type="w:ST_LongHexNumber"/>
+     <xsd:attribute name="textId" type="w:ST_LongHexNumber"/>
+   </xsd:attributeGroup>
+   <xsd:attribute name="anchorId" type="w:ST_LongHexNumber"/>
+   <xsd:attribute name="noSpellErr" type="ST_OnOff"/>
+   <xsd:element name="customXmlConflictInsRangeStart" type="w:CT_TrackChange"/>
+   <xsd:element name="customXmlConflictInsRangeEnd" type="w:CT_Markup"/>
+   <xsd:element name="customXmlConflictDelRangeStart" type="w:CT_TrackChange"/>
+   <xsd:element name="customXmlConflictDelRangeEnd" type="w:CT_Markup"/>
+   <xsd:group name="EG_RunLevelConflicts">
+     <xsd:sequence>
+       <xsd:element name="conflictIns" type="w:CT_RunTrackChange" minOccurs="0"/>
+       <xsd:element name="conflictDel" type="w:CT_RunTrackChange" minOccurs="0"/>
+     </xsd:sequence>
+   </xsd:group>
+   <xsd:group name="EG_Conflicts">
+     <xsd:choice>
+       <xsd:element name="conflictIns" type="w:CT_TrackChange" minOccurs="0"/>
+       <xsd:element name="conflictDel" type="w:CT_TrackChange" minOccurs="0"/>
+     </xsd:choice>
+   </xsd:group>
+   <xsd:complexType name="CT_Percentage">
+     <xsd:attribute name="val" type="a:ST_Percentage" use="required"/>
+   </xsd:complexType>
+   <xsd:complexType name="CT_PositiveFixedPercentage">
+     <xsd:attribute name="val" type="a:ST_PositiveFixedPercentage" use="required"/>
+   </xsd:complexType>
+   <xsd:complexType name="CT_PositivePercentage">
+     <xsd:attribute name="val" type="a:ST_PositivePercentage" use="required"/>
+   </xsd:complexType>
+   <xsd:simpleType name="ST_SchemeColorVal">
+     <xsd:restriction base="xsd:string">
+       <xsd:enumeration value="bg1"/>
+       <xsd:enumeration value="tx1"/>
+       <xsd:enumeration value="bg2"/>
+       <xsd:enumeration value="tx2"/>
+       <xsd:enumeration value="accent1"/>
+       <xsd:enumeration value="accent2"/>
+       <xsd:enumeration value="accent3"/>
+       <xsd:enumeration value="accent4"/>
+       <xsd:enumeration value="accent5"/>
+       <xsd:enumeration value="accent6"/>
+       <xsd:enumeration value="hlink"/>
+       <xsd:enumeration value="folHlink"/>
+       <xsd:enumeration value="dk1"/>
+       <xsd:enumeration value="lt1"/>
+       <xsd:enumeration value="dk2"/>
+       <xsd:enumeration value="lt2"/>
+       <xsd:enumeration value="phClr"/>
+     </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="ST_RectAlignment">
+     <xsd:restriction base="xsd:string">
+       <xsd:enumeration value="none"/>
+       <xsd:enumeration value="tl"/>
+       <xsd:enumeration value="t"/>
+       <xsd:enumeration value="tr"/>
+       <xsd:enumeration value="l"/>
+       <xsd:enumeration value="ctr"/>
+       <xsd:enumeration value="r"/>
+       <xsd:enumeration value="bl"/>
+       <xsd:enumeration value="b"/>
+       <xsd:enumeration value="br"/>
+     </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="ST_PathShadeType">
+     <xsd:restriction base="xsd:string">
+       <xsd:enumeration value="shape"/>
+       <xsd:enumeration value="circle"/>
+       <xsd:enumeration value="rect"/>
+     </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="ST_LineCap">
+     <xsd:restriction base="xsd:string">
+       <xsd:enumeration value="rnd"/>
+       <xsd:enumeration value="sq"/>
+       <xsd:enumeration value="flat"/>
+     </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="ST_PresetLineDashVal">
+     <xsd:restriction base="xsd:string">
+       <xsd:enumeration value="solid"/>
+       <xsd:enumeration value="dot"/>
+       <xsd:enumeration value="sysDot"/>
+       <xsd:enumeration value="dash"/>
+       <xsd:enumeration value="sysDash"/>
+       <xsd:enumeration value="lgDash"/>
+       <xsd:enumeration value="dashDot"/>
+       <xsd:enumeration value="sysDashDot"/>
+       <xsd:enumeration value="lgDashDot"/>
+       <xsd:enumeration value="lgDashDotDot"/>
+       <xsd:enumeration value="sysDashDotDot"/>
+     </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="ST_PenAlignment">
+     <xsd:restriction base="xsd:string">
+       <xsd:enumeration value="ctr"/>
+       <xsd:enumeration value="in"/>
+     </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="ST_CompoundLine">
+     <xsd:restriction base="xsd:string">
+       <xsd:enumeration value="sng"/>
+       <xsd:enumeration value="dbl"/>
+       <xsd:enumeration value="thickThin"/>
+       <xsd:enumeration value="thinThick"/>
+       <xsd:enumeration value="tri"/>
+     </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="CT_RelativeRect">
+     <xsd:attribute name="l" use="optional" type="a:ST_Percentage"/>
+     <xsd:attribute name="t" use="optional" type="a:ST_Percentage"/>
+     <xsd:attribute name="r" use="optional" type="a:ST_Percentage"/>
+     <xsd:attribute name="b" use="optional" type="a:ST_Percentage"/>
+   </xsd:complexType>
+   <xsd:group name="EG_ColorTransform">
+     <xsd:choice>
+       <xsd:element name="tint" type="CT_PositiveFixedPercentage"/>
+       <xsd:element name="shade" type="CT_PositiveFixedPercentage"/>
+       <xsd:element name="alpha" type="CT_PositiveFixedPercentage"/>
+       <xsd:element name="hueMod" type="CT_PositivePercentage"/>
+       <xsd:element name="sat" type="CT_Percentage"/>
+       <xsd:element name="satOff" type="CT_Percentage"/>
+       <xsd:element name="satMod" type="CT_Percentage"/>
+       <xsd:element name="lum" type="CT_Percentage"/>
+       <xsd:element name="lumOff" type="CT_Percentage"/>
+       <xsd:element name="lumMod" type="CT_Percentage"/>
+     </xsd:choice>
+   </xsd:group>
+   <xsd:complexType name="CT_SRgbColor">
+     <xsd:sequence>
+       <xsd:group ref="EG_ColorTransform" minOccurs="0" maxOccurs="unbounded"/>
+     </xsd:sequence>
+     <xsd:attribute name="val" type="s:ST_HexColorRGB" use="required"/>
+   </xsd:complexType>
+   <xsd:complexType name="CT_SchemeColor">
+     <xsd:sequence>
+       <xsd:group ref="EG_ColorTransform" minOccurs="0" maxOccurs="unbounded"/>
+     </xsd:sequence>
+     <xsd:attribute name="val" type="ST_SchemeColorVal" use="required"/>
+   </xsd:complexType>
+   <xsd:group name="EG_ColorChoice">
+     <xsd:choice>
+       <xsd:element name="srgbClr" type="CT_SRgbColor"/>
+       <xsd:element name="schemeClr" type="CT_SchemeColor"/>
+     </xsd:choice>
+   </xsd:group>
+   <xsd:complexType name="CT_Color">
+     <xsd:sequence>
+       <xsd:group ref="EG_ColorChoice"/>
+     </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CT_GradientStop">
+     <xsd:sequence>
+       <xsd:group ref="EG_ColorChoice"/>
+     </xsd:sequence>
+     <xsd:attribute name="pos" type="a:ST_PositiveFixedPercentage" use="required"/>
+   </xsd:complexType>
+   <xsd:complexType name="CT_GradientStopList">
+     <xsd:sequence>
+       <xsd:element name="gs" type="CT_GradientStop" minOccurs="2" maxOccurs="10"/>
+     </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CT_LinearShadeProperties">
+     <xsd:attribute name="ang" type="a:ST_PositiveFixedAngle" use="optional"/>
+     <xsd:attribute name="scaled" type="ST_OnOff" use="optional"/>
+   </xsd:complexType>
+   <xsd:complexType name="CT_PathShadeProperties">
+     <xsd:sequence>
+       <xsd:element name="fillToRect" type="CT_RelativeRect" minOccurs="0"/>
+     </xsd:sequence>
+     <xsd:attribute name="path" type="ST_PathShadeType" use="optional"/>
+   </xsd:complexType>
+   <xsd:group name="EG_ShadeProperties">
+     <xsd:choice>
+       <xsd:element name="lin" type="CT_LinearShadeProperties"/>
+       <xsd:element name="path" type="CT_PathShadeProperties"/>
+     </xsd:choice>
+   </xsd:group>
+   <xsd:complexType name="CT_SolidColorFillProperties">
+     <xsd:sequence>
+       <xsd:group ref="EG_ColorChoice" minOccurs="0"/>
+     </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CT_GradientFillProperties">
+     <xsd:sequence>
+       <xsd:element name="gsLst" type="CT_GradientStopList" minOccurs="0"/>
+       <xsd:group ref="EG_ShadeProperties" minOccurs="0"/>
+     </xsd:sequence>
+   </xsd:complexType>
+   <xsd:group name="EG_FillProperties">
+     <xsd:choice>
+       <xsd:element name="noFill" type="w:CT_Empty"/>
+       <xsd:element name="solidFill" type="CT_SolidColorFillProperties"/>
+       <xsd:element name="gradFill" type="CT_GradientFillProperties"/>
+     </xsd:choice>
+   </xsd:group>
+   <xsd:complexType name="CT_PresetLineDashProperties">
+     <xsd:attribute name="val" type="ST_PresetLineDashVal" use="optional"/>
+   </xsd:complexType>
+   <xsd:group name="EG_LineDashProperties">
+     <xsd:choice>
+       <xsd:element name="prstDash" type="CT_PresetLineDashProperties"/>
+     </xsd:choice>
+   </xsd:group>
+   <xsd:complexType name="CT_LineJoinMiterProperties">
+     <xsd:attribute name="lim" type="a:ST_PositivePercentage" use="optional"/>
+   </xsd:complexType>
+   <xsd:group name="EG_LineJoinProperties">
+     <xsd:choice>
+       <xsd:element name="round" type="w:CT_Empty"/>
+       <xsd:element name="bevel" type="w:CT_Empty"/>
+       <xsd:element name="miter" type="CT_LineJoinMiterProperties"/>
+     </xsd:choice>
+   </xsd:group>
+   <xsd:simpleType name="ST_PresetCameraType">
+     <xsd:restriction base="xsd:token">
+       <xsd:enumeration value="legacyObliqueTopLeft"/>
+       <xsd:enumeration value="legacyObliqueTop"/>
+       <xsd:enumeration value="legacyObliqueTopRight"/>
+       <xsd:enumeration value="legacyObliqueLeft"/>
+       <xsd:enumeration value="legacyObliqueFront"/>
+       <xsd:enumeration value="legacyObliqueRight"/>
+       <xsd:enumeration value="legacyObliqueBottomLeft"/>
+       <xsd:enumeration value="legacyObliqueBottom"/>
+       <xsd:enumeration value="legacyObliqueBottomRight"/>
+       <xsd:enumeration value="legacyPerspectiveTopLeft"/>
+       <xsd:enumeration value="legacyPerspectiveTop"/>
+       <xsd:enumeration value="legacyPerspectiveTopRight"/>
+       <xsd:enumeration value="legacyPerspectiveLeft"/>
+       <xsd:enumeration value="legacyPerspectiveFront"/>
+       <xsd:enumeration value="legacyPerspectiveRight"/>
+       <xsd:enumeration value="legacyPerspectiveBottomLeft"/>
+       <xsd:enumeration value="legacyPerspectiveBottom"/>
+       <xsd:enumeration value="legacyPerspectiveBottomRight"/>
+       <xsd:enumeration value="orthographicFront"/>
+       <xsd:enumeration value="isometricTopUp"/>
+       <xsd:enumeration value="isometricTopDown"/>
+       <xsd:enumeration value="isometricBottomUp"/>
+       <xsd:enumeration value="isometricBottomDown"/>
+       <xsd:enumeration value="isometricLeftUp"/>
+       <xsd:enumeration value="isometricLeftDown"/>
+       <xsd:enumeration value="isometricRightUp"/>
+       <xsd:enumeration value="isometricRightDown"/>
+       <xsd:enumeration value="isometricOffAxis1Left"/>
+       <xsd:enumeration value="isometricOffAxis1Right"/>
+       <xsd:enumeration value="isometricOffAxis1Top"/>
+       <xsd:enumeration value="isometricOffAxis2Left"/>
+       <xsd:enumeration value="isometricOffAxis2Right"/>
+       <xsd:enumeration value="isometricOffAxis2Top"/>
+       <xsd:enumeration value="isometricOffAxis3Left"/>
+       <xsd:enumeration value="isometricOffAxis3Right"/>
+       <xsd:enumeration value="isometricOffAxis3Bottom"/>
+       <xsd:enumeration value="isometricOffAxis4Left"/>
+       <xsd:enumeration value="isometricOffAxis4Right"/>
+       <xsd:enumeration value="isometricOffAxis4Bottom"/>
+       <xsd:enumeration value="obliqueTopLeft"/>
+       <xsd:enumeration value="obliqueTop"/>
+       <xsd:enumeration value="obliqueTopRight"/>
+       <xsd:enumeration value="obliqueLeft"/>
+       <xsd:enumeration value="obliqueRight"/>
+       <xsd:enumeration value="obliqueBottomLeft"/>
+       <xsd:enumeration value="obliqueBottom"/>
+       <xsd:enumeration value="obliqueBottomRight"/>
+       <xsd:enumeration value="perspectiveFront"/>
+       <xsd:enumeration value="perspectiveLeft"/>
+       <xsd:enumeration value="perspectiveRight"/>
+       <xsd:enumeration value="perspectiveAbove"/>
+       <xsd:enumeration value="perspectiveBelow"/>
+       <xsd:enumeration value="perspectiveAboveLeftFacing"/>
+       <xsd:enumeration value="perspectiveAboveRightFacing"/>
+       <xsd:enumeration value="perspectiveContrastingLeftFacing"/>
+       <xsd:enumeration value="perspectiveContrastingRightFacing"/>
+       <xsd:enumeration value="perspectiveHeroicLeftFacing"/>
+       <xsd:enumeration value="perspectiveHeroicRightFacing"/>
+       <xsd:enumeration value="perspectiveHeroicExtremeLeftFacing"/>
+       <xsd:enumeration value="perspectiveHeroicExtremeRightFacing"/>
+       <xsd:enumeration value="perspectiveRelaxed"/>
+       <xsd:enumeration value="perspectiveRelaxedModerately"/>
+     </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="CT_Camera">
+     <xsd:attribute name="prst" use="required" type="ST_PresetCameraType"/>
+   </xsd:complexType>
+   <xsd:complexType name="CT_SphereCoords">
+     <xsd:attribute name="lat" type="a:ST_PositiveFixedAngle" use="required"/>
+     <xsd:attribute name="lon" type="a:ST_PositiveFixedAngle" use="required"/>
+     <xsd:attribute name="rev" type="a:ST_PositiveFixedAngle" use="required"/>
+   </xsd:complexType>
+   <xsd:simpleType name="ST_LightRigType">
+     <xsd:restriction base="xsd:token">
+       <xsd:enumeration value="legacyFlat1"/>
+       <xsd:enumeration value="legacyFlat2"/>
+       <xsd:enumeration value="legacyFlat3"/>
+       <xsd:enumeration value="legacyFlat4"/>
+       <xsd:enumeration value="legacyNormal1"/>
+       <xsd:enumeration value="legacyNormal2"/>
+       <xsd:enumeration value="legacyNormal3"/>
+       <xsd:enumeration value="legacyNormal4"/>
+       <xsd:enumeration value="legacyHarsh1"/>
+       <xsd:enumeration value="legacyHarsh2"/>
+       <xsd:enumeration value="legacyHarsh3"/>
+       <xsd:enumeration value="legacyHarsh4"/>
+       <xsd:enumeration value="threePt"/>
+       <xsd:enumeration value="balanced"/>
+       <xsd:enumeration value="soft"/>
+       <xsd:enumeration value="harsh"/>
+       <xsd:enumeration value="flood"/>
+       <xsd:enumeration value="contrasting"/>
+       <xsd:enumeration value="morning"/>
+       <xsd:enumeration value="sunrise"/>
+       <xsd:enumeration value="sunset"/>
+       <xsd:enumeration value="chilly"/>
+       <xsd:enumeration value="freezing"/>
+       <xsd:enumeration value="flat"/>
+       <xsd:enumeration value="twoPt"/>
+       <xsd:enumeration value="glow"/>
+       <xsd:enumeration value="brightRoom"/>
+     </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="ST_LightRigDirection">
+     <xsd:restriction base="xsd:token">
+       <xsd:enumeration value="tl"/>
+       <xsd:enumeration value="t"/>
+       <xsd:enumeration value="tr"/>
+       <xsd:enumeration value="l"/>
+       <xsd:enumeration value="r"/>
+       <xsd:enumeration value="bl"/>
+       <xsd:enumeration value="b"/>
+       <xsd:enumeration value="br"/>
+     </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="CT_LightRig">
+     <xsd:sequence>
+       <xsd:element name="rot" type="CT_SphereCoords" minOccurs="0"/>
+     </xsd:sequence>
+     <xsd:attribute name="rig" type="ST_LightRigType" use="required"/>
+     <xsd:attribute name="dir" type="ST_LightRigDirection" use="required"/>
+   </xsd:complexType>
+   <xsd:simpleType name="ST_BevelPresetType">
+     <xsd:restriction base="xsd:token">
+       <xsd:enumeration value="relaxedInset"/>
+       <xsd:enumeration value="circle"/>
+       <xsd:enumeration value="slope"/>
+       <xsd:enumeration value="cross"/>
+       <xsd:enumeration value="angle"/>
+       <xsd:enumeration value="softRound"/>
+       <xsd:enumeration value="convex"/>
+       <xsd:enumeration value="coolSlant"/>
+       <xsd:enumeration value="divot"/>
+       <xsd:enumeration value="riblet"/>
+       <xsd:enumeration value="hardEdge"/>
+       <xsd:enumeration value="artDeco"/>
+     </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="CT_Bevel">
+     <xsd:attribute name="w" type="a:ST_PositiveCoordinate" use="optional"/>
+     <xsd:attribute name="h" type="a:ST_PositiveCoordinate" use="optional"/>
+     <xsd:attribute name="prst" type="ST_BevelPresetType" use="optional"/>
+   </xsd:complexType>
+   <xsd:simpleType name="ST_PresetMaterialType">
+     <xsd:restriction base="xsd:token">
+       <xsd:enumeration value="legacyMatte"/>
+       <xsd:enumeration value="legacyPlastic"/>
+       <xsd:enumeration value="legacyMetal"/>
+       <xsd:enumeration value="legacyWireframe"/>
+       <xsd:enumeration value="matte"/>
+       <xsd:enumeration value="plastic"/>
+       <xsd:enumeration value="metal"/>
+       <xsd:enumeration value="warmMatte"/>
+       <xsd:enumeration value="translucentPowder"/>
+       <xsd:enumeration value="powder"/>
+       <xsd:enumeration value="dkEdge"/>
+       <xsd:enumeration value="softEdge"/>
+       <xsd:enumeration value="clear"/>
+       <xsd:enumeration value="flat"/>
+       <xsd:enumeration value="softmetal"/>
+       <xsd:enumeration value="none"/>
+     </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="CT_Glow">
+     <xsd:sequence>
+       <xsd:group ref="EG_ColorChoice"/>
+     </xsd:sequence>
+     <xsd:attribute name="rad" use="optional" type="a:ST_PositiveCoordinate"/>
+   </xsd:complexType>
+   <xsd:complexType name="CT_Shadow">
+     <xsd:sequence>
+       <xsd:group ref="EG_ColorChoice"/>
+     </xsd:sequence>
+     <xsd:attribute name="blurRad" use="optional" type="a:ST_PositiveCoordinate"/>
+     <xsd:attribute name="dist" use="optional" type="a:ST_PositiveCoordinate"/>
+     <xsd:attribute name="dir" use="optional" type="a:ST_PositiveFixedAngle"/>
+     <xsd:attribute name="sx" use="optional" type="a:ST_Percentage"/>
+     <xsd:attribute name="sy" use="optional" type="a:ST_Percentage"/>
+     <xsd:attribute name="kx" use="optional" type="a:ST_FixedAngle"/>
+     <xsd:attribute name="ky" use="optional" type="a:ST_FixedAngle"/>
+     <xsd:attribute name="algn" use="optional" type="ST_RectAlignment"/>
+   </xsd:complexType>
+   <xsd:complexType name="CT_Reflection">
+     <xsd:attribute name="blurRad" use="optional" type="a:ST_PositiveCoordinate"/>
+     <xsd:attribute name="stA" use="optional" type="a:ST_PositiveFixedPercentage"/>
+     <xsd:attribute name="stPos" use="optional" type="a:ST_PositiveFixedPercentage"/>
+     <xsd:attribute name="endA" use="optional" type="a:ST_PositiveFixedPercentage"/>
+     <xsd:attribute name="endPos" use="optional" type="a:ST_PositiveFixedPercentage"/>
+     <xsd:attribute name="dist" use="optional" type="a:ST_PositiveCoordinate"/>
+     <xsd:attribute name="dir" use="optional" type="a:ST_PositiveFixedAngle"/>
+     <xsd:attribute name="fadeDir" use="optional" type="a:ST_PositiveFixedAngle"/>
+     <xsd:attribute name="sx" use="optional" type="a:ST_Percentage"/>
+     <xsd:attribute name="sy" use="optional" type="a:ST_Percentage"/>
+     <xsd:attribute name="kx" use="optional" type="a:ST_FixedAngle"/>
+     <xsd:attribute name="ky" use="optional" type="a:ST_FixedAngle"/>
+     <xsd:attribute name="algn" use="optional" type="ST_RectAlignment"/>
+   </xsd:complexType>
+   <xsd:complexType name="CT_FillTextEffect">
+     <xsd:sequence>
+       <xsd:group ref="EG_FillProperties" minOccurs="0"/>
+     </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CT_TextOutlineEffect">
+     <xsd:sequence>
+       <xsd:group ref="EG_FillProperties" minOccurs="0"/>
+       <xsd:group ref="EG_LineDashProperties" minOccurs="0"/>
+       <xsd:group ref="EG_LineJoinProperties" minOccurs="0"/>
+     </xsd:sequence>
+     <xsd:attribute name="w" use="optional" type="a:ST_LineWidth"/>
+     <xsd:attribute name="cap" use="optional" type="ST_LineCap"/>
+     <xsd:attribute name="cmpd" use="optional" type="ST_CompoundLine"/>
+     <xsd:attribute name="algn" use="optional" type="ST_PenAlignment"/>
+   </xsd:complexType>
+   <xsd:complexType name="CT_Scene3D">
+     <xsd:sequence>
+       <xsd:element name="camera" type="CT_Camera"/>
+       <xsd:element name="lightRig" type="CT_LightRig"/>
+     </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CT_Props3D">
+     <xsd:sequence>
+       <xsd:element name="bevelT" type="CT_Bevel" minOccurs="0"/>
+       <xsd:element name="bevelB" type="CT_Bevel" minOccurs="0"/>
+       <xsd:element name="extrusionClr" type="CT_Color" minOccurs="0"/>
+       <xsd:element name="contourClr" type="CT_Color" minOccurs="0"/>
+     </xsd:sequence>
+     <xsd:attribute name="extrusionH" type="a:ST_PositiveCoordinate" use="optional"/>
+     <xsd:attribute name="contourW" type="a:ST_PositiveCoordinate" use="optional"/>
+     <xsd:attribute name="prstMaterial" type="ST_PresetMaterialType" use="optional"/>
+   </xsd:complexType>
+   <xsd:group name="EG_RPrTextEffects">
+     <xsd:sequence>
+       <xsd:element name="glow" minOccurs="0" type="CT_Glow"/>
+       <xsd:element name="shadow" minOccurs="0" type="CT_Shadow"/>
+       <xsd:element name="reflection" minOccurs="0" type="CT_Reflection"/>
+       <xsd:element name="textOutline" minOccurs="0" type="CT_TextOutlineEffect"/>
+       <xsd:element name="textFill" minOccurs="0" type="CT_FillTextEffect"/>
+       <xsd:element name="scene3d" minOccurs="0" type="CT_Scene3D"/>
+       <xsd:element name="props3d" minOccurs="0" type="CT_Props3D"/>
+     </xsd:sequence>
+   </xsd:group>
+   <xsd:simpleType name="ST_Ligatures">
+     <xsd:restriction base="xsd:string">
+       <xsd:enumeration value="none"/>
+       <xsd:enumeration value="standard"/>
+       <xsd:enumeration value="contextual"/>
+       <xsd:enumeration value="historical"/>
+       <xsd:enumeration value="discretional"/>
+       <xsd:enumeration value="standardContextual"/>
+       <xsd:enumeration value="standardHistorical"/>
+       <xsd:enumeration value="contextualHistorical"/>
+       <xsd:enumeration value="standardDiscretional"/>
+       <xsd:enumeration value="contextualDiscretional"/>
+       <xsd:enumeration value="historicalDiscretional"/>
+       <xsd:enumeration value="standardContextualHistorical"/>
+       <xsd:enumeration value="standardContextualDiscretional"/>
+       <xsd:enumeration value="standardHistoricalDiscretional"/>
+       <xsd:enumeration value="contextualHistoricalDiscretional"/>
+       <xsd:enumeration value="all"/>
+     </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="CT_Ligatures">
+     <xsd:attribute name="val" type="ST_Ligatures" use="required"/>
+   </xsd:complexType>
+   <xsd:simpleType name="ST_NumForm">
+     <xsd:restriction base="xsd:string">
+       <xsd:enumeration value="default"/>
+       <xsd:enumeration value="lining"/>
+       <xsd:enumeration value="oldStyle"/>
+     </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="CT_NumForm">
+     <xsd:attribute name="val" type="ST_NumForm" use="required"/>
+   </xsd:complexType>
+   <xsd:simpleType name="ST_NumSpacing">
+     <xsd:restriction base="xsd:string">
+       <xsd:enumeration value="default"/>
+       <xsd:enumeration value="proportional"/>
+       <xsd:enumeration value="tabular"/>
+     </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="CT_NumSpacing">
+     <xsd:attribute name="val" type="ST_NumSpacing" use="required"/>
+   </xsd:complexType>
+   <xsd:complexType name="CT_StyleSet">
+     <xsd:attribute name="id" type="s:ST_UnsignedDecimalNumber" use="required"/>
+     <xsd:attribute name="val" type="ST_OnOff" use="optional"/>
+   </xsd:complexType>
+   <xsd:complexType name="CT_StylisticSets">
+     <xsd:sequence minOccurs="0">
+       <xsd:element name="styleSet" minOccurs="0" maxOccurs="unbounded" type="CT_StyleSet"/>
+     </xsd:sequence>
+   </xsd:complexType>
+   <xsd:group name="EG_RPrOpenType">
+     <xsd:sequence>
+       <xsd:element name="ligatures" minOccurs="0" type="CT_Ligatures"/>
+       <xsd:element name="numForm" minOccurs="0" type="CT_NumForm"/>
+       <xsd:element name="numSpacing" minOccurs="0" type="CT_NumSpacing"/>
+       <xsd:element name="stylisticSets" minOccurs="0" type="CT_StylisticSets"/>
+       <xsd:element name="cntxtAlts" minOccurs="0" type="CT_OnOff"/>
+     </xsd:sequence>
+   </xsd:group>
+   <xsd:element name="discardImageEditingData" type="CT_OnOff"/>
+   <xsd:element name="defaultImageDpi" type="CT_DefaultImageDpi"/>
+   <xsd:complexType name="CT_DefaultImageDpi">
+     <xsd:attribute name="val" type="w:ST_DecimalNumber" use="required"/>
+   </xsd:complexType>
+   <xsd:element name="entityPicker" type="w:CT_Empty"/>
+   <xsd:complexType name="CT_SdtCheckboxSymbol">
+     <xsd:attribute name="font" type="s:ST_String"/>
+     <xsd:attribute name="val" type="w:ST_ShortHexNumber"/>
+   </xsd:complexType>
+   <xsd:complexType name="CT_SdtCheckbox">
+     <xsd:sequence>
+       <xsd:element name="checked" type="CT_OnOff" minOccurs="0"/>
+       <xsd:element name="checkedState" type="CT_SdtCheckboxSymbol" minOccurs="0"/>
+       <xsd:element name="uncheckedState" type="CT_SdtCheckboxSymbol" minOccurs="0"/>
+     </xsd:sequence>
+   </xsd:complexType>
+   <xsd:element name="checkbox" type="CT_SdtCheckbox"/>
+ </xsd:schema>

--- a/skills/xlsx/scripts/office/schemas/microsoft/wml-2012.xsd
+++ b/skills/xlsx/scripts/office/schemas/microsoft/wml-2012.xsd
@@ -1,0 +1,67 @@
+ <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:w12="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:s="http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes" elementFormDefault="qualified" attributeFormDefault="qualified" blockDefault="#all" xmlns="http://schemas.microsoft.com/office/word/2012/wordml" targetNamespace="http://schemas.microsoft.com/office/word/2012/wordml">
+   <xsd:import id="w12" namespace="http://schemas.openxmlformats.org/wordprocessingml/2006/main" schemaLocation="../ISO-IEC29500-4_2016/wml.xsd"/>
+   <xsd:import namespace="http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes" schemaLocation="../ISO-IEC29500-4_2016/shared-commonSimpleTypes.xsd"/>
+   <xsd:element name="color" type="w12:CT_Color"/>
+   <xsd:simpleType name="ST_SdtAppearance">
+     <xsd:restriction base="xsd:string">
+       <xsd:enumeration value="boundingBox"/>
+       <xsd:enumeration value="tags"/>
+       <xsd:enumeration value="hidden"/>
+     </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:element name="dataBinding" type="w12:CT_DataBinding"/>
+   <xsd:complexType name="CT_SdtAppearance">
+     <xsd:attribute name="val" type="ST_SdtAppearance"/>
+   </xsd:complexType>
+   <xsd:element name="appearance" type="CT_SdtAppearance"/>
+   <xsd:complexType name="CT_CommentsEx">
+     <xsd:sequence>
+       <xsd:element name="commentEx" type="CT_CommentEx" minOccurs="0" maxOccurs="unbounded"/>
+     </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CT_CommentEx">
+     <xsd:attribute name="paraId" type="w12:ST_LongHexNumber" use="required"/>
+     <xsd:attribute name="paraIdParent" type="w12:ST_LongHexNumber" use="optional"/>
+     <xsd:attribute name="done" type="s:ST_OnOff" use="optional"/>
+   </xsd:complexType>
+   <xsd:element name="commentsEx" type="CT_CommentsEx"/>
+   <xsd:complexType name="CT_People">
+     <xsd:sequence>
+       <xsd:element name="person" type="CT_Person" minOccurs="0" maxOccurs="unbounded"/>
+     </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CT_PresenceInfo">
+     <xsd:attribute name="providerId" type="xsd:string" use="required"/>
+     <xsd:attribute name="userId" type="xsd:string" use="required"/>
+   </xsd:complexType>
+   <xsd:complexType name="CT_Person">
+     <xsd:sequence>
+       <xsd:element name="presenceInfo" type="CT_PresenceInfo" minOccurs="0" maxOccurs="1"/>
+     </xsd:sequence>
+     <xsd:attribute name="author" type="s:ST_String" use="required"/>
+   </xsd:complexType>
+   <xsd:element name="people" type="CT_People"/>
+   <xsd:complexType name="CT_SdtRepeatedSection">
+     <xsd:sequence>
+       <xsd:element name="sectionTitle" type="w12:CT_String" minOccurs="0"/>
+       <xsd:element name="doNotAllowInsertDeleteSection" type="w12:CT_OnOff" minOccurs="0"/>
+     </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="ST_Guid">
+     <xsd:restriction base="xsd:token">
+       <xsd:pattern value="\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\}"/>
+     </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="CT_Guid">
+     <xsd:attribute name="val" type="ST_Guid"/>
+   </xsd:complexType>
+   <xsd:element name="repeatingSection" type="CT_SdtRepeatedSection"/>
+   <xsd:element name="repeatingSectionItem" type="w12:CT_Empty"/>
+   <xsd:element name="chartTrackingRefBased" type="w12:CT_OnOff"/>
+   <xsd:element name="collapsed" type="w12:CT_OnOff"/>
+   <xsd:element name="docId" type="CT_Guid"/>
+   <xsd:element name="footnoteColumns" type="w12:CT_DecimalNumber"/>
+   <xsd:element name="webExtensionLinked" type="w12:CT_OnOff"/>
+   <xsd:element name="webExtensionCreated" type="w12:CT_OnOff"/>
+   <xsd:attribute name="restartNumberingAfterBreak" type="s:ST_OnOff"/>
+ </xsd:schema>

--- a/skills/xlsx/scripts/office/schemas/microsoft/wml-2018.xsd
+++ b/skills/xlsx/scripts/office/schemas/microsoft/wml-2018.xsd
@@ -1,0 +1,14 @@
+ <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:w12="http://schemas.openxmlformats.org/wordprocessingml/2006/main" elementFormDefault="qualified" attributeFormDefault="qualified" blockDefault="#all" xmlns="http://schemas.microsoft.com/office/word/2018/wordml" targetNamespace="http://schemas.microsoft.com/office/word/2018/wordml">
+   <xsd:import id="w12" namespace="http://schemas.openxmlformats.org/wordprocessingml/2006/main" schemaLocation="../ISO-IEC29500-4_2016/wml.xsd"/>
+   <xsd:complexType name="CT_Extension">
+     <xsd:sequence>
+       <xsd:any processContents="lax"/>
+     </xsd:sequence>
+     <xsd:attribute name="uri" type="xsd:token"/>
+   </xsd:complexType>
+   <xsd:complexType name="CT_ExtensionList">
+     <xsd:sequence>
+       <xsd:element name="ext" type="CT_Extension" minOccurs="0" maxOccurs="unbounded"/>
+     </xsd:sequence>
+   </xsd:complexType>
+ </xsd:schema>

--- a/skills/xlsx/scripts/office/schemas/microsoft/wml-cex-2018.xsd
+++ b/skills/xlsx/scripts/office/schemas/microsoft/wml-cex-2018.xsd
@@ -1,0 +1,20 @@
+ <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:s="http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes" xmlns:w16="http://schemas.microsoft.com/office/word/2018/wordml" elementFormDefault="qualified" attributeFormDefault="qualified" blockDefault="#all" xmlns="http://schemas.microsoft.com/office/word/2018/wordml/cex" targetNamespace="http://schemas.microsoft.com/office/word/2018/wordml/cex">
+   <xsd:import id="w16" namespace="http://schemas.microsoft.com/office/word/2018/wordml" schemaLocation="wml-2018.xsd"/>
+   <xsd:import id="w" namespace="http://schemas.openxmlformats.org/wordprocessingml/2006/main" schemaLocation="../ISO-IEC29500-4_2016/wml.xsd"/>
+   <xsd:import id="s" namespace="http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes" schemaLocation="../ISO-IEC29500-4_2016/shared-commonSimpleTypes.xsd"/>
+   <xsd:complexType name="CT_CommentsExtensible">
+     <xsd:sequence>
+       <xsd:element name="commentExtensible" type="CT_CommentExtensible" minOccurs="0" maxOccurs="unbounded"/>
+       <xsd:element name="extLst" type="w16:CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+     </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CT_CommentExtensible">
+     <xsd:sequence>
+       <xsd:element name="extLst" type="w16:CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+     </xsd:sequence>
+     <xsd:attribute name="durableId" type="w:ST_LongHexNumber" use="required"/>
+     <xsd:attribute name="dateUtc" type="w:ST_DateTime" use="optional"/>
+     <xsd:attribute name="intelligentPlaceholder" type="s:ST_OnOff" use="optional"/>
+   </xsd:complexType>
+   <xsd:element name="commentsExtensible" type="CT_CommentsExtensible"/>
+ </xsd:schema>

--- a/skills/xlsx/scripts/office/schemas/microsoft/wml-cid-2016.xsd
+++ b/skills/xlsx/scripts/office/schemas/microsoft/wml-cid-2016.xsd
@@ -1,0 +1,13 @@
+ <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:w12="http://schemas.openxmlformats.org/wordprocessingml/2006/main" elementFormDefault="qualified" attributeFormDefault="qualified" blockDefault="#all" xmlns="http://schemas.microsoft.com/office/word/2016/wordml/cid" targetNamespace="http://schemas.microsoft.com/office/word/2016/wordml/cid">
+   <xsd:import id="w12" namespace="http://schemas.openxmlformats.org/wordprocessingml/2006/main" schemaLocation="../ISO-IEC29500-4_2016/wml.xsd"/>
+   <xsd:complexType name="CT_CommentsIds">
+     <xsd:sequence>
+       <xsd:element name="commentId" type="CT_CommentId" minOccurs="0" maxOccurs="unbounded"/>
+     </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CT_CommentId">
+     <xsd:attribute name="paraId" type="w12:ST_LongHexNumber" use="required"/>
+     <xsd:attribute name="durableId" type="w12:ST_LongHexNumber" use="required"/>
+   </xsd:complexType>
+   <xsd:element name="commentsIds" type="CT_CommentsIds"/>
+ </xsd:schema>

--- a/skills/xlsx/scripts/office/schemas/microsoft/wml-sdtdatahash-2020.xsd
+++ b/skills/xlsx/scripts/office/schemas/microsoft/wml-sdtdatahash-2020.xsd
@@ -1,0 +1,4 @@
+ <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:w12="http://schemas.openxmlformats.org/wordprocessingml/2006/main" elementFormDefault="qualified" attributeFormDefault="qualified" blockDefault="#all" xmlns="http://schemas.microsoft.com/office/word/2020/wordml/sdtdatahash" targetNamespace="http://schemas.microsoft.com/office/word/2020/wordml/sdtdatahash">
+   <xsd:import id="w12" namespace="http://schemas.openxmlformats.org/wordprocessingml/2006/main" schemaLocation="../ISO-IEC29500-4_2016/wml.xsd"/>
+   <xsd:attribute name="storeItemChecksum" type="w12:ST_String"/>
+ </xsd:schema>

--- a/skills/xlsx/scripts/office/schemas/microsoft/wml-symex-2015.xsd
+++ b/skills/xlsx/scripts/office/schemas/microsoft/wml-symex-2015.xsd
@@ -1,0 +1,8 @@
+ <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:w12="http://schemas.openxmlformats.org/wordprocessingml/2006/main" elementFormDefault="qualified" attributeFormDefault="qualified" blockDefault="#all" xmlns="http://schemas.microsoft.com/office/word/2015/wordml/symex" targetNamespace="http://schemas.microsoft.com/office/word/2015/wordml/symex">
+   <xsd:import id="w12" namespace="http://schemas.openxmlformats.org/wordprocessingml/2006/main" schemaLocation="../ISO-IEC29500-4_2016/wml.xsd"/>
+   <xsd:complexType name="CT_SymEx">
+     <xsd:attribute name="font" type="w12:ST_String"/>
+     <xsd:attribute name="char" type="w12:ST_LongHexNumber"/>
+   </xsd:complexType>
+   <xsd:element name="symEx" type="CT_SymEx"/>
+ </xsd:schema>

--- a/skills/xlsx/scripts/office/soffice.py
+++ b/skills/xlsx/scripts/office/soffice.py
@@ -1,0 +1,183 @@
+"""
+Helper for running LibreOffice (soffice) in environments where AF_UNIX
+sockets may be blocked (e.g., sandboxed VMs).  Detects the restriction
+at runtime and applies an LD_PRELOAD shim if needed.
+
+Usage:
+    from office.soffice import run_soffice, get_soffice_env
+
+    # Option 1 – run soffice directly
+    result = run_soffice(["--headless", "--convert-to", "pdf", "input.docx"])
+
+    # Option 2 – get env dict for your own subprocess calls
+    env = get_soffice_env()
+    subprocess.run(["soffice", ...], env=env)
+"""
+
+import os
+import socket
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def get_soffice_env() -> dict:
+    env = os.environ.copy()
+    env["SAL_USE_VCLPLUGIN"] = "svp"
+
+    if _needs_shim():
+        shim = _ensure_shim()
+        env["LD_PRELOAD"] = str(shim)
+
+    return env
+
+
+def run_soffice(args: list[str], **kwargs) -> subprocess.CompletedProcess:
+    env = get_soffice_env()
+    return subprocess.run(["soffice"] + args, env=env, **kwargs)
+
+
+
+_SHIM_SO = Path(tempfile.gettempdir()) / "lo_socket_shim.so"
+
+
+def _needs_shim() -> bool:
+    try:
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        s.close()
+        return False
+    except OSError:
+        return True
+
+
+def _ensure_shim() -> Path:
+    if _SHIM_SO.exists():
+        return _SHIM_SO
+
+    src = Path(tempfile.gettempdir()) / "lo_socket_shim.c"
+    src.write_text(_SHIM_SOURCE)
+    subprocess.run(
+        ["gcc", "-shared", "-fPIC", "-o", str(_SHIM_SO), str(src), "-ldl"],
+        check=True,
+        capture_output=True,
+    )
+    src.unlink()
+    return _SHIM_SO
+
+
+
+_SHIM_SOURCE = r"""
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+static int (*real_socket)(int, int, int);
+static int (*real_socketpair)(int, int, int, int[2]);
+static int (*real_listen)(int, int);
+static int (*real_accept)(int, struct sockaddr *, socklen_t *);
+static int (*real_close)(int);
+static int (*real_read)(int, void *, size_t);
+
+/* Per-FD bookkeeping (FDs >= 1024 are passed through unshimmed). */
+static int is_shimmed[1024];
+static int peer_of[1024];
+static int wake_r[1024];            /* accept() blocks reading this */
+static int wake_w[1024];            /* close()  writes to this      */
+static int listener_fd = -1;        /* FD that received listen()    */
+
+__attribute__((constructor))
+static void init(void) {
+    real_socket     = dlsym(RTLD_NEXT, "socket");
+    real_socketpair = dlsym(RTLD_NEXT, "socketpair");
+    real_listen     = dlsym(RTLD_NEXT, "listen");
+    real_accept     = dlsym(RTLD_NEXT, "accept");
+    real_close      = dlsym(RTLD_NEXT, "close");
+    real_read       = dlsym(RTLD_NEXT, "read");
+    for (int i = 0; i < 1024; i++) {
+        peer_of[i] = -1;
+        wake_r[i]  = -1;
+        wake_w[i]  = -1;
+    }
+}
+
+/* ---- socket ---------------------------------------------------------- */
+int socket(int domain, int type, int protocol) {
+    if (domain == AF_UNIX) {
+        int fd = real_socket(domain, type, protocol);
+        if (fd >= 0) return fd;
+        /* socket(AF_UNIX) blocked – fall back to socketpair(). */
+        int sv[2];
+        if (real_socketpair(domain, type, protocol, sv) == 0) {
+            if (sv[0] >= 0 && sv[0] < 1024) {
+                is_shimmed[sv[0]] = 1;
+                peer_of[sv[0]]    = sv[1];
+                int wp[2];
+                if (pipe(wp) == 0) {
+                    wake_r[sv[0]] = wp[0];
+                    wake_w[sv[0]] = wp[1];
+                }
+            }
+            return sv[0];
+        }
+        errno = EPERM;
+        return -1;
+    }
+    return real_socket(domain, type, protocol);
+}
+
+/* ---- listen ---------------------------------------------------------- */
+int listen(int sockfd, int backlog) {
+    if (sockfd >= 0 && sockfd < 1024 && is_shimmed[sockfd]) {
+        listener_fd = sockfd;
+        return 0;
+    }
+    return real_listen(sockfd, backlog);
+}
+
+/* ---- accept ---------------------------------------------------------- */
+int accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen) {
+    if (sockfd >= 0 && sockfd < 1024 && is_shimmed[sockfd]) {
+        /* Block until close() writes to the wake pipe. */
+        if (wake_r[sockfd] >= 0) {
+            char buf;
+            real_read(wake_r[sockfd], &buf, 1);
+        }
+        errno = ECONNABORTED;
+        return -1;
+    }
+    return real_accept(sockfd, addr, addrlen);
+}
+
+/* ---- close ----------------------------------------------------------- */
+int close(int fd) {
+    if (fd >= 0 && fd < 1024 && is_shimmed[fd]) {
+        int was_listener = (fd == listener_fd);
+        is_shimmed[fd] = 0;
+
+        if (wake_w[fd] >= 0) {              /* unblock accept() */
+            char c = 0;
+            write(wake_w[fd], &c, 1);
+            real_close(wake_w[fd]);
+            wake_w[fd] = -1;
+        }
+        if (wake_r[fd] >= 0) { real_close(wake_r[fd]); wake_r[fd]  = -1; }
+        if (peer_of[fd] >= 0) { real_close(peer_of[fd]); peer_of[fd] = -1; }
+
+        if (was_listener)
+            _exit(0);                        /* conversion done – exit */
+    }
+    return real_close(fd);
+}
+"""
+
+
+
+if __name__ == "__main__":
+    import sys
+    result = run_soffice(sys.argv[1:])
+    sys.exit(result.returncode)

--- a/skills/xlsx/scripts/office/unpack.py
+++ b/skills/xlsx/scripts/office/unpack.py
@@ -1,0 +1,132 @@
+"""Unpack Office files (DOCX, PPTX, XLSX) for editing.
+
+Extracts the ZIP archive, pretty-prints XML files, and optionally:
+- Merges adjacent runs with identical formatting (DOCX only)
+- Simplifies adjacent tracked changes from same author (DOCX only)
+
+Usage:
+    python unpack.py <office_file> <output_dir> [options]
+
+Examples:
+    python unpack.py document.docx unpacked/
+    python unpack.py presentation.pptx unpacked/
+    python unpack.py document.docx unpacked/ --merge-runs false
+"""
+
+import argparse
+import sys
+import zipfile
+from pathlib import Path
+
+import defusedxml.minidom
+
+from helpers.merge_runs import merge_runs as do_merge_runs
+from helpers.simplify_redlines import simplify_redlines as do_simplify_redlines
+
+SMART_QUOTE_REPLACEMENTS = {
+    "\u201c": "&#x201C;",  
+    "\u201d": "&#x201D;",  
+    "\u2018": "&#x2018;",  
+    "\u2019": "&#x2019;",  
+}
+
+
+def unpack(
+    input_file: str,
+    output_directory: str,
+    merge_runs: bool = True,
+    simplify_redlines: bool = True,
+) -> tuple[None, str]:
+    input_path = Path(input_file)
+    output_path = Path(output_directory)
+    suffix = input_path.suffix.lower()
+
+    if not input_path.exists():
+        return None, f"Error: {input_file} does not exist"
+
+    if suffix not in {".docx", ".pptx", ".xlsx"}:
+        return None, f"Error: {input_file} must be a .docx, .pptx, or .xlsx file"
+
+    try:
+        output_path.mkdir(parents=True, exist_ok=True)
+
+        with zipfile.ZipFile(input_path, "r") as zf:
+            zf.extractall(output_path)
+
+        xml_files = list(output_path.rglob("*.xml")) + list(output_path.rglob("*.rels"))
+        for xml_file in xml_files:
+            _pretty_print_xml(xml_file)
+
+        message = f"Unpacked {input_file} ({len(xml_files)} XML files)"
+
+        if suffix == ".docx":
+            if simplify_redlines:
+                simplify_count, _ = do_simplify_redlines(str(output_path))
+                message += f", simplified {simplify_count} tracked changes"
+
+            if merge_runs:
+                merge_count, _ = do_merge_runs(str(output_path))
+                message += f", merged {merge_count} runs"
+
+        for xml_file in xml_files:
+            _escape_smart_quotes(xml_file)
+
+        return None, message
+
+    except zipfile.BadZipFile:
+        return None, f"Error: {input_file} is not a valid Office file"
+    except Exception as e:
+        return None, f"Error unpacking: {e}"
+
+
+def _pretty_print_xml(xml_file: Path) -> None:
+    try:
+        content = xml_file.read_text(encoding="utf-8")
+        dom = defusedxml.minidom.parseString(content)
+        xml_file.write_bytes(dom.toprettyxml(indent="  ", encoding="utf-8"))
+    except Exception:
+        pass  
+
+
+def _escape_smart_quotes(xml_file: Path) -> None:
+    try:
+        content = xml_file.read_text(encoding="utf-8")
+        for char, entity in SMART_QUOTE_REPLACEMENTS.items():
+            content = content.replace(char, entity)
+        xml_file.write_text(content, encoding="utf-8")
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Unpack an Office file (DOCX, PPTX, XLSX) for editing"
+    )
+    parser.add_argument("input_file", help="Office file to unpack")
+    parser.add_argument("output_directory", help="Output directory")
+    parser.add_argument(
+        "--merge-runs",
+        type=lambda x: x.lower() == "true",
+        default=True,
+        metavar="true|false",
+        help="Merge adjacent runs with identical formatting (DOCX only, default: true)",
+    )
+    parser.add_argument(
+        "--simplify-redlines",
+        type=lambda x: x.lower() == "true",
+        default=True,
+        metavar="true|false",
+        help="Merge adjacent tracked changes from same author (DOCX only, default: true)",
+    )
+    args = parser.parse_args()
+
+    _, message = unpack(
+        args.input_file,
+        args.output_directory,
+        merge_runs=args.merge_runs,
+        simplify_redlines=args.simplify_redlines,
+    )
+    print(message)
+
+    if "Error" in message:
+        sys.exit(1)

--- a/skills/xlsx/scripts/office/validate.py
+++ b/skills/xlsx/scripts/office/validate.py
@@ -1,0 +1,111 @@
+"""
+Command line tool to validate Office document XML files against XSD schemas and tracked changes.
+
+Usage:
+    python validate.py <path> [--original <original_file>] [--auto-repair] [--author NAME]
+
+The first argument can be either:
+- An unpacked directory containing the Office document XML files
+- A packed Office file (.docx/.pptx/.xlsx) which will be unpacked to a temp directory
+
+Auto-repair fixes:
+- paraId/durableId values that exceed OOXML limits
+- Missing xml:space="preserve" on w:t elements with whitespace
+"""
+
+import argparse
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+from validators import DOCXSchemaValidator, PPTXSchemaValidator, RedliningValidator
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Validate Office document XML files")
+    parser.add_argument(
+        "path",
+        help="Path to unpacked directory or packed Office file (.docx/.pptx/.xlsx)",
+    )
+    parser.add_argument(
+        "--original",
+        required=False,
+        default=None,
+        help="Path to original file (.docx/.pptx/.xlsx). If omitted, all XSD errors are reported and redlining validation is skipped.",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Enable verbose output",
+    )
+    parser.add_argument(
+        "--auto-repair",
+        action="store_true",
+        help="Automatically repair common issues (hex IDs, whitespace preservation)",
+    )
+    parser.add_argument(
+        "--author",
+        default="Claude",
+        help="Author name for redlining validation (default: Claude)",
+    )
+    args = parser.parse_args()
+
+    path = Path(args.path)
+    assert path.exists(), f"Error: {path} does not exist"
+
+    original_file = None
+    if args.original:
+        original_file = Path(args.original)
+        assert original_file.is_file(), f"Error: {original_file} is not a file"
+        assert original_file.suffix.lower() in [".docx", ".pptx", ".xlsx"], (
+            f"Error: {original_file} must be a .docx, .pptx, or .xlsx file"
+        )
+
+    file_extension = (original_file or path).suffix.lower()
+    assert file_extension in [".docx", ".pptx", ".xlsx"], (
+        f"Error: Cannot determine file type from {path}. Use --original or provide a .docx/.pptx/.xlsx file."
+    )
+
+    if path.is_file() and path.suffix.lower() in [".docx", ".pptx", ".xlsx"]:
+        temp_dir = tempfile.mkdtemp()
+        with zipfile.ZipFile(path, "r") as zf:
+            zf.extractall(temp_dir)
+        unpacked_dir = Path(temp_dir)
+    else:
+        assert path.is_dir(), f"Error: {path} is not a directory or Office file"
+        unpacked_dir = path
+
+    match file_extension:
+        case ".docx":
+            validators = [
+                DOCXSchemaValidator(unpacked_dir, original_file, verbose=args.verbose),
+            ]
+            if original_file:
+                validators.append(
+                    RedliningValidator(unpacked_dir, original_file, verbose=args.verbose, author=args.author)  
+                )
+        case ".pptx":
+            validators = [
+                PPTXSchemaValidator(unpacked_dir, original_file, verbose=args.verbose),
+            ]
+        case _:
+            print(f"Error: Validation not supported for file type {file_extension}")
+            sys.exit(1)
+
+    if args.auto_repair:
+        total_repairs = sum(v.repair() for v in validators)
+        if total_repairs:
+            print(f"Auto-repaired {total_repairs} issue(s)")
+
+    success = all(v.validate() for v in validators)
+
+    if success:
+        print("All validations PASSED!")
+
+    sys.exit(0 if success else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/xlsx/scripts/office/validators/__init__.py
+++ b/skills/xlsx/scripts/office/validators/__init__.py
@@ -1,0 +1,15 @@
+"""
+Validation modules for Word document processing.
+"""
+
+from .base import BaseSchemaValidator
+from .docx import DOCXSchemaValidator
+from .pptx import PPTXSchemaValidator
+from .redlining import RedliningValidator
+
+__all__ = [
+    "BaseSchemaValidator",
+    "DOCXSchemaValidator",
+    "PPTXSchemaValidator",
+    "RedliningValidator",
+]

--- a/skills/xlsx/scripts/office/validators/base.py
+++ b/skills/xlsx/scripts/office/validators/base.py
@@ -1,0 +1,847 @@
+"""
+Base validator with common validation logic for document files.
+"""
+
+import re
+from pathlib import Path
+
+import defusedxml.minidom
+import lxml.etree
+
+
+class BaseSchemaValidator:
+
+    IGNORED_VALIDATION_ERRORS = [
+        "hyphenationZone",
+        "purl.org/dc/terms",
+    ]
+
+    UNIQUE_ID_REQUIREMENTS = {
+        "comment": ("id", "file"),  
+        "commentrangestart": ("id", "file"),  
+        "commentrangeend": ("id", "file"),  
+        "bookmarkstart": ("id", "file"),  
+        "bookmarkend": ("id", "file"),  
+        "sldid": ("id", "file"),  
+        "sldmasterid": ("id", "global"),  
+        "sldlayoutid": ("id", "global"),  
+        "cm": ("authorid", "file"),  
+        "sheet": ("sheetid", "file"),  
+        "definedname": ("id", "file"),  
+        "cxnsp": ("id", "file"),  
+        "sp": ("id", "file"),  
+        "pic": ("id", "file"),  
+        "grpsp": ("id", "file"),  
+    }
+
+    EXCLUDED_ID_CONTAINERS = {
+        "sectionlst",  
+    }
+
+    ELEMENT_RELATIONSHIP_TYPES = {}
+
+    SCHEMA_MAPPINGS = {
+        "word": "ISO-IEC29500-4_2016/wml.xsd",  
+        "ppt": "ISO-IEC29500-4_2016/pml.xsd",  
+        "xl": "ISO-IEC29500-4_2016/sml.xsd",  
+        "[Content_Types].xml": "ecma/fouth-edition/opc-contentTypes.xsd",
+        "app.xml": "ISO-IEC29500-4_2016/shared-documentPropertiesExtended.xsd",
+        "core.xml": "ecma/fouth-edition/opc-coreProperties.xsd",
+        "custom.xml": "ISO-IEC29500-4_2016/shared-documentPropertiesCustom.xsd",
+        ".rels": "ecma/fouth-edition/opc-relationships.xsd",
+        "people.xml": "microsoft/wml-2012.xsd",
+        "commentsIds.xml": "microsoft/wml-cid-2016.xsd",
+        "commentsExtensible.xml": "microsoft/wml-cex-2018.xsd",
+        "commentsExtended.xml": "microsoft/wml-2012.xsd",
+        "chart": "ISO-IEC29500-4_2016/dml-chart.xsd",
+        "theme": "ISO-IEC29500-4_2016/dml-main.xsd",
+        "drawing": "ISO-IEC29500-4_2016/dml-main.xsd",
+    }
+
+    MC_NAMESPACE = "http://schemas.openxmlformats.org/markup-compatibility/2006"
+    XML_NAMESPACE = "http://www.w3.org/XML/1998/namespace"
+
+    PACKAGE_RELATIONSHIPS_NAMESPACE = (
+        "http://schemas.openxmlformats.org/package/2006/relationships"
+    )
+    OFFICE_RELATIONSHIPS_NAMESPACE = (
+        "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+    )
+    CONTENT_TYPES_NAMESPACE = (
+        "http://schemas.openxmlformats.org/package/2006/content-types"
+    )
+
+    MAIN_CONTENT_FOLDERS = {"word", "ppt", "xl"}
+
+    OOXML_NAMESPACES = {
+        "http://schemas.openxmlformats.org/officeDocument/2006/math",
+        "http://schemas.openxmlformats.org/officeDocument/2006/relationships",
+        "http://schemas.openxmlformats.org/schemaLibrary/2006/main",
+        "http://schemas.openxmlformats.org/drawingml/2006/main",
+        "http://schemas.openxmlformats.org/drawingml/2006/chart",
+        "http://schemas.openxmlformats.org/drawingml/2006/chartDrawing",
+        "http://schemas.openxmlformats.org/drawingml/2006/diagram",
+        "http://schemas.openxmlformats.org/drawingml/2006/picture",
+        "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing",
+        "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing",
+        "http://schemas.openxmlformats.org/wordprocessingml/2006/main",
+        "http://schemas.openxmlformats.org/presentationml/2006/main",
+        "http://schemas.openxmlformats.org/spreadsheetml/2006/main",
+        "http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes",
+        "http://www.w3.org/XML/1998/namespace",
+    }
+
+    def __init__(self, unpacked_dir, original_file=None, verbose=False):
+        self.unpacked_dir = Path(unpacked_dir).resolve()
+        self.original_file = Path(original_file) if original_file else None
+        self.verbose = verbose
+
+        self.schemas_dir = Path(__file__).parent.parent / "schemas"
+
+        patterns = ["*.xml", "*.rels"]
+        self.xml_files = [
+            f for pattern in patterns for f in self.unpacked_dir.rglob(pattern)
+        ]
+
+        if not self.xml_files:
+            print(f"Warning: No XML files found in {self.unpacked_dir}")
+
+    def validate(self):
+        raise NotImplementedError("Subclasses must implement the validate method")
+
+    def repair(self) -> int:
+        return self.repair_whitespace_preservation()
+
+    def repair_whitespace_preservation(self) -> int:
+        repairs = 0
+
+        for xml_file in self.xml_files:
+            try:
+                content = xml_file.read_text(encoding="utf-8")
+                dom = defusedxml.minidom.parseString(content)
+                modified = False
+
+                for elem in dom.getElementsByTagName("*"):
+                    if elem.tagName.endswith(":t") and elem.firstChild:
+                        text = elem.firstChild.nodeValue
+                        if text and (text.startswith((' ', '\t')) or text.endswith((' ', '\t'))):
+                            if elem.getAttribute("xml:space") != "preserve":
+                                elem.setAttribute("xml:space", "preserve")
+                                text_preview = repr(text[:30]) + "..." if len(text) > 30 else repr(text)
+                                print(f"  Repaired: {xml_file.name}: Added xml:space='preserve' to {elem.tagName}: {text_preview}")
+                                repairs += 1
+                                modified = True
+
+                if modified:
+                    xml_file.write_bytes(dom.toxml(encoding="UTF-8"))
+
+            except Exception:
+                pass
+
+        return repairs
+
+    def validate_xml(self):
+        errors = []
+
+        for xml_file in self.xml_files:
+            try:
+                lxml.etree.parse(str(xml_file))
+            except lxml.etree.XMLSyntaxError as e:
+                errors.append(
+                    f"  {xml_file.relative_to(self.unpacked_dir)}: "
+                    f"Line {e.lineno}: {e.msg}"
+                )
+            except Exception as e:
+                errors.append(
+                    f"  {xml_file.relative_to(self.unpacked_dir)}: "
+                    f"Unexpected error: {str(e)}"
+                )
+
+        if errors:
+            print(f"FAILED - Found {len(errors)} XML violations:")
+            for error in errors:
+                print(error)
+            return False
+        else:
+            if self.verbose:
+                print("PASSED - All XML files are well-formed")
+            return True
+
+    def validate_namespaces(self):
+        errors = []
+
+        for xml_file in self.xml_files:
+            try:
+                root = lxml.etree.parse(str(xml_file)).getroot()
+                declared = set(root.nsmap.keys()) - {None}  
+
+                for attr_val in [
+                    v for k, v in root.attrib.items() if k.endswith("Ignorable")
+                ]:
+                    undeclared = set(attr_val.split()) - declared
+                    errors.extend(
+                        f"  {xml_file.relative_to(self.unpacked_dir)}: "
+                        f"Namespace '{ns}' in Ignorable but not declared"
+                        for ns in undeclared
+                    )
+            except lxml.etree.XMLSyntaxError:
+                continue
+
+        if errors:
+            print(f"FAILED - {len(errors)} namespace issues:")
+            for error in errors:
+                print(error)
+            return False
+        if self.verbose:
+            print("PASSED - All namespace prefixes properly declared")
+        return True
+
+    def validate_unique_ids(self):
+        errors = []
+        global_ids = {}  
+
+        for xml_file in self.xml_files:
+            try:
+                root = lxml.etree.parse(str(xml_file)).getroot()
+                file_ids = {}  
+
+                mc_elements = root.xpath(
+                    ".//mc:AlternateContent", namespaces={"mc": self.MC_NAMESPACE}
+                )
+                for elem in mc_elements:
+                    elem.getparent().remove(elem)
+
+                for elem in root.iter():
+                    tag = (
+                        elem.tag.split("}")[-1].lower()
+                        if "}" in elem.tag
+                        else elem.tag.lower()
+                    )
+
+                    if tag in self.UNIQUE_ID_REQUIREMENTS:
+                        in_excluded_container = any(
+                            ancestor.tag.split("}")[-1].lower() in self.EXCLUDED_ID_CONTAINERS
+                            for ancestor in elem.iterancestors()
+                        )
+                        if in_excluded_container:
+                            continue
+
+                        attr_name, scope = self.UNIQUE_ID_REQUIREMENTS[tag]
+
+                        id_value = None
+                        for attr, value in elem.attrib.items():
+                            attr_local = (
+                                attr.split("}")[-1].lower()
+                                if "}" in attr
+                                else attr.lower()
+                            )
+                            if attr_local == attr_name:
+                                id_value = value
+                                break
+
+                        if id_value is not None:
+                            if scope == "global":
+                                if id_value in global_ids:
+                                    prev_file, prev_line, prev_tag = global_ids[
+                                        id_value
+                                    ]
+                                    errors.append(
+                                        f"  {xml_file.relative_to(self.unpacked_dir)}: "
+                                        f"Line {elem.sourceline}: Global ID '{id_value}' in <{tag}> "
+                                        f"already used in {prev_file} at line {prev_line} in <{prev_tag}>"
+                                    )
+                                else:
+                                    global_ids[id_value] = (
+                                        xml_file.relative_to(self.unpacked_dir),
+                                        elem.sourceline,
+                                        tag,
+                                    )
+                            elif scope == "file":
+                                key = (tag, attr_name)
+                                if key not in file_ids:
+                                    file_ids[key] = {}
+
+                                if id_value in file_ids[key]:
+                                    prev_line = file_ids[key][id_value]
+                                    errors.append(
+                                        f"  {xml_file.relative_to(self.unpacked_dir)}: "
+                                        f"Line {elem.sourceline}: Duplicate {attr_name}='{id_value}' in <{tag}> "
+                                        f"(first occurrence at line {prev_line})"
+                                    )
+                                else:
+                                    file_ids[key][id_value] = elem.sourceline
+
+            except (lxml.etree.XMLSyntaxError, Exception) as e:
+                errors.append(
+                    f"  {xml_file.relative_to(self.unpacked_dir)}: Error: {e}"
+                )
+
+        if errors:
+            print(f"FAILED - Found {len(errors)} ID uniqueness violations:")
+            for error in errors:
+                print(error)
+            return False
+        else:
+            if self.verbose:
+                print("PASSED - All required IDs are unique")
+            return True
+
+    def validate_file_references(self):
+        errors = []
+
+        rels_files = list(self.unpacked_dir.rglob("*.rels"))
+
+        if not rels_files:
+            if self.verbose:
+                print("PASSED - No .rels files found")
+            return True
+
+        all_files = []
+        for file_path in self.unpacked_dir.rglob("*"):
+            if (
+                file_path.is_file()
+                and file_path.name != "[Content_Types].xml"
+                and not file_path.name.endswith(".rels")
+            ):  
+                all_files.append(file_path.resolve())
+
+        all_referenced_files = set()
+
+        if self.verbose:
+            print(
+                f"Found {len(rels_files)} .rels files and {len(all_files)} target files"
+            )
+
+        for rels_file in rels_files:
+            try:
+                rels_root = lxml.etree.parse(str(rels_file)).getroot()
+
+                rels_dir = rels_file.parent
+
+                referenced_files = set()
+                broken_refs = []
+
+                for rel in rels_root.findall(
+                    ".//ns:Relationship",
+                    namespaces={"ns": self.PACKAGE_RELATIONSHIPS_NAMESPACE},
+                ):
+                    target = rel.get("Target")
+                    if target and not target.startswith(
+                        ("http", "mailto:")
+                    ):  
+                        if target.startswith("/"):
+                            target_path = self.unpacked_dir / target.lstrip("/")
+                        elif rels_file.name == ".rels":
+                            target_path = self.unpacked_dir / target
+                        else:
+                            base_dir = rels_dir.parent
+                            target_path = base_dir / target
+
+                        try:
+                            target_path = target_path.resolve()
+                            if target_path.exists() and target_path.is_file():
+                                referenced_files.add(target_path)
+                                all_referenced_files.add(target_path)
+                            else:
+                                broken_refs.append((target, rel.sourceline))
+                        except (OSError, ValueError):
+                            broken_refs.append((target, rel.sourceline))
+
+                if broken_refs:
+                    rel_path = rels_file.relative_to(self.unpacked_dir)
+                    for broken_ref, line_num in broken_refs:
+                        errors.append(
+                            f"  {rel_path}: Line {line_num}: Broken reference to {broken_ref}"
+                        )
+
+            except Exception as e:
+                rel_path = rels_file.relative_to(self.unpacked_dir)
+                errors.append(f"  Error parsing {rel_path}: {e}")
+
+        unreferenced_files = set(all_files) - all_referenced_files
+
+        if unreferenced_files:
+            for unref_file in sorted(unreferenced_files):
+                unref_rel_path = unref_file.relative_to(self.unpacked_dir)
+                errors.append(f"  Unreferenced file: {unref_rel_path}")
+
+        if errors:
+            print(f"FAILED - Found {len(errors)} relationship validation errors:")
+            for error in errors:
+                print(error)
+            print(
+                "CRITICAL: These errors will cause the document to appear corrupt. "
+                + "Broken references MUST be fixed, "
+                + "and unreferenced files MUST be referenced or removed."
+            )
+            return False
+        else:
+            if self.verbose:
+                print(
+                    "PASSED - All references are valid and all files are properly referenced"
+                )
+            return True
+
+    def validate_all_relationship_ids(self):
+        import lxml.etree
+
+        errors = []
+
+        for xml_file in self.xml_files:
+            if xml_file.suffix == ".rels":
+                continue
+
+            rels_dir = xml_file.parent / "_rels"
+            rels_file = rels_dir / f"{xml_file.name}.rels"
+
+            if not rels_file.exists():
+                continue
+
+            try:
+                rels_root = lxml.etree.parse(str(rels_file)).getroot()
+                rid_to_type = {}
+
+                for rel in rels_root.findall(
+                    f".//{{{self.PACKAGE_RELATIONSHIPS_NAMESPACE}}}Relationship"
+                ):
+                    rid = rel.get("Id")
+                    rel_type = rel.get("Type", "")
+                    if rid:
+                        if rid in rid_to_type:
+                            rels_rel_path = rels_file.relative_to(self.unpacked_dir)
+                            errors.append(
+                                f"  {rels_rel_path}: Line {rel.sourceline}: "
+                                f"Duplicate relationship ID '{rid}' (IDs must be unique)"
+                            )
+                        type_name = (
+                            rel_type.split("/")[-1] if "/" in rel_type else rel_type
+                        )
+                        rid_to_type[rid] = type_name
+
+                xml_root = lxml.etree.parse(str(xml_file)).getroot()
+
+                r_ns = self.OFFICE_RELATIONSHIPS_NAMESPACE
+                rid_attrs_to_check = ["id", "embed", "link"]
+                for elem in xml_root.iter():
+                    for attr_name in rid_attrs_to_check:
+                        rid_attr = elem.get(f"{{{r_ns}}}{attr_name}")
+                        if not rid_attr:
+                            continue
+                        xml_rel_path = xml_file.relative_to(self.unpacked_dir)
+                        elem_name = (
+                            elem.tag.split("}")[-1] if "}" in elem.tag else elem.tag
+                        )
+
+                        if rid_attr not in rid_to_type:
+                            errors.append(
+                                f"  {xml_rel_path}: Line {elem.sourceline}: "
+                                f"<{elem_name}> r:{attr_name} references non-existent relationship '{rid_attr}' "
+                                f"(valid IDs: {', '.join(sorted(rid_to_type.keys())[:5])}{'...' if len(rid_to_type) > 5 else ''})"
+                            )
+                        elif attr_name == "id" and self.ELEMENT_RELATIONSHIP_TYPES:
+                            expected_type = self._get_expected_relationship_type(
+                                elem_name
+                            )
+                            if expected_type:
+                                actual_type = rid_to_type[rid_attr]
+                                if expected_type not in actual_type.lower():
+                                    errors.append(
+                                        f"  {xml_rel_path}: Line {elem.sourceline}: "
+                                        f"<{elem_name}> references '{rid_attr}' which points to '{actual_type}' "
+                                        f"but should point to a '{expected_type}' relationship"
+                                    )
+
+            except Exception as e:
+                xml_rel_path = xml_file.relative_to(self.unpacked_dir)
+                errors.append(f"  Error processing {xml_rel_path}: {e}")
+
+        if errors:
+            print(f"FAILED - Found {len(errors)} relationship ID reference errors:")
+            for error in errors:
+                print(error)
+            print("\nThese ID mismatches will cause the document to appear corrupt!")
+            return False
+        else:
+            if self.verbose:
+                print("PASSED - All relationship ID references are valid")
+            return True
+
+    def _get_expected_relationship_type(self, element_name):
+        elem_lower = element_name.lower()
+
+        if elem_lower in self.ELEMENT_RELATIONSHIP_TYPES:
+            return self.ELEMENT_RELATIONSHIP_TYPES[elem_lower]
+
+        if elem_lower.endswith("id") and len(elem_lower) > 2:
+            prefix = elem_lower[:-2]  
+            if prefix.endswith("master"):
+                return prefix.lower()
+            elif prefix.endswith("layout"):
+                return prefix.lower()
+            else:
+                if prefix == "sld":
+                    return "slide"
+                return prefix.lower()
+
+        if elem_lower.endswith("reference") and len(elem_lower) > 9:
+            prefix = elem_lower[:-9]  
+            return prefix.lower()
+
+        return None
+
+    def validate_content_types(self):
+        errors = []
+
+        content_types_file = self.unpacked_dir / "[Content_Types].xml"
+        if not content_types_file.exists():
+            print("FAILED - [Content_Types].xml file not found")
+            return False
+
+        try:
+            root = lxml.etree.parse(str(content_types_file)).getroot()
+            declared_parts = set()
+            declared_extensions = set()
+
+            for override in root.findall(
+                f".//{{{self.CONTENT_TYPES_NAMESPACE}}}Override"
+            ):
+                part_name = override.get("PartName")
+                if part_name is not None:
+                    declared_parts.add(part_name.lstrip("/"))
+
+            for default in root.findall(
+                f".//{{{self.CONTENT_TYPES_NAMESPACE}}}Default"
+            ):
+                extension = default.get("Extension")
+                if extension is not None:
+                    declared_extensions.add(extension.lower())
+
+            declarable_roots = {
+                "sld",
+                "sldLayout",
+                "sldMaster",
+                "presentation",  
+                "document",  
+                "workbook",
+                "worksheet",  
+                "theme",  
+            }
+
+            media_extensions = {
+                "png": "image/png",
+                "jpg": "image/jpeg",
+                "jpeg": "image/jpeg",
+                "gif": "image/gif",
+                "bmp": "image/bmp",
+                "tiff": "image/tiff",
+                "wmf": "image/x-wmf",
+                "emf": "image/x-emf",
+            }
+
+            all_files = list(self.unpacked_dir.rglob("*"))
+            all_files = [f for f in all_files if f.is_file()]
+
+            for xml_file in self.xml_files:
+                path_str = str(xml_file.relative_to(self.unpacked_dir)).replace(
+                    "\\", "/"
+                )
+
+                if any(
+                    skip in path_str
+                    for skip in [".rels", "[Content_Types]", "docProps/", "_rels/"]
+                ):
+                    continue
+
+                try:
+                    root_tag = lxml.etree.parse(str(xml_file)).getroot().tag
+                    root_name = root_tag.split("}")[-1] if "}" in root_tag else root_tag
+
+                    if root_name in declarable_roots and path_str not in declared_parts:
+                        errors.append(
+                            f"  {path_str}: File with <{root_name}> root not declared in [Content_Types].xml"
+                        )
+
+                except Exception:
+                    continue  
+
+            for file_path in all_files:
+                if file_path.suffix.lower() in {".xml", ".rels"}:
+                    continue
+                if file_path.name == "[Content_Types].xml":
+                    continue
+                if "_rels" in file_path.parts or "docProps" in file_path.parts:
+                    continue
+
+                extension = file_path.suffix.lstrip(".").lower()
+                if extension and extension not in declared_extensions:
+                    if extension in media_extensions:
+                        relative_path = file_path.relative_to(self.unpacked_dir)
+                        errors.append(
+                            f'  {relative_path}: File with extension \'{extension}\' not declared in [Content_Types].xml - should add: <Default Extension="{extension}" ContentType="{media_extensions[extension]}"/>'
+                        )
+
+        except Exception as e:
+            errors.append(f"  Error parsing [Content_Types].xml: {e}")
+
+        if errors:
+            print(f"FAILED - Found {len(errors)} content type declaration errors:")
+            for error in errors:
+                print(error)
+            return False
+        else:
+            if self.verbose:
+                print(
+                    "PASSED - All content files are properly declared in [Content_Types].xml"
+                )
+            return True
+
+    def validate_file_against_xsd(self, xml_file, verbose=False):
+        xml_file = Path(xml_file).resolve()
+        unpacked_dir = self.unpacked_dir.resolve()
+
+        is_valid, current_errors = self._validate_single_file_xsd(
+            xml_file, unpacked_dir
+        )
+
+        if is_valid is None:
+            return None, set()  
+        elif is_valid:
+            return True, set()  
+
+        original_errors = self._get_original_file_errors(xml_file)
+
+        assert current_errors is not None
+        new_errors = current_errors - original_errors
+
+        new_errors = {
+            e for e in new_errors
+            if not any(pattern in e for pattern in self.IGNORED_VALIDATION_ERRORS)
+        }
+
+        if new_errors:
+            if verbose:
+                relative_path = xml_file.relative_to(unpacked_dir)
+                print(f"FAILED - {relative_path}: {len(new_errors)} new error(s)")
+                for error in list(new_errors)[:3]:
+                    truncated = error[:250] + "..." if len(error) > 250 else error
+                    print(f"  - {truncated}")
+            return False, new_errors
+        else:
+            if verbose:
+                print(
+                    f"PASSED - No new errors (original had {len(current_errors)} errors)"
+                )
+            return True, set()
+
+    def validate_against_xsd(self):
+        new_errors = []
+        original_error_count = 0
+        valid_count = 0
+        skipped_count = 0
+
+        for xml_file in self.xml_files:
+            relative_path = str(xml_file.relative_to(self.unpacked_dir))
+            is_valid, new_file_errors = self.validate_file_against_xsd(
+                xml_file, verbose=False
+            )
+
+            if is_valid is None:
+                skipped_count += 1
+                continue
+            elif is_valid and not new_file_errors:
+                valid_count += 1
+                continue
+            elif is_valid:
+                original_error_count += 1
+                valid_count += 1
+                continue
+
+            new_errors.append(f"  {relative_path}: {len(new_file_errors)} new error(s)")
+            for error in list(new_file_errors)[:3]:  
+                new_errors.append(
+                    f"    - {error[:250]}..." if len(error) > 250 else f"    - {error}"
+                )
+
+        if self.verbose:
+            print(f"Validated {len(self.xml_files)} files:")
+            print(f"  - Valid: {valid_count}")
+            print(f"  - Skipped (no schema): {skipped_count}")
+            if original_error_count:
+                print(f"  - With original errors (ignored): {original_error_count}")
+            print(
+                f"  - With NEW errors: {len(new_errors) > 0 and len([e for e in new_errors if not e.startswith('    ')]) or 0}"
+            )
+
+        if new_errors:
+            print("\nFAILED - Found NEW validation errors:")
+            for error in new_errors:
+                print(error)
+            return False
+        else:
+            if self.verbose:
+                print("\nPASSED - No new XSD validation errors introduced")
+            return True
+
+    def _get_schema_path(self, xml_file):
+        if xml_file.name in self.SCHEMA_MAPPINGS:
+            return self.schemas_dir / self.SCHEMA_MAPPINGS[xml_file.name]
+
+        if xml_file.suffix == ".rels":
+            return self.schemas_dir / self.SCHEMA_MAPPINGS[".rels"]
+
+        if "charts/" in str(xml_file) and xml_file.name.startswith("chart"):
+            return self.schemas_dir / self.SCHEMA_MAPPINGS["chart"]
+
+        if "theme/" in str(xml_file) and xml_file.name.startswith("theme"):
+            return self.schemas_dir / self.SCHEMA_MAPPINGS["theme"]
+
+        if xml_file.parent.name in self.MAIN_CONTENT_FOLDERS:
+            return self.schemas_dir / self.SCHEMA_MAPPINGS[xml_file.parent.name]
+
+        return None
+
+    def _clean_ignorable_namespaces(self, xml_doc):
+        xml_string = lxml.etree.tostring(xml_doc, encoding="unicode")
+        xml_copy = lxml.etree.fromstring(xml_string)
+
+        for elem in xml_copy.iter():
+            attrs_to_remove = []
+
+            for attr in elem.attrib:
+                if "{" in attr:
+                    ns = attr.split("}")[0][1:]
+                    if ns not in self.OOXML_NAMESPACES:
+                        attrs_to_remove.append(attr)
+
+            for attr in attrs_to_remove:
+                del elem.attrib[attr]
+
+        self._remove_ignorable_elements(xml_copy)
+
+        return lxml.etree.ElementTree(xml_copy)
+
+    def _remove_ignorable_elements(self, root):
+        elements_to_remove = []
+
+        for elem in list(root):
+            if not hasattr(elem, "tag") or callable(elem.tag):
+                continue
+
+            tag_str = str(elem.tag)
+            if tag_str.startswith("{"):
+                ns = tag_str.split("}")[0][1:]
+                if ns not in self.OOXML_NAMESPACES:
+                    elements_to_remove.append(elem)
+                    continue
+
+            self._remove_ignorable_elements(elem)
+
+        for elem in elements_to_remove:
+            root.remove(elem)
+
+    def _preprocess_for_mc_ignorable(self, xml_doc):
+        root = xml_doc.getroot()
+
+        if f"{{{self.MC_NAMESPACE}}}Ignorable" in root.attrib:
+            del root.attrib[f"{{{self.MC_NAMESPACE}}}Ignorable"]
+
+        return xml_doc
+
+    def _validate_single_file_xsd(self, xml_file, base_path):
+        schema_path = self._get_schema_path(xml_file)
+        if not schema_path:
+            return None, None  
+
+        try:
+            with open(schema_path, "rb") as xsd_file:
+                parser = lxml.etree.XMLParser()
+                xsd_doc = lxml.etree.parse(
+                    xsd_file, parser=parser, base_url=str(schema_path)
+                )
+                schema = lxml.etree.XMLSchema(xsd_doc)
+
+            with open(xml_file, "r") as f:
+                xml_doc = lxml.etree.parse(f)
+
+            xml_doc, _ = self._remove_template_tags_from_text_nodes(xml_doc)
+            xml_doc = self._preprocess_for_mc_ignorable(xml_doc)
+
+            relative_path = xml_file.relative_to(base_path)
+            if (
+                relative_path.parts
+                and relative_path.parts[0] in self.MAIN_CONTENT_FOLDERS
+            ):
+                xml_doc = self._clean_ignorable_namespaces(xml_doc)
+
+            if schema.validate(xml_doc):
+                return True, set()
+            else:
+                errors = set()
+                for error in schema.error_log:
+                    errors.add(error.message)
+                return False, errors
+
+        except Exception as e:
+            return False, {str(e)}
+
+    def _get_original_file_errors(self, xml_file):
+        if self.original_file is None:
+            return set()
+
+        import tempfile
+        import zipfile
+
+        xml_file = Path(xml_file).resolve()
+        unpacked_dir = self.unpacked_dir.resolve()
+        relative_path = xml_file.relative_to(unpacked_dir)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+
+            with zipfile.ZipFile(self.original_file, "r") as zip_ref:
+                zip_ref.extractall(temp_path)
+
+            original_xml_file = temp_path / relative_path
+
+            if not original_xml_file.exists():
+                return set()
+
+            is_valid, errors = self._validate_single_file_xsd(
+                original_xml_file, temp_path
+            )
+            return errors if errors else set()
+
+    def _remove_template_tags_from_text_nodes(self, xml_doc):
+        warnings = []
+        template_pattern = re.compile(r"\{\{[^}]*\}\}")
+
+        xml_string = lxml.etree.tostring(xml_doc, encoding="unicode")
+        xml_copy = lxml.etree.fromstring(xml_string)
+
+        def process_text_content(text, content_type):
+            if not text:
+                return text
+            matches = list(template_pattern.finditer(text))
+            if matches:
+                for match in matches:
+                    warnings.append(
+                        f"Found template tag in {content_type}: {match.group()}"
+                    )
+                return template_pattern.sub("", text)
+            return text
+
+        for elem in xml_copy.iter():
+            if not hasattr(elem, "tag") or callable(elem.tag):
+                continue
+            tag_str = str(elem.tag)
+            if tag_str.endswith("}t") or tag_str == "t":
+                continue
+
+            elem.text = process_text_content(elem.text, "text content")
+            elem.tail = process_text_content(elem.tail, "tail content")
+
+        return lxml.etree.ElementTree(xml_copy), warnings
+
+
+if __name__ == "__main__":
+    raise RuntimeError("This module should not be run directly.")

--- a/skills/xlsx/scripts/office/validators/docx.py
+++ b/skills/xlsx/scripts/office/validators/docx.py
@@ -1,0 +1,446 @@
+"""
+Validator for Word document XML files against XSD schemas.
+"""
+
+import random
+import re
+import tempfile
+import zipfile
+
+import defusedxml.minidom
+import lxml.etree
+
+from .base import BaseSchemaValidator
+
+
+class DOCXSchemaValidator(BaseSchemaValidator):
+
+    WORD_2006_NAMESPACE = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+    W14_NAMESPACE = "http://schemas.microsoft.com/office/word/2010/wordml"
+    W16CID_NAMESPACE = "http://schemas.microsoft.com/office/word/2016/wordml/cid"
+
+    ELEMENT_RELATIONSHIP_TYPES = {}
+
+    def validate(self):
+        if not self.validate_xml():
+            return False
+
+        all_valid = True
+        if not self.validate_namespaces():
+            all_valid = False
+
+        if not self.validate_unique_ids():
+            all_valid = False
+
+        if not self.validate_file_references():
+            all_valid = False
+
+        if not self.validate_content_types():
+            all_valid = False
+
+        if not self.validate_against_xsd():
+            all_valid = False
+
+        if not self.validate_whitespace_preservation():
+            all_valid = False
+
+        if not self.validate_deletions():
+            all_valid = False
+
+        if not self.validate_insertions():
+            all_valid = False
+
+        if not self.validate_all_relationship_ids():
+            all_valid = False
+
+        if not self.validate_id_constraints():
+            all_valid = False
+
+        if not self.validate_comment_markers():
+            all_valid = False
+
+        self.compare_paragraph_counts()
+
+        return all_valid
+
+    def validate_whitespace_preservation(self):
+        errors = []
+
+        for xml_file in self.xml_files:
+            if xml_file.name != "document.xml":
+                continue
+
+            try:
+                root = lxml.etree.parse(str(xml_file)).getroot()
+
+                for elem in root.iter(f"{{{self.WORD_2006_NAMESPACE}}}t"):
+                    if elem.text:
+                        text = elem.text
+                        if re.search(r"^[ \t\n\r]", text) or re.search(
+                            r"[ \t\n\r]$", text
+                        ):
+                            xml_space_attr = f"{{{self.XML_NAMESPACE}}}space"
+                            if (
+                                xml_space_attr not in elem.attrib
+                                or elem.attrib[xml_space_attr] != "preserve"
+                            ):
+                                text_preview = (
+                                    repr(text)[:50] + "..."
+                                    if len(repr(text)) > 50
+                                    else repr(text)
+                                )
+                                errors.append(
+                                    f"  {xml_file.relative_to(self.unpacked_dir)}: "
+                                    f"Line {elem.sourceline}: w:t element with whitespace missing xml:space='preserve': {text_preview}"
+                                )
+
+            except (lxml.etree.XMLSyntaxError, Exception) as e:
+                errors.append(
+                    f"  {xml_file.relative_to(self.unpacked_dir)}: Error: {e}"
+                )
+
+        if errors:
+            print(f"FAILED - Found {len(errors)} whitespace preservation violations:")
+            for error in errors:
+                print(error)
+            return False
+        else:
+            if self.verbose:
+                print("PASSED - All whitespace is properly preserved")
+            return True
+
+    def validate_deletions(self):
+        errors = []
+
+        for xml_file in self.xml_files:
+            if xml_file.name != "document.xml":
+                continue
+
+            try:
+                root = lxml.etree.parse(str(xml_file)).getroot()
+                namespaces = {"w": self.WORD_2006_NAMESPACE}
+
+                for t_elem in root.xpath(".//w:del//w:t", namespaces=namespaces):
+                    if t_elem.text:
+                        text_preview = (
+                            repr(t_elem.text)[:50] + "..."
+                            if len(repr(t_elem.text)) > 50
+                            else repr(t_elem.text)
+                        )
+                        errors.append(
+                            f"  {xml_file.relative_to(self.unpacked_dir)}: "
+                            f"Line {t_elem.sourceline}: <w:t> found within <w:del>: {text_preview}"
+                        )
+
+                for instr_elem in root.xpath(
+                    ".//w:del//w:instrText", namespaces=namespaces
+                ):
+                    text_preview = (
+                        repr(instr_elem.text or "")[:50] + "..."
+                        if len(repr(instr_elem.text or "")) > 50
+                        else repr(instr_elem.text or "")
+                    )
+                    errors.append(
+                        f"  {xml_file.relative_to(self.unpacked_dir)}: "
+                        f"Line {instr_elem.sourceline}: <w:instrText> found within <w:del> (use <w:delInstrText>): {text_preview}"
+                    )
+
+            except (lxml.etree.XMLSyntaxError, Exception) as e:
+                errors.append(
+                    f"  {xml_file.relative_to(self.unpacked_dir)}: Error: {e}"
+                )
+
+        if errors:
+            print(f"FAILED - Found {len(errors)} deletion validation violations:")
+            for error in errors:
+                print(error)
+            return False
+        else:
+            if self.verbose:
+                print("PASSED - No w:t elements found within w:del elements")
+            return True
+
+    def count_paragraphs_in_unpacked(self):
+        count = 0
+
+        for xml_file in self.xml_files:
+            if xml_file.name != "document.xml":
+                continue
+
+            try:
+                root = lxml.etree.parse(str(xml_file)).getroot()
+                paragraphs = root.findall(f".//{{{self.WORD_2006_NAMESPACE}}}p")
+                count = len(paragraphs)
+            except Exception as e:
+                print(f"Error counting paragraphs in unpacked document: {e}")
+
+        return count
+
+    def count_paragraphs_in_original(self):
+        original = self.original_file
+        if original is None:
+            return 0
+
+        count = 0
+
+        try:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                with zipfile.ZipFile(original, "r") as zip_ref:
+                    zip_ref.extractall(temp_dir)
+
+                doc_xml_path = temp_dir + "/word/document.xml"
+                root = lxml.etree.parse(doc_xml_path).getroot()
+
+                paragraphs = root.findall(f".//{{{self.WORD_2006_NAMESPACE}}}p")
+                count = len(paragraphs)
+
+        except Exception as e:
+            print(f"Error counting paragraphs in original document: {e}")
+
+        return count
+
+    def validate_insertions(self):
+        errors = []
+
+        for xml_file in self.xml_files:
+            if xml_file.name != "document.xml":
+                continue
+
+            try:
+                root = lxml.etree.parse(str(xml_file)).getroot()
+                namespaces = {"w": self.WORD_2006_NAMESPACE}
+
+                invalid_elements = root.xpath(
+                    ".//w:ins//w:delText[not(ancestor::w:del)]", namespaces=namespaces
+                )
+
+                for elem in invalid_elements:
+                    text_preview = (
+                        repr(elem.text or "")[:50] + "..."
+                        if len(repr(elem.text or "")) > 50
+                        else repr(elem.text or "")
+                    )
+                    errors.append(
+                        f"  {xml_file.relative_to(self.unpacked_dir)}: "
+                        f"Line {elem.sourceline}: <w:delText> within <w:ins>: {text_preview}"
+                    )
+
+            except (lxml.etree.XMLSyntaxError, Exception) as e:
+                errors.append(
+                    f"  {xml_file.relative_to(self.unpacked_dir)}: Error: {e}"
+                )
+
+        if errors:
+            print(f"FAILED - Found {len(errors)} insertion validation violations:")
+            for error in errors:
+                print(error)
+            return False
+        else:
+            if self.verbose:
+                print("PASSED - No w:delText elements within w:ins elements")
+            return True
+
+    def compare_paragraph_counts(self):
+        original_count = self.count_paragraphs_in_original()
+        new_count = self.count_paragraphs_in_unpacked()
+
+        diff = new_count - original_count
+        diff_str = f"+{diff}" if diff > 0 else str(diff)
+        print(f"\nParagraphs: {original_count} → {new_count} ({diff_str})")
+
+    def _parse_id_value(self, val: str, base: int = 16) -> int:
+        return int(val, base)
+
+    def validate_id_constraints(self):
+        errors = []
+        para_id_attr = f"{{{self.W14_NAMESPACE}}}paraId"
+        durable_id_attr = f"{{{self.W16CID_NAMESPACE}}}durableId"
+
+        for xml_file in self.xml_files:
+            try:
+                for elem in lxml.etree.parse(str(xml_file)).iter():
+                    if val := elem.get(para_id_attr):
+                        if self._parse_id_value(val, base=16) >= 0x80000000:
+                            errors.append(
+                                f"  {xml_file.name}:{elem.sourceline}: paraId={val} >= 0x80000000"
+                            )
+
+                    if val := elem.get(durable_id_attr):
+                        if xml_file.name == "numbering.xml":
+                            try:
+                                if self._parse_id_value(val, base=10) >= 0x7FFFFFFF:
+                                    errors.append(
+                                        f"  {xml_file.name}:{elem.sourceline}: "
+                                        f"durableId={val} >= 0x7FFFFFFF"
+                                    )
+                            except ValueError:
+                                errors.append(
+                                    f"  {xml_file.name}:{elem.sourceline}: "
+                                    f"durableId={val} must be decimal in numbering.xml"
+                                )
+                        else:
+                            if self._parse_id_value(val, base=16) >= 0x7FFFFFFF:
+                                errors.append(
+                                    f"  {xml_file.name}:{elem.sourceline}: "
+                                    f"durableId={val} >= 0x7FFFFFFF"
+                                )
+            except Exception:
+                pass
+
+        if errors:
+            print(f"FAILED - {len(errors)} ID constraint violations:")
+            for e in errors:
+                print(e)
+        elif self.verbose:
+            print("PASSED - All paraId/durableId values within constraints")
+        return not errors
+
+    def validate_comment_markers(self):
+        errors = []
+
+        document_xml = None
+        comments_xml = None
+        for xml_file in self.xml_files:
+            if xml_file.name == "document.xml" and "word" in str(xml_file):
+                document_xml = xml_file
+            elif xml_file.name == "comments.xml":
+                comments_xml = xml_file
+
+        if not document_xml:
+            if self.verbose:
+                print("PASSED - No document.xml found (skipping comment validation)")
+            return True
+
+        try:
+            doc_root = lxml.etree.parse(str(document_xml)).getroot()
+            namespaces = {"w": self.WORD_2006_NAMESPACE}
+
+            range_starts = {
+                elem.get(f"{{{self.WORD_2006_NAMESPACE}}}id")
+                for elem in doc_root.xpath(
+                    ".//w:commentRangeStart", namespaces=namespaces
+                )
+            }
+            range_ends = {
+                elem.get(f"{{{self.WORD_2006_NAMESPACE}}}id")
+                for elem in doc_root.xpath(
+                    ".//w:commentRangeEnd", namespaces=namespaces
+                )
+            }
+            references = {
+                elem.get(f"{{{self.WORD_2006_NAMESPACE}}}id")
+                for elem in doc_root.xpath(
+                    ".//w:commentReference", namespaces=namespaces
+                )
+            }
+
+            orphaned_ends = range_ends - range_starts
+            for comment_id in sorted(
+                orphaned_ends, key=lambda x: int(x) if x and x.isdigit() else 0
+            ):
+                errors.append(
+                    f'  document.xml: commentRangeEnd id="{comment_id}" has no matching commentRangeStart'
+                )
+
+            orphaned_starts = range_starts - range_ends
+            for comment_id in sorted(
+                orphaned_starts, key=lambda x: int(x) if x and x.isdigit() else 0
+            ):
+                errors.append(
+                    f'  document.xml: commentRangeStart id="{comment_id}" has no matching commentRangeEnd'
+                )
+
+            comment_ids = set()
+            if comments_xml and comments_xml.exists():
+                comments_root = lxml.etree.parse(str(comments_xml)).getroot()
+                comment_ids = {
+                    elem.get(f"{{{self.WORD_2006_NAMESPACE}}}id")
+                    for elem in comments_root.xpath(
+                        ".//w:comment", namespaces=namespaces
+                    )
+                }
+
+                marker_ids = range_starts | range_ends | references
+                invalid_refs = marker_ids - comment_ids
+                for comment_id in sorted(
+                    invalid_refs, key=lambda x: int(x) if x and x.isdigit() else 0
+                ):
+                    if comment_id:  
+                        errors.append(
+                            f'  document.xml: marker id="{comment_id}" references non-existent comment'
+                        )
+
+        except (lxml.etree.XMLSyntaxError, Exception) as e:
+            errors.append(f"  Error parsing XML: {e}")
+
+        if errors:
+            print(f"FAILED - {len(errors)} comment marker violations:")
+            for error in errors:
+                print(error)
+            return False
+        else:
+            if self.verbose:
+                print("PASSED - All comment markers properly paired")
+            return True
+
+    def repair(self) -> int:
+        repairs = super().repair()
+        repairs += self.repair_durableId()
+        return repairs
+
+    def repair_durableId(self) -> int:
+        repairs = 0
+
+        for xml_file in self.xml_files:
+            try:
+                content = xml_file.read_text(encoding="utf-8")
+                dom = defusedxml.minidom.parseString(content)
+                modified = False
+
+                for elem in dom.getElementsByTagName("*"):
+                    if not elem.hasAttribute("w16cid:durableId"):
+                        continue
+
+                    durable_id = elem.getAttribute("w16cid:durableId")
+                    needs_repair = False
+
+                    if xml_file.name == "numbering.xml":
+                        try:
+                            needs_repair = (
+                                self._parse_id_value(durable_id, base=10) >= 0x7FFFFFFF
+                            )
+                        except ValueError:
+                            needs_repair = True
+                    else:
+                        try:
+                            needs_repair = (
+                                self._parse_id_value(durable_id, base=16) >= 0x7FFFFFFF
+                            )
+                        except ValueError:
+                            needs_repair = True
+
+                    if needs_repair:
+                        value = random.randint(1, 0x7FFFFFFE)
+                        if xml_file.name == "numbering.xml":
+                            new_id = str(value)  
+                        else:
+                            new_id = f"{value:08X}"  
+
+                        elem.setAttribute("w16cid:durableId", new_id)
+                        print(
+                            f"  Repaired: {xml_file.name}: durableId {durable_id} → {new_id}"
+                        )
+                        repairs += 1
+                        modified = True
+
+                if modified:
+                    xml_file.write_bytes(dom.toxml(encoding="UTF-8"))
+
+            except Exception:
+                pass
+
+        return repairs
+
+
+if __name__ == "__main__":
+    raise RuntimeError("This module should not be run directly.")

--- a/skills/xlsx/scripts/office/validators/pptx.py
+++ b/skills/xlsx/scripts/office/validators/pptx.py
@@ -1,0 +1,275 @@
+"""
+Validator for PowerPoint presentation XML files against XSD schemas.
+"""
+
+import re
+
+from .base import BaseSchemaValidator
+
+
+class PPTXSchemaValidator(BaseSchemaValidator):
+
+    PRESENTATIONML_NAMESPACE = (
+        "http://schemas.openxmlformats.org/presentationml/2006/main"
+    )
+
+    ELEMENT_RELATIONSHIP_TYPES = {
+        "sldid": "slide",
+        "sldmasterid": "slidemaster",
+        "notesmasterid": "notesmaster",
+        "sldlayoutid": "slidelayout",
+        "themeid": "theme",
+        "tablestyleid": "tablestyles",
+    }
+
+    def validate(self):
+        if not self.validate_xml():
+            return False
+
+        all_valid = True
+        if not self.validate_namespaces():
+            all_valid = False
+
+        if not self.validate_unique_ids():
+            all_valid = False
+
+        if not self.validate_uuid_ids():
+            all_valid = False
+
+        if not self.validate_file_references():
+            all_valid = False
+
+        if not self.validate_slide_layout_ids():
+            all_valid = False
+
+        if not self.validate_content_types():
+            all_valid = False
+
+        if not self.validate_against_xsd():
+            all_valid = False
+
+        if not self.validate_notes_slide_references():
+            all_valid = False
+
+        if not self.validate_all_relationship_ids():
+            all_valid = False
+
+        if not self.validate_no_duplicate_slide_layouts():
+            all_valid = False
+
+        return all_valid
+
+    def validate_uuid_ids(self):
+        import lxml.etree
+
+        errors = []
+        uuid_pattern = re.compile(
+            r"^[\{\(]?[0-9A-Fa-f]{8}-?[0-9A-Fa-f]{4}-?[0-9A-Fa-f]{4}-?[0-9A-Fa-f]{4}-?[0-9A-Fa-f]{12}[\}\)]?$"
+        )
+
+        for xml_file in self.xml_files:
+            try:
+                root = lxml.etree.parse(str(xml_file)).getroot()
+
+                for elem in root.iter():
+                    for attr, value in elem.attrib.items():
+                        attr_name = attr.split("}")[-1].lower()
+                        if attr_name == "id" or attr_name.endswith("id"):
+                            if self._looks_like_uuid(value):
+                                if not uuid_pattern.match(value):
+                                    errors.append(
+                                        f"  {xml_file.relative_to(self.unpacked_dir)}: "
+                                        f"Line {elem.sourceline}: ID '{value}' appears to be a UUID but contains invalid hex characters"
+                                    )
+
+            except (lxml.etree.XMLSyntaxError, Exception) as e:
+                errors.append(
+                    f"  {xml_file.relative_to(self.unpacked_dir)}: Error: {e}"
+                )
+
+        if errors:
+            print(f"FAILED - Found {len(errors)} UUID ID validation errors:")
+            for error in errors:
+                print(error)
+            return False
+        else:
+            if self.verbose:
+                print("PASSED - All UUID-like IDs contain valid hex values")
+            return True
+
+    def _looks_like_uuid(self, value):
+        clean_value = value.strip("{}()").replace("-", "")
+        return len(clean_value) == 32 and all(c.isalnum() for c in clean_value)
+
+    def validate_slide_layout_ids(self):
+        import lxml.etree
+
+        errors = []
+
+        slide_masters = list(self.unpacked_dir.glob("ppt/slideMasters/*.xml"))
+
+        if not slide_masters:
+            if self.verbose:
+                print("PASSED - No slide masters found")
+            return True
+
+        for slide_master in slide_masters:
+            try:
+                root = lxml.etree.parse(str(slide_master)).getroot()
+
+                rels_file = slide_master.parent / "_rels" / f"{slide_master.name}.rels"
+
+                if not rels_file.exists():
+                    errors.append(
+                        f"  {slide_master.relative_to(self.unpacked_dir)}: "
+                        f"Missing relationships file: {rels_file.relative_to(self.unpacked_dir)}"
+                    )
+                    continue
+
+                rels_root = lxml.etree.parse(str(rels_file)).getroot()
+
+                valid_layout_rids = set()
+                for rel in rels_root.findall(
+                    f".//{{{self.PACKAGE_RELATIONSHIPS_NAMESPACE}}}Relationship"
+                ):
+                    rel_type = rel.get("Type", "")
+                    if "slideLayout" in rel_type:
+                        valid_layout_rids.add(rel.get("Id"))
+
+                for sld_layout_id in root.findall(
+                    f".//{{{self.PRESENTATIONML_NAMESPACE}}}sldLayoutId"
+                ):
+                    r_id = sld_layout_id.get(
+                        f"{{{self.OFFICE_RELATIONSHIPS_NAMESPACE}}}id"
+                    )
+                    layout_id = sld_layout_id.get("id")
+
+                    if r_id and r_id not in valid_layout_rids:
+                        errors.append(
+                            f"  {slide_master.relative_to(self.unpacked_dir)}: "
+                            f"Line {sld_layout_id.sourceline}: sldLayoutId with id='{layout_id}' "
+                            f"references r:id='{r_id}' which is not found in slide layout relationships"
+                        )
+
+            except (lxml.etree.XMLSyntaxError, Exception) as e:
+                errors.append(
+                    f"  {slide_master.relative_to(self.unpacked_dir)}: Error: {e}"
+                )
+
+        if errors:
+            print(f"FAILED - Found {len(errors)} slide layout ID validation errors:")
+            for error in errors:
+                print(error)
+            print(
+                "Remove invalid references or add missing slide layouts to the relationships file."
+            )
+            return False
+        else:
+            if self.verbose:
+                print("PASSED - All slide layout IDs reference valid slide layouts")
+            return True
+
+    def validate_no_duplicate_slide_layouts(self):
+        import lxml.etree
+
+        errors = []
+        slide_rels_files = list(self.unpacked_dir.glob("ppt/slides/_rels/*.xml.rels"))
+
+        for rels_file in slide_rels_files:
+            try:
+                root = lxml.etree.parse(str(rels_file)).getroot()
+
+                layout_rels = [
+                    rel
+                    for rel in root.findall(
+                        f".//{{{self.PACKAGE_RELATIONSHIPS_NAMESPACE}}}Relationship"
+                    )
+                    if "slideLayout" in rel.get("Type", "")
+                ]
+
+                if len(layout_rels) > 1:
+                    errors.append(
+                        f"  {rels_file.relative_to(self.unpacked_dir)}: has {len(layout_rels)} slideLayout references"
+                    )
+
+            except Exception as e:
+                errors.append(
+                    f"  {rels_file.relative_to(self.unpacked_dir)}: Error: {e}"
+                )
+
+        if errors:
+            print("FAILED - Found slides with duplicate slideLayout references:")
+            for error in errors:
+                print(error)
+            return False
+        else:
+            if self.verbose:
+                print("PASSED - All slides have exactly one slideLayout reference")
+            return True
+
+    def validate_notes_slide_references(self):
+        import lxml.etree
+
+        errors = []
+        notes_slide_references = {}  
+
+        slide_rels_files = list(self.unpacked_dir.glob("ppt/slides/_rels/*.xml.rels"))
+
+        if not slide_rels_files:
+            if self.verbose:
+                print("PASSED - No slide relationship files found")
+            return True
+
+        for rels_file in slide_rels_files:
+            try:
+                root = lxml.etree.parse(str(rels_file)).getroot()
+
+                for rel in root.findall(
+                    f".//{{{self.PACKAGE_RELATIONSHIPS_NAMESPACE}}}Relationship"
+                ):
+                    rel_type = rel.get("Type", "")
+                    if "notesSlide" in rel_type:
+                        target = rel.get("Target", "")
+                        if target:
+                            normalized_target = target.replace("../", "")
+
+                            slide_name = rels_file.stem.replace(
+                                ".xml", ""
+                            )  
+
+                            if normalized_target not in notes_slide_references:
+                                notes_slide_references[normalized_target] = []
+                            notes_slide_references[normalized_target].append(
+                                (slide_name, rels_file)
+                            )
+
+            except (lxml.etree.XMLSyntaxError, Exception) as e:
+                errors.append(
+                    f"  {rels_file.relative_to(self.unpacked_dir)}: Error: {e}"
+                )
+
+        for target, references in notes_slide_references.items():
+            if len(references) > 1:
+                slide_names = [ref[0] for ref in references]
+                errors.append(
+                    f"  Notes slide '{target}' is referenced by multiple slides: {', '.join(slide_names)}"
+                )
+                for slide_name, rels_file in references:
+                    errors.append(f"    - {rels_file.relative_to(self.unpacked_dir)}")
+
+        if errors:
+            print(
+                f"FAILED - Found {len([e for e in errors if not e.startswith('    ')])} notes slide reference validation errors:"
+            )
+            for error in errors:
+                print(error)
+            print("Each slide may optionally have its own slide file.")
+            return False
+        else:
+            if self.verbose:
+                print("PASSED - All notes slide references are unique")
+            return True
+
+
+if __name__ == "__main__":
+    raise RuntimeError("This module should not be run directly.")

--- a/skills/xlsx/scripts/office/validators/redlining.py
+++ b/skills/xlsx/scripts/office/validators/redlining.py
@@ -1,0 +1,247 @@
+"""
+Validator for tracked changes in Word documents.
+"""
+
+import subprocess
+import tempfile
+import zipfile
+from pathlib import Path
+
+
+class RedliningValidator:
+
+    def __init__(self, unpacked_dir, original_docx, verbose=False, author="Claude"):
+        self.unpacked_dir = Path(unpacked_dir)
+        self.original_docx = Path(original_docx)
+        self.verbose = verbose
+        self.author = author
+        self.namespaces = {
+            "w": "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+        }
+
+    def repair(self) -> int:
+        return 0
+
+    def validate(self):
+        modified_file = self.unpacked_dir / "word" / "document.xml"
+        if not modified_file.exists():
+            print(f"FAILED - Modified document.xml not found at {modified_file}")
+            return False
+
+        try:
+            import xml.etree.ElementTree as ET
+
+            tree = ET.parse(modified_file)
+            root = tree.getroot()
+
+            del_elements = root.findall(".//w:del", self.namespaces)
+            ins_elements = root.findall(".//w:ins", self.namespaces)
+
+            author_del_elements = [
+                elem
+                for elem in del_elements
+                if elem.get(f"{{{self.namespaces['w']}}}author") == self.author
+            ]
+            author_ins_elements = [
+                elem
+                for elem in ins_elements
+                if elem.get(f"{{{self.namespaces['w']}}}author") == self.author
+            ]
+
+            if not author_del_elements and not author_ins_elements:
+                if self.verbose:
+                    print(f"PASSED - No tracked changes by {self.author} found.")
+                return True
+
+        except Exception:
+            pass
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+
+            try:
+                with zipfile.ZipFile(self.original_docx, "r") as zip_ref:
+                    zip_ref.extractall(temp_path)
+            except Exception as e:
+                print(f"FAILED - Error unpacking original docx: {e}")
+                return False
+
+            original_file = temp_path / "word" / "document.xml"
+            if not original_file.exists():
+                print(
+                    f"FAILED - Original document.xml not found in {self.original_docx}"
+                )
+                return False
+
+            try:
+                import xml.etree.ElementTree as ET
+
+                modified_tree = ET.parse(modified_file)
+                modified_root = modified_tree.getroot()
+                original_tree = ET.parse(original_file)
+                original_root = original_tree.getroot()
+            except ET.ParseError as e:
+                print(f"FAILED - Error parsing XML files: {e}")
+                return False
+
+            self._remove_author_tracked_changes(original_root)
+            self._remove_author_tracked_changes(modified_root)
+
+            modified_text = self._extract_text_content(modified_root)
+            original_text = self._extract_text_content(original_root)
+
+            if modified_text != original_text:
+                error_message = self._generate_detailed_diff(
+                    original_text, modified_text
+                )
+                print(error_message)
+                return False
+
+            if self.verbose:
+                print(f"PASSED - All changes by {self.author} are properly tracked")
+            return True
+
+    def _generate_detailed_diff(self, original_text, modified_text):
+        error_parts = [
+            f"FAILED - Document text doesn't match after removing {self.author}'s tracked changes",
+            "",
+            "Likely causes:",
+            "  1. Modified text inside another author's <w:ins> or <w:del> tags",
+            "  2. Made edits without proper tracked changes",
+            "  3. Didn't nest <w:del> inside <w:ins> when deleting another's insertion",
+            "",
+            "For pre-redlined documents, use correct patterns:",
+            "  - To reject another's INSERTION: Nest <w:del> inside their <w:ins>",
+            "  - To restore another's DELETION: Add new <w:ins> AFTER their <w:del>",
+            "",
+        ]
+
+        git_diff = self._get_git_word_diff(original_text, modified_text)
+        if git_diff:
+            error_parts.extend(["Differences:", "============", git_diff])
+        else:
+            error_parts.append("Unable to generate word diff (git not available)")
+
+        return "\n".join(error_parts)
+
+    def _get_git_word_diff(self, original_text, modified_text):
+        try:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                temp_path = Path(temp_dir)
+
+                original_file = temp_path / "original.txt"
+                modified_file = temp_path / "modified.txt"
+
+                original_file.write_text(original_text, encoding="utf-8")
+                modified_file.write_text(modified_text, encoding="utf-8")
+
+                result = subprocess.run(
+                    [
+                        "git",
+                        "diff",
+                        "--word-diff=plain",
+                        "--word-diff-regex=.",  
+                        "-U0",  
+                        "--no-index",
+                        str(original_file),
+                        str(modified_file),
+                    ],
+                    capture_output=True,
+                    text=True,
+                )
+
+                if result.stdout.strip():
+                    lines = result.stdout.split("\n")
+                    content_lines = []
+                    in_content = False
+                    for line in lines:
+                        if line.startswith("@@"):
+                            in_content = True
+                            continue
+                        if in_content and line.strip():
+                            content_lines.append(line)
+
+                    if content_lines:
+                        return "\n".join(content_lines)
+
+                result = subprocess.run(
+                    [
+                        "git",
+                        "diff",
+                        "--word-diff=plain",
+                        "-U0",  
+                        "--no-index",
+                        str(original_file),
+                        str(modified_file),
+                    ],
+                    capture_output=True,
+                    text=True,
+                )
+
+                if result.stdout.strip():
+                    lines = result.stdout.split("\n")
+                    content_lines = []
+                    in_content = False
+                    for line in lines:
+                        if line.startswith("@@"):
+                            in_content = True
+                            continue
+                        if in_content and line.strip():
+                            content_lines.append(line)
+                    return "\n".join(content_lines)
+
+        except (subprocess.CalledProcessError, FileNotFoundError, Exception):
+            pass
+
+        return None
+
+    def _remove_author_tracked_changes(self, root):
+        ins_tag = f"{{{self.namespaces['w']}}}ins"
+        del_tag = f"{{{self.namespaces['w']}}}del"
+        author_attr = f"{{{self.namespaces['w']}}}author"
+
+        for parent in root.iter():
+            to_remove = []
+            for child in parent:
+                if child.tag == ins_tag and child.get(author_attr) == self.author:
+                    to_remove.append(child)
+            for elem in to_remove:
+                parent.remove(elem)
+
+        deltext_tag = f"{{{self.namespaces['w']}}}delText"
+        t_tag = f"{{{self.namespaces['w']}}}t"
+
+        for parent in root.iter():
+            to_process = []
+            for child in parent:
+                if child.tag == del_tag and child.get(author_attr) == self.author:
+                    to_process.append((child, list(parent).index(child)))
+
+            for del_elem, del_index in reversed(to_process):
+                for elem in del_elem.iter():
+                    if elem.tag == deltext_tag:
+                        elem.tag = t_tag
+
+                for child in reversed(list(del_elem)):
+                    parent.insert(del_index, child)
+                parent.remove(del_elem)
+
+    def _extract_text_content(self, root):
+        p_tag = f"{{{self.namespaces['w']}}}p"
+        t_tag = f"{{{self.namespaces['w']}}}t"
+
+        paragraphs = []
+        for p_elem in root.findall(f".//{p_tag}"):
+            text_parts = []
+            for t_elem in p_elem.findall(f".//{t_tag}"):
+                if t_elem.text:
+                    text_parts.append(t_elem.text)
+            paragraph_text = "".join(text_parts)
+            if paragraph_text:
+                paragraphs.append(paragraph_text)
+
+        return "\n".join(paragraphs)
+
+
+if __name__ == "__main__":
+    raise RuntimeError("This module should not be run directly.")

--- a/skills/xlsx/scripts/recalc.py
+++ b/skills/xlsx/scripts/recalc.py
@@ -1,0 +1,184 @@
+"""
+Excel Formula Recalculation Script
+Recalculates all formulas in an Excel file using LibreOffice
+"""
+
+import json
+import os
+import platform
+import subprocess
+import sys
+from pathlib import Path
+
+from office.soffice import get_soffice_env
+
+from openpyxl import load_workbook
+
+MACRO_DIR_MACOS = "~/Library/Application Support/LibreOffice/4/user/basic/Standard"
+MACRO_DIR_LINUX = "~/.config/libreoffice/4/user/basic/Standard"
+MACRO_FILENAME = "Module1.xba"
+
+RECALCULATE_MACRO = """<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE script:module PUBLIC "-//OpenOffice.org//DTD OfficeDocument 1.0//EN" "module.dtd">
+<script:module xmlns:script="http://openoffice.org/2000/script" script:name="Module1" script:language="StarBasic">
+    Sub RecalculateAndSave()
+      ThisComponent.calculateAll()
+      ThisComponent.store()
+      ThisComponent.close(True)
+    End Sub
+</script:module>"""
+
+
+def has_gtimeout():
+    try:
+        subprocess.run(
+            ["gtimeout", "--version"], capture_output=True, timeout=1, check=False
+        )
+        return True
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+def setup_libreoffice_macro():
+    macro_dir = os.path.expanduser(
+        MACRO_DIR_MACOS if platform.system() == "Darwin" else MACRO_DIR_LINUX
+    )
+    macro_file = os.path.join(macro_dir, MACRO_FILENAME)
+
+    if (
+        os.path.exists(macro_file)
+        and "RecalculateAndSave" in Path(macro_file).read_text()
+    ):
+        return True
+
+    if not os.path.exists(macro_dir):
+        subprocess.run(
+            ["soffice", "--headless", "--terminate_after_init"],
+            capture_output=True,
+            timeout=10,
+            env=get_soffice_env(),
+        )
+        os.makedirs(macro_dir, exist_ok=True)
+
+    try:
+        Path(macro_file).write_text(RECALCULATE_MACRO)
+        return True
+    except Exception:
+        return False
+
+
+def recalc(filename, timeout=30):
+    if not Path(filename).exists():
+        return {"error": f"File {filename} does not exist"}
+
+    abs_path = str(Path(filename).absolute())
+
+    if not setup_libreoffice_macro():
+        return {"error": "Failed to setup LibreOffice macro"}
+
+    cmd = [
+        "soffice",
+        "--headless",
+        "--norestore",
+        "vnd.sun.star.script:Standard.Module1.RecalculateAndSave?language=Basic&location=application",
+        abs_path,
+    ]
+
+    if platform.system() == "Linux":
+        cmd = ["timeout", str(timeout)] + cmd
+    elif platform.system() == "Darwin" and has_gtimeout():
+        cmd = ["gtimeout", str(timeout)] + cmd
+
+    result = subprocess.run(cmd, capture_output=True, text=True, env=get_soffice_env())
+
+    if result.returncode != 0 and result.returncode != 124:  
+        error_msg = result.stderr or "Unknown error during recalculation"
+        if "Module1" in error_msg or "RecalculateAndSave" not in error_msg:
+            return {"error": "LibreOffice macro not configured properly"}
+        return {"error": error_msg}
+
+    try:
+        wb = load_workbook(filename, data_only=True)
+
+        excel_errors = [
+            "#VALUE!",
+            "#DIV/0!",
+            "#REF!",
+            "#NAME?",
+            "#NULL!",
+            "#NUM!",
+            "#N/A",
+        ]
+        error_details = {err: [] for err in excel_errors}
+        total_errors = 0
+
+        for sheet_name in wb.sheetnames:
+            ws = wb[sheet_name]
+            for row in ws.iter_rows():
+                for cell in row:
+                    if cell.value is not None and isinstance(cell.value, str):
+                        for err in excel_errors:
+                            if err in cell.value:
+                                location = f"{sheet_name}!{cell.coordinate}"
+                                error_details[err].append(location)
+                                total_errors += 1
+                                break
+
+        wb.close()
+
+        result = {
+            "status": "success" if total_errors == 0 else "errors_found",
+            "total_errors": total_errors,
+            "error_summary": {},
+        }
+
+        for err_type, locations in error_details.items():
+            if locations:
+                result["error_summary"][err_type] = {
+                    "count": len(locations),
+                    "locations": locations[:20],  
+                }
+
+        wb_formulas = load_workbook(filename, data_only=False)
+        formula_count = 0
+        for sheet_name in wb_formulas.sheetnames:
+            ws = wb_formulas[sheet_name]
+            for row in ws.iter_rows():
+                for cell in row:
+                    if (
+                        cell.value
+                        and isinstance(cell.value, str)
+                        and cell.value.startswith("=")
+                    ):
+                        formula_count += 1
+        wb_formulas.close()
+
+        result["total_formulas"] = formula_count
+
+        return result
+
+    except Exception as e:
+        return {"error": str(e)}
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python recalc.py <excel_file> [timeout_seconds]")
+        print("\nRecalculates all formulas in an Excel file using LibreOffice")
+        print("\nReturns JSON with error details:")
+        print("  - status: 'success' or 'errors_found'")
+        print("  - total_errors: Total number of Excel errors found")
+        print("  - total_formulas: Number of formulas in the file")
+        print("  - error_summary: Breakdown by error type with locations")
+        print("    - #VALUE!, #DIV/0!, #REF!, #NAME?, #NULL!, #NUM!, #N/A")
+        sys.exit(1)
+
+    filename = sys.argv[1]
+    timeout = int(sys.argv[2]) if len(sys.argv) > 2 else 30
+
+    result = recalc(filename, timeout)
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_skills_manifest.py
+++ b/tests/test_skills_manifest.py
@@ -13,7 +13,10 @@ from pathlib import Path
 import pytest
 
 SKILLS_DIR = Path(__file__).parent.parent / "skills"
-ALL_SKILLS = sorted(SKILLS_DIR.glob("*/SKILL.md"))
+VENDORED_SKILLS = {"xlsx"}
+ALL_SKILLS = sorted(
+    p for p in SKILLS_DIR.glob("*/SKILL.md") if p.parent.name not in VENDORED_SKILLS
+)
 SKILLS_WITH_PRECONDITION = [p for p in ALL_SKILLS if p.parent.name != "academic-context"]
 
 


### PR DESCRIPTION
## Summary

- Vendoriert den `xlsx`-Skill aus `anthropics/skills/document-skills/` nach `skills/xlsx/` ins Plugin, so dass der Excel-Export ohne externe `document-skills@anthropic-agent-skills`-Installation funktioniert.
- Alle `document-skills`-Prerequisite-Checks in Command, Setup-Skript, SessionStart-Hook und README entfernt; dafür `openpyxl` + `pandas` als Python-Deps und Python-Env-Check ergänzt.
- `tests/test_skills_manifest.py`: vendored Skills (aktuell `xlsx`) von plugin-spezifischen Manifest-Konventionen (Vorbedingungen/Keine-Fabrikation/Umlaut-Paare) ausgenommen.

**Trade-off bewusst gewählt:** Upstream-Updates des xlsx-Skills müssen manuell per `cp -R` aus `~/.claude/plugins/marketplaces/anthropic-agent-skills/skills/xlsx/` nachgezogen werden.

## Test plan

- [x] Lokal: `pytest tests/ --ignore=tests/evals` → 88/88 grün
- [ ] Im Facharbeit-Ordner: `/academic-research:setup` laufen lassen und prüfen, dass `openpyxl` im venv landet und keine document-skills-Warnung mehr erscheint
- [ ] Testlauf `/academic-research:excel` auf vorhandener Session prüfen

🤖 Generated with [Claude Code](https://claude.com/claude-code)