### PR TITLE
v6.0: Vault MCP-Server Skeleton (Phase 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,13 @@ firebase-debug.log
 # Brainstorming-Artefakte (persönliche Arbeitsprodukte, nicht Release-Inhalt)
 docs/superpowers/specs/
 docs/superpowers/plans/
+
+# mmp orchestrator state — track config, archives, original ticket backups; ignore runtime
+.orchestrator/*
+.orchestrator/.sync/
+!.orchestrator/config.yaml
+!.orchestrator/README.md
+!.orchestrator/archive/
+!.orchestrator/improved-tickets/
+.orchestrator/improved-tickets/*
+!.orchestrator/improved-tickets/*.original.md

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "academic-vault": {
+      "command": "python",
+      "args": ["-m", "mcp.academic_vault.server"],
+      "env": {
+        "VAULT_DB_PATH": "${CLAUDE_PLUGIN_ROOT}/vault.db",
+        "SQLITE_VEC_PATH": ""
+      }
+    }
+  }
+}

--- a/.orchestrator/README.md
+++ b/.orchestrator/README.md
@@ -1,0 +1,45 @@
+# .orchestrator/
+
+This directory holds runtime state for the `mmp` plugin in this repo.
+
+## Files
+
+- `config.yaml` — project-specific configuration for the orchestrator
+- `status.yaml` — live state of the current wave (don't edit by hand)
+- `<milestone>-context.md` — milestone dossier built by Phase 0
+- `infra-brief.md` — repo conventions snapshot for subagents
+- `chunks.md` — Phase 1 decomposition output (user-approved)
+- `improved-tickets/<id>.{original,draft}.md` — Phase 0.5 audit trail
+- `archive/<milestone>-w<N>-<date>/` — completed wave snapshots
+
+## Git tracking policy
+
+The shipped `.gitignore` snippet enforces the following:
+
+| Path | Tracked? | Reason |
+|---|---|---|
+| `config.yaml` | YES | shared project configuration |
+| `README.md` | YES | this file |
+| `archive/` | YES | historical wave snapshots — useful for audit |
+| `improved-tickets/*.original.md` | YES | disaster-recovery backups of upstream tickets |
+| `improved-tickets/*.draft.md` | NO | regenerable per-run scratch |
+| `status.yaml` | NO | live runtime state, single-machine |
+| `<milestone>-context.md` | NO | regenerable per-run snapshot |
+| `infra-brief.md` | NO | regenerable per-run snapshot |
+| `chunks.md` | NO | regenerable per-run snapshot |
+| `status.yaml.bak` / tmp files | NO | atomic-write artifacts |
+
+If you need to share runtime state across machines, override the snippet
+manually — but note that `mmp` assumes a single-user / single-machine
+workflow.
+
+## Recovering from a crash
+
+Run `/mmp:doctor` to see where things stand, then `/mmp:resume` (or
+`/mmp:run <milestone> --resume`).
+
+## Manual cleanup
+
+`/mmp:archive <milestone>` archives a completed wave. Delete `.orchestrator/`
+entirely to start fresh — but ensure no PRs are still open referencing
+worktrees that will be removed.

--- a/.orchestrator/config.yaml
+++ b/.orchestrator/config.yaml
@@ -1,0 +1,70 @@
+# .orchestrator/config.yaml
+# Project-specific config for mmp. Plugin defaults apply for any field omitted.
+
+ticket_source:
+  strategy: milestone           # milestone | label | project
+  milestone_pattern: "{name}"
+  label_pattern: "milestone:{name}"
+  project_number: null
+  state: open
+
+docs:
+  paths:
+    - "docs/milestones/{name}.md"
+    - "docs/{name}.md"
+
+branching:
+  pattern: "feat/{milestone}-{chunk_id}"
+  base: main
+
+ci:
+  provider: github-actions
+  poll_timeout_minutes: 30
+
+decomposition:
+  max_files_per_chunk: 15
+  max_loc_per_chunk: 500
+  max_hours_per_chunk: 8
+
+caps:
+  review_fix_iterations: 3
+  spec_revision_rounds: 2
+  plan_revision_rounds: 2
+  ci_fix_iterations: 3
+  coverage_fix_rounds: 2
+
+required_plugins:
+  # Plain plugin names (no owner/marketplace prefix). The pre-flight glob
+  # `~/.claude/plugins/cache/*/<name>/` resolves them regardless of which
+  # marketplace they came from.
+  - superpowers
+  - code-simplifier
+  - code-review
+
+ticket_improvement:
+  enabled: true
+  mode: live                    # live | local | ask
+  skip_labels:
+    - well-defined
+    - spec-ready
+    - wip
+    - do-not-improve
+  diff_preview: per_ticket      # per_ticket (required if mode=live) | batched | none
+
+gates:
+  # question_buffer_seconds is INFORMATIONAL only — L0 is single-threaded
+  # and cannot wait by clock. Q&A batching happens naturally per
+  # Tool-Result block / phase boundary. See skill reference gates.md.
+  question_buffer_seconds: 30
+  question_buffer_count: 5
+
+pr:
+  draft_initially: true
+  title_pattern: "{milestone}: {chunk_summary}"
+  body_template_path: null
+
+concurrency:
+  lock_timeout_hours: 8        # 1-24 (hard timeout for stale lock detection)
+  steal_on_expired: true       # auto-take expired locks; false → require /mmp:unlock
+  state_sync_branch_prefix: "mmp/state"
+  archive_branch_prefix: "mmp/archive"

--- a/.orchestrator/improved-tickets/65.original.md
+++ b/.orchestrator/improved-tickets/65.original.md
@@ -1,0 +1,11 @@
+**Audit-Bezug:** [`docs/AUDIT-v6-roadmap.md`](../blob/main/docs/AUDIT-v6-roadmap.md) §4.1 + §18.1
+
+## Scope
+- [ ] `agents/quote-extractor.md`: `source.type: "file"` mit `file_id`
+- [ ] `extra_headers={"anthropic-beta": "files-api-2025-04-14"}`
+- [ ] Fallback auf base64 bei Feature-Flag-OFF
+- [ ] anthropic SDK ≥ 0.40 in `scripts/requirements.txt`
+
+## Akzeptanzkriterien
+- [ ] 5 PDFs × 3 Iterationen → -75 % Input-Tokens vs. base64
+- [ ] Fehlende Beta-Header → graceful Fallback

--- a/.orchestrator/improved-tickets/67.original.md
+++ b/.orchestrator/improved-tickets/67.original.md
@@ -1,0 +1,11 @@
+**Audit-Bezug:** [`docs/AUDIT-v6-roadmap.md`](../blob/main/docs/AUDIT-v6-roadmap.md) §4.3
+
+## Scope
+- [ ] `skills/_common/preamble.md` mit Pflicht-Blöcken (Vorbedingungen, Keine Fabrikation, Aktivierung, Abgrenzung)
+- [ ] Markdown-Include oder Frontmatter-Reference in allen 13 Skills
+- [ ] `references/<variant>.md` lazy laden
+- [ ] Browser-Modul: nur Schema-Result in Modell-Context, Raw-DOM in `\$SESSION_DIR/raw/`
+
+## Akzeptanzkriterien
+- [ ] Skill-Aktivierung -500 Token pro Skill
+- [ ] `tests/test_skills_manifest.py` weiter grün

--- a/.orchestrator/improved-tickets/69.original.md
+++ b/.orchestrator/improved-tickets/69.original.md
@@ -1,0 +1,11 @@
+**Audit-Bezug:** [`docs/AUDIT-v6-roadmap.md`](../blob/main/docs/AUDIT-v6-roadmap.md) §7.2 + §18.2
+
+## Scope
+- [ ] `commands/humanize.md` mit YAML-Frontmatter (`Skill(humanizer-de)`)
+- [ ] Argument: `<kapitel-pfad> [--mode normal|deep]`
+- [ ] Output: `<basename>.humanized.md` + `<basename>.diff.md` (Severity-gegliedert)
+- [ ] Voice-Calibration: `~/.academic-research/projects/<slug>/voice-samples/`
+
+## Akzeptanzkriterien
+- [ ] `/academic-research:humanize kapitel/3.md --mode deep` produziert beide Files
+- [ ] Diff-File listet pro Severity die Änderungen

--- a/.orchestrator/improved-tickets/70.original.md
+++ b/.orchestrator/improved-tickets/70.original.md
@@ -1,0 +1,11 @@
+**Audit-Bezug:** [`docs/AUDIT-v6-roadmap.md`](../blob/main/docs/AUDIT-v6-roadmap.md) §12
+
+## Scope
+- [ ] `scripts/project_bootstrap.py`: Frage "Git aktivieren?" (y/n)
+- [ ] Bei y: `git init` + initial commit (`academic_context.md`, `CLAUDE.md`, `.gitignore`)
+- [ ] `hooks/hooks.json`: Stop-Hook prüft `academic_context.md`-Diff > 0 → User-Hinweis
+- [ ] `.gitignore`-Erweiterung: `pdfs/`, `sessions/`, `credentials.json`
+
+## Akzeptanzkriterien
+- [ ] Setup in leerem Ordner zeigt git-Repo nach y
+- [ ] Ohne git installiert → graceful Skip

--- a/docs/AUDIT-v6-roadmap.md
+++ b/docs/AUDIT-v6-roadmap.md
@@ -1,0 +1,956 @@
+# Academic-Research v6 — Audit & Roadmap
+
+**Erstellt:** 2026-05-07 · **Bezugsversion:** v5.4.0 · **Branch:** main
+**Ziel:** Token-Halbierung, Buch-Handling auf Citations-API-Niveau, neuer
+`/humanizer-de`-Workflow, semi-automatische Beschaffung nicht-OA-Quellen,
+optionale Obsidian/Zotero/NotebookLM-Bridges.
+
+---
+
+## 1 · Executive Summary
+
+Das Plugin macht heute, was es soll. Drei Schmerzpunkte limitieren den Sprung
+auf das nächste Level:
+
+1. **Token-Hunger.** Viele Skills laden komplette `references/`-Varianten,
+   `chapter-writer` baut den Kontext jedes Mal neu auf, `relevance-scorer`
+   batched zwar, aber PDFs werden bei jedem Folgecall re-uploaded statt
+   per Files-API referenziert. **Ziel:** −50–70 % Input-Tokens auf typischen
+   Sessions.
+2. **Buch-Handling.** Der Pfad `quote-extractor` → `citation-extraction`
+   funktioniert für Paper, aber nicht für Bücher: keine ISBN-Resolution,
+   keine Kapitel-Schnitte, Seitenangaben aus Scan-PDFs unzuverlässig,
+   PyPDF2 kann keine OCR. **Ziel:** Buch-Pfad mit korrekten Seitenangaben
+   und Verbatim-Zitaten gleichwertig zu Papern.
+3. **Kontext-Drift.** `academic_context.md` / `literature_state.md` /
+   `writing_state.md` werden nicht versioniert oder bei langer Session
+   nachgezogen. Bei Compaction gehen Entscheidungen (Zitierstil-Wahl,
+   abgelehnte Quellen, Variant-References) verloren. **Ziel:** Memory-Tool
+   + state-events.log + Snapshot-Hooks.
+
+Plus 12 weitere Felder (siehe §4–§15).
+
+---
+
+## 2 · Schwachstellen heute (Befund)
+
+### 2.1 Token-Lecks
+
+| Stelle | Befund | Hebel |
+|---|---|---|
+| `chapter-writer` lädt `academic_context.md` + `literature_state.md` + Style-Variant pro Aufruf | ~6–10k Tokens fix | cache_control + Files-API |
+| `quote-extractor` PDF base64 pro Call | 1 PDF ≈ 60–100 k Token, x N Aufrufe | `file_id` referenzieren statt base64 |
+| `relevance-scorer` 10er-Batch nutzt 5min-TTL | Cache läuft bei Pause aus | `cache_control: {type: "ephemeral", ttl: "1h"}` |
+| 13 Skills duplizieren `## Vorbedingungen` / `## Keine Fabrikation` / `## Aktivierung` | ~500 Token Overhead pro Skill | Shared `references/_common.md` per Hot-Link |
+| Browser-Search-Schritt liefert volle DOM-Snapshots in Modell-Context | je Modul bis 30k Token | nur strukturierte Felder zurückgeben, raw Snapshot in `$SESSION_DIR/raw/` |
+| `search.py` schreibt API-Roh-Antwort in `api_results.json` und Modell liest mit | unnötig | Modell liest nur das normalisierte Schema |
+
+### 2.2 Buch-Schwachstellen
+
+- **Kein Buch-Pfad in `search.py`.** APIs sind auf Paper getunt; Bücher
+  haben oft keine DOI, dafür aber ISBN/OCLC.
+- **Seitenangaben:** Die Citations-API ist seitengenau für **PDF-Pages**.
+  Bei Scan-PDFs ohne Text-Layer stimmt aber `start_page_number` nicht
+  zwingend mit der **gedruckten** Seitenzahl überein (PDF-Seite vs.
+  Buchseite — Vorwort/Inhalt verschieben Indizes oft um 10–30).
+- **Zitat-Verbatim:** PyPDF2 produziert bei Zwei-Spalten-Layout und
+  Hyphenation Wort-Salat → der Verbatim-Match aus Citations-API zeigt
+  den korrekten Text, aber `paper.pdf_text` (heuristik-Pfad ohne
+  Citations) liefert verstümmelte Zitate.
+- **Lange Bücher:** Über 600 Seiten reißt die PDF-Page-Limit-Grenze
+  (200k-Modell: 100 Seiten max, 1M-Modell: 600 Seiten max). Kein
+  Chunk-by-Chapter-Pfad vorhanden.
+- **Kapitel-Granularität:** Bücher zitieren oft pro Kapitel mit
+  eigenen Editor:innen. CSL-Felder `container-title`, `editor`,
+  `chapter-number`, `page` werden im aktuellen Schema nicht erfasst.
+- **OCR fehlt.** Scans aus dem Hochschul-OPAC (Tip-2-Online-Scans) sind
+  Bilddateien ohne Text-Layer. Aktuell stiller Fail.
+
+### 2.3 Kontext-/Erinnerungs-Drift
+
+- `academic_context.md` ist die Single Source of Truth, aber niemand
+  zwingt das Modell, sie nach Entscheidungen (z. B. „Wir nutzen IEEE
+  statt APA") zu **überschreiben**.
+- Nach Claude-Compaction verschwinden Bemerkungen wie „X habe ich
+  schon abgelehnt, weil Y" → Nachfolge-Calls schlagen dieselbe Quelle
+  wieder vor.
+- Kein Decision-Log (`decisions.log` o. Ä.).
+
+### 2.4 Workflow-Lücken
+
+- Beschaffung nicht-OA-Quellen (≈ 40–60 % der Treffer in Wirtschaft)
+  läuft heute manuell.
+- KI-Stil-Erkennung ist auf den `style-evaluator`-Skill verteilt
+  (`KI-Glanzschicht entfernen`), aber kein dedizierter `humanizer-de`-
+  Pass mit Severity-Ranking + zweitem Audit.
+- Keine Anbindung an Zotero/Obsidian/NotebookLM für Nutzer:innen, die
+  diese Tools sowieso einsetzen.
+- Kein PRISMA-Flow-Export für Systematic Reviews / Bachelorarbeiten,
+  die Methodik-Transparenz erfordern.
+
+---
+
+## 3 · Felder Übersicht
+
+| ID | Feld | Aufwand | Impact |
+|----|------|---------|--------|
+| F1 | Token-Effizienz (Cache + Files-API) | M | sehr hoch |
+| F2 | Buch-Pfad (ISBN, Kapitel, OCR, Seitenmapping) | L | sehr hoch |
+| F3 | Kontext-Persistenz (Memory-Tool + Decision-Log) | M | hoch |
+| F4 | `/humanizer-de` als first-class Workflow | S | hoch |
+| F5 | Beschaffungs-Excel (Fernleihe / Bibliotheks-Pickup) | S | hoch |
+| F6 | Auto-Download-Pipeline mit fail-soft | M | mittel |
+| F7 | Zotero-Bridge (Web-API v3) | M | mittel |
+| F8 | Obsidian-Bridge (Vault-Sync) | S | mittel |
+| F9 | NotebookLM-Bridge (manuell + optional CLI) | S | mittel |
+| F10 | PRISMA-Flow Diagramm + Inclusion-Log | M | hoch (für Bachelor/Master) |
+| F11 | Cluster-Visualisierung (Mermaid + Excel-Chart) | S | mittel |
+| F12 | Versionierung des Projekt-Kontexts (Git-Integration) | S | mittel |
+| F13 | Citation-Style-Erweiterung (CSL-JSON Import) | M | mittel |
+| F14 | Reading-List-Modus (kuratierte Quellen) | S | niedrig |
+| F15 | Eval-Suite Coverage (Buch-Cases) | M | hoch (Qualität) |
+| F16 | Universal Book Fetcher (TIB, autonomes Navigieren, Per-Uni-Profile) | L | sehr hoch |
+
+---
+
+## 4 · F1 — Token-Effizienz
+
+### 4.1 Files-API für PDFs
+
+**Problem:** `quote-extractor` schickt heute `source.type: "base64"`. Bei
+mehrfacher Verwendung desselben PDFs im selben Projekt wird dieselbe
+Datei mehrmals upgeloadet.
+
+**Lösung:**
+
+1. Beim ersten Verarbeiten eines PDFs `client.beta.files.upload(...)`
+   aufrufen, `file_id` in `pdf_status.json` schreiben.
+2. Folgenden Calls nur noch:
+   ```python
+   {"type": "document", "source": {"type": "file", "file_id": fid},
+    "citations": {"enabled": True}}
+   ```
+3. TTL-Tracking: file_ids ablaufen lassen wenn älter als Plugin-Konfig
+   (`~/.academic-research/files_ttl_days`, Default 30).
+
+**Trade-off:** Files-API ist Beta (`anthropic-beta: files-api-2025-04-14`)
+und erfordert anthropic SDK ≥ 0.40.
+
+### 4.2 Cache-Strategie umstellen
+
+- `relevance-scorer`, `quote-extractor`, `chapter-writer`, `quality-reviewer`:
+  `cache_control: {"type": "ephemeral", "ttl": "1h"}` auf System-Prompt
+  (Anthropic änderte 6. März 2026 den Default zurück auf 5 min — ohne
+  expliziten ttl zahlt man cache-write-Aufschlag mehrfach).
+- Cache-Breakpoint **vor** das `documents[]`-Array, nicht danach. So bleibt
+  der Agent-Prompt auch dann gecacht, wenn das PDF wechselt.
+
+### 4.3 Skills schlanker
+
+- Gemeinsame Pflicht-Blöcke (`Vorbedingungen`, `Keine Fabrikation`,
+  `Abgrenzung`) in `skills/_common/preamble.md` extrahieren und per
+  Markdown-Include linken.
+- `references/<variant>.md` lazy laden — nicht im Skill-Body listen,
+  sondern erst dann öffnen, wenn der Variant-Selector eine Datei
+  fixiert hat.
+- Browser-Snapshots **nicht** in Antwort-Context geben. Modell sieht
+  nur das Schema-normalisierte Ergebnis (`title`, `authors`, …),
+  Raw-DOM bleibt in `$SESSION_DIR/raw/` für Debug.
+
+**Erwartung:** −30–50 % Input-Tokens bei `/search` und `/score`,
+−60 % bei wiederholten Zitat-Extraktionen.
+
+### 4.4 Batch-API für Bulk-Scoring
+
+`relevance-scorer` über 50+ Papers → in Message-Batches-API auslagern.
+50 % Discount, 1h-Latenz. Hook im `/search`-Command:
+`--batch` Flag → Job submitten, Job-ID in `$SESSION_DIR/batch.json`,
+Pickup über `/academic-research:history --batch <id>`.
+
+---
+
+## 5 · F2 — Buch-Pfad
+
+### 5.1 Neuer Skill `book-handler`
+
+**Trigger:** „Buch", „Monografie", „Sammelband", „Kapitel von …",
+ISBN-Pattern (`\d{3}-\d{1,5}-\d{1,7}-\d{1,7}-\d`).
+
+**Pipeline:**
+
+```
+ISBN/Title → DNB SRU + OpenLibrary + GoogleBooks
+          → Metadaten (CSL: book / chapter)
+          → OPAC-Suche (verfügbar lokal? Standort? Signatur?)
+          → DOAB / OAPEN (OA-Bücher)
+          → falls PDF: Kapitel-Schnitt + OCR-Check + Seitenmapping
+          → Eintrag in literature_state.md (type: book|chapter)
+```
+
+### 5.2 Kapitel-Schnitt
+
+PDF-Inhaltsverzeichnis aus dem Outline-Tree (PyPDF2 `outline`) oder
+Textextraktion. Pro Kapitel:
+
+- `chunk_pdf.py --input book.pdf --chapter 3 --output chapter3.pdf`
+- separater Citations-API-Call mit nur diesem Kapitel als Document
+- spart Tokens (statt 600 Seiten nur 30) und hält die 100/600-Page-
+  Limits ein.
+
+### 5.3 Seitenmapping (PDF-Page ≠ Druck-Seite)
+
+**Problem:** `start_page_number` aus Citations-API ist die **PDF-Seite**.
+Druck-Seite kann um Vorwort/Inhalt versetzt sein.
+
+**Fix:**
+
+1. Beim ersten Buch-PDF-Verarbeiten: Modell scannt erste 30 PDF-Seiten,
+   findet die erste **gedruckte** Seitenzahl `1` und speichert
+   `page_offset = pdf_page - printed_page` in `pdf_status.json`.
+2. Bei Citation-Output:
+   `printed_page = api.start_page_number - page_offset`.
+3. Sanity-Check: Modell schaut auf 2 zufällige weitere Seiten, ob
+   das Offset stimmt — wenn nicht (Buch hat Doppelpaginierung,
+   römische Vorseiten etc.), Offset-Map als JSON.
+
+### 5.4 OCR-Path
+
+- Detektion: PDF erste Seite hat `< 100` extrahierbare Zeichen → OCR-Flag.
+- OCR-Tool: `ocrmypdf` (CLI) als Plugin-optional Dep.
+- Bei OCR-Flag → Modell warnt User, fragt ob OCR laufen soll
+  (lokal, dauert ~30 s/Seite). Nach OCR neuer PDF-Pfad.
+
+### 5.5 CSL-Felder erweitern
+
+`literature_state.md` Schema um `type: book | chapter | article-journal`
+und chapter-spezifische Felder (`container-title`, `editor[]`,
+`chapter`, `page-first`, `page-last`).
+
+`citation-extraction/references/` neue Variante: `book-chapter-de.md`
+mit Beispielen für DIN 1505, Harvard-de, APA-7 für Sammelbände.
+
+---
+
+## 6 · F3 — Kontext-Persistenz
+
+### 6.1 Memory-Tool
+
+`~/.academic-research/projects/<slug>/memory/` mit Anthropic-Memory-Tool
+befüllen. Schema:
+
+- `decisions.md` — chronologisch: Zitierstil, Methodik-Wahl, abgelehnte
+  Quellen, Cluster-Definitionen
+- `glossary.md` — projektspezifische Begriffe
+- `style-overrides.md` — User-spezifische Stil-Präferenzen
+  (z. B. „nutzt 'Wir' statt 'man'")
+
+Alle Skills lesen Memory-Tool **vor** dem Hauptprompt → 0 Tokens für
+Kontext-Wiederholung über Sessions hinweg.
+
+### 6.2 Decision-Log Hook
+
+Hook `PostToolUse` für `Write` mit Pfad-Match auf `*.md` im Projekt:
+schreibt 1-Zeile in `decisions.log` mit Timestamp + Skill + Δ. Hilft
+beim Auditing und ist die Vorlage für PRISMA-Flow.
+
+### 6.3 Auto-Snapshot vor Compaction
+
+Hook `PreCompact`: schreibt aktuellen `academic_context.md` +
+`literature_state.md` + `writing_state.md` als Tarball nach
+`~/.academic-research/snapshots/<slug>/<ts>.tgz`. Bei Bedarf
+mit `/academic-research:history --restore <ts>` zurück.
+
+---
+
+## 7 · F4 — `/humanizer-de` Integration
+
+### 7.1 Status
+
+`humanizer-de` ist als globaler Skill bereits unter
+`~/.codex/skills/humanizer-de/` (siehe Skill-Description: Anti-KI-Audit,
+Severity-Ranking, Modi-System, Stimmkalibrierung). Keine Re-Implementation
+nötig.
+
+### 7.2 Integration in academic-research
+
+Drei Punkte:
+
+1. **`style-evaluator`** triggert `humanizer-de` als Subagent-Skill,
+   wenn `output_target` ∈ {Bachelor, Master, Diplom, Dissertation}.
+2. **`chapter-writer`** ruft `humanizer-de` im **Mode `audit`** vor
+   `quality-reviewer` auf — Reihenfolge:
+   ```
+   draft → humanizer-de(audit) → quality-reviewer → final
+   ```
+3. **Neuer Slash-Command `/academic-research:humanize`** als
+   eigenständiger Pass: liest `kapitel/<n>.md`, läuft Mode `deep`
+   gegen humanizer-de, schreibt `kapitel/<n>.humanized.md` plus
+   `kapitel/<n>.diff.md`.
+
+### 7.3 Stimmkalibrierung
+
+`humanizer-de` kennt Voice-Calibration aus User-Schreibproben.
+Vorschlag: `~/.academic-research/projects/<slug>/voice-samples/`
+für 3–5 eigene Texte des Users (frühere Hausarbeiten). Erstaktivierung
+fragt nach Samples.
+
+### 7.4 Trade-off
+
+Weniger fluffige Symbolik = weniger LLM-Wow-Effekt. Funktion ist
+**Schutz** vor KI-Detektoren wie Turnitin / GPTZero / OriginalityAI.
+Default off in nicht-Hochschul-Projekten (siehe Best-Practice
+„Overhead in Nicht-Facharbeit-Projekten deaktivieren").
+
+---
+
+## 8 · F5/F6 — Beschaffung & Auto-Download
+
+### 8.1 5-Tier-Pipeline (heute) erweitern auf 8 Tiers
+
+Aktuell: Unpaywall → CORE → Module-OA-URL → Direct-PDF → arXiv-Title.
+
+Erweiterung:
+
+6. **OpenAccessButton** (`api.openaccessbutton.org/find`)
+7. **DOAB / OAPEN** für Bücher
+8. **EuropePMC** (`europepmc.org/api`) für Biomedizin
+
+### 8.2 Bibliotheks-Excel `pickup-list.xlsx`
+
+**Trigger:** `/academic-research:pickup` (neuer Command).
+
+Liest `literature_state.md`, filtert auf `source != open_access`,
+ergänzt:
+
+- OPAC-Standort + Signatur (über DAIA / `gbv.github.io/cdvost2018`)
+- Status (verfügbar / ausgeliehen / Fernleihe nötig)
+- Direktlink Fernleihe-Formular der Heim-Uni (User konfiguriert URL
+  in `~/.academic-research/config.yaml`)
+- ISBN-Barcode (Code128) als Excel-Bild für mobiles Scannen am Regal
+
+Sheets:
+
+1. **Vor Ort verfügbar** — Pickup-Reihenfolge nach Signatur sortiert
+2. **Fernleihe** — fertig formatierte Anfrage-Texte (Title, Author,
+   Year, ISBN/DOI) als Copy-Paste-Block pro Zeile
+3. **Online OA** — Direktlinks
+4. **Lizenz nötig** — proprietary, Hinweis auf Uni-VPN
+
+### 8.3 Browser-Modul `library-pickup`
+
+`browser-use`-Skript: loggt sich (HAN-Auth) ins Bibliotheks-Konto ein,
+trägt automatisch Fernleihe-Bestellungen ein. **Opt-in**, weil
+verbindlich (kostenpflichtig pro Anfrage).
+
+### 8.4 PDF-Status-Workflow
+
+```
+literature_state.md  ─┬─► auto_download (8-tier)
+                       ├─► via_opac (download-link)
+                       ├─► fernleihe (manual_followup)
+                       └─► self_uploaded (~/papers/)
+```
+
+Skill `source-quality-audit` warnt, wenn > 30 % der zitierten Quellen
+nur Metadaten sind (kein Volltext) → Risiko für `quote-extractor`.
+
+---
+
+## 9 · F7/F8/F9 — Knowledge-Tool-Bridges
+
+### 9.1 Zotero (F7)
+
+- **Einseitige Sync**: `pyzotero` als optionale Dep.
+- Neuer Skill `zotero-sync`: liest Zotero-Library (User-Key in
+  `~/.academic-research/config.yaml`), mappt auf
+  `literature_state.md`-Schema, dedupliziert per DOI/ISBN.
+- **Zwei-Wege-Sync**: erst v6.1, weil OAuth1-Schreib-Auth fehleranfällig.
+- Better-BibTeX-Export-File (`<vault>/zotero.bib`) auch ok für Pull-only.
+
+### 9.2 Obsidian (F8)
+
+- Neuer Skill `obsidian-export`: schreibt pro Paper eine Markdown-Datei
+  in `<vault>/lit/<citekey>.md` mit Frontmatter (`title`, `authors`,
+  `year`, `doi`, `tags: [academic-research, cluster-X]`) und Body
+  (Abstract, Top-3-Zitate, Notizen).
+- Cluster-MOC (`<vault>/lit/_clusters/<cluster>.md`) als Übersicht.
+- Kompatibel mit ZotLit-Templates.
+
+### 9.3 NotebookLM (F9)
+
+- Kein offizielles API. Optionen:
+  - **Manuell**: Skill `notebook-export` baut PDF-Bundle aus Top-N
+    Papern + Bibliographie als ein PDF (via xlsx-Skill-Pattern, nur
+    PDF-Pack), User uploadet selbst.
+  - **Halb-automatisch**: `notebooklm-py` (unofficial) als optionale
+    Dep für User mit Google-Account (Risiko: bricht bei UI-Updates).
+- Use-Case: 1M-Token-Source-Grounding bei Büchern, die für unsere
+  Citations-API zu groß sind. Abgrenzung: NotebookLM ersetzt **nicht**
+  unseren Zitat-Pfad — Output dort ist nicht verbatim-garantiert.
+
+### 9.4 Empfehlung
+
+Default: Obsidian-Bridge (Markdown ist null-Lock-in). Zotero-Pull-Sync
+für Nutzer:innen mit bestehender Library. NotebookLM nur bei
+Riesen-Büchern (> 600 PDF-Seiten) als Triage-Tool, **nie** als
+Zitationsquelle.
+
+---
+
+## 10 · F10 — PRISMA-Workflow
+
+Bachelor-/Master-Arbeiten mit Methodik „Systematic Review" brauchen
+einen PRISMA-Flow:
+
+```
+Identifikation (n=) → Screening (n=) → Eligibility (n=) → Included (n=)
+```
+
+**Implementierung:**
+
+1. `/search` schreibt `n_identified` pro Modul.
+2. Dedup-Schritt schreibt `n_after_dedup`.
+3. `relevance-scorer` < 0.5 → `excluded_screening`.
+4. `quality-reviewer` Ablehnung → `excluded_eligibility`.
+5. Neuer Skill `prisma-flow` rendert Mermaid-Diagramm in
+   `kapitel/methodik.md` und exportiert als PNG via
+   Mermaid-CLI.
+6. Begleitend `prisma-checklist.md` (27-Punkte-PRISMA-2020).
+
+---
+
+## 11 · F11 — Cluster-Visualisierung
+
+- Excel-Sheet bereits da, aber statisch.
+- Mermaid-Diagramm aus 5D-Scoring-Output: Cluster als Knoten,
+  Querverbindungen (Co-Authors, Co-Citations) als Kanten. Im
+  `kapitel/literatur.md` einbettbar.
+- Optional: D3-HTML-Export für Browser-Browse (lokales File).
+
+---
+
+## 12 · F12 — Projekt-Versionierung
+
+- Setup legt heute schon `.gitignore` an. Erweiterung:
+  `git init` + initial commit der Bootstrap-Files automatisch
+  (User-Opt-in im Setup).
+- Hook `Stop`: Diff `academic_context.md` seit letztem Commit > 0
+  → Modell schlägt `/academic-research:commit "..."` vor.
+- Branch-Strategie für Methodik-Experimente
+  („was wäre wenn ich qualitativ statt quantitativ arbeite") in
+  Best-Practices dokumentieren.
+
+---
+
+## 13 · F13 — CSL-JSON Import
+
+Aktuelle Variant-Selector-Logik (`apa.md`, `harvard.md` …) ist
+hand-curated. CSL-Repository auf GitHub hat 10.000+ Stile.
+
+**Lösung:** Skill `citation-style-import` lädt eine `.csl`-Datei
+aus dem Repo (User gibt Stil-Name an), parst sie zu prompt-fähigen
+Regeln. Ergebnis als neue Variant `references/custom-<style>.md`.
+
+Trade-off: Volle CSL-Spec ist groß. Pragmatischer Ansatz: nur die
+Felder formatieren, die `literature_state.md` kennt
+(book, chapter, journal, conference).
+
+---
+
+## 14 · F14 — Reading-List-Modus
+
+Manche Profs geben eine Lese-Liste vor. Aktuell muss der User die
+händisch in `literature_state.md` tippen.
+
+**Skill `reading-list-import`:**
+
+- Input: PDF / Markdown / Plaintext mit Liste von Quellen.
+- Pipeline: Anystyle (Ruby) oder eigener LLM-Parser → strukturierte
+  Liste → DOI-/ISBN-Resolution → `literature_state.md`.
+
+---
+
+## 15 · F15 — Eval-Coverage
+
+Heute: 16 Eval-Verzeichnisse, aber Buch-Cases fehlen. Neue Eval-Sets:
+
+- `evals/book-handler/` — 5 Bücher (1 OA, 2 ISBN-only, 1 Scan-PDF,
+  1 Sammelband mit Editor-Kapiteln)
+- `evals/humanizer-de-pipeline/` — 3 Drafts vor/nach humanizer-de
+- `evals/prisma-flow/` — 1 Mini-Review-Beispiel
+
+Bestehende Evals um Token-Counts erweitern → Regression-Tests gegen
+F1.
+
+---
+
+## 15a · F16 — Universal Book Fetcher (browser-use only)
+
+### Constraint
+
+**Nur `browser-use` CLI + Subagenten.** Keine API-basierte Discovery,
+kein curl/wget, kein direktes Anthropic-Files-Upload. Jede Quelle wird
+wie ein Mensch im Browser bedient. Begründung:
+
+- Verlags-Auth (Shibboleth, HAN, EZproxy) liefert nur Browser-Sessions
+- DNB/OpenLibrary-APIs sind nice-to-have, aber nicht der Kern-Wunsch
+- User will ein **autonomes Subagenten-System** das auf Sites navigiert
+- Memory-Direktive: "browser-use statt Playwright/MCP-API"
+
+### Befund (Status quo)
+
+- 9 Browser-Guides in `config/browser_guides/`, alle **such-zentriert**
+  — Metadaten + URL holen, dann zurück. Kein Download-Step.
+- Springer-Guide erwähnt "Download PDF"-Button, aber kein dokumentierter
+  `browser-use`-Workflow für lokales Speichern.
+- HAN-Login auf **Leibniz FH** hardcoded
+- TIB.eu fehlt komplett — wichtigste DACH-Quelle (143 Mio Records,
+  71 Mio Volltexte)
+- Keine Subagenten für Site-Navigation. Heute macht das der Master-
+  Modell-Loop selbst → frisst Tokens und ist fragil.
+
+### Architektur (Subagenten-System)
+
+```
+                      ┌─────────────────────────┐
+                      │  /academic-research:    │
+                      │  fetch <isbn|doi|titel> │
+                      └────────────┬────────────┘
+                                   │
+                      ┌────────────▼────────────┐
+                      │  book-fetcher           │  ← Master-Subagent
+                      │  (Sonnet)               │     entscheidet,
+                      │  - Site-Strategie       │     wo gesucht wird
+                      │  - Fallback-Kette       │
+                      └─┬───┬───┬───┬───┬───┬──┘
+                        │   │   │   │   │   │
+       ┌────────────────┘   │   │   │   │   └────────────────┐
+       ▼                    ▼   ▼   ▼   ▼                    ▼
+   tib-fetcher       springer-fetcher   oapen-fetcher    generic-fetcher
+   (Haiku)              (Sonnet)         (Haiku)         (Sonnet)
+   nur tib.eu         nur SpringerLink   nur oapen.org   beliebige URL
+   browser-use        browser-use        browser-use     browser-use
+```
+
+Jeder Site-Subagent ist ein **eigener Agent in `agents/`** mit:
+- `tools: [Bash(browser-use:*), Bash(browser-use *), Read, Write]`
+- `model: sonnet` für alle Site-Subagenten (browser-Navigation braucht
+  zuverlässige DOM-Heuristik und Fehlertoleranz; Haiku scheitert hier
+  zu oft an State-Output-Drift)
+- maxTurns: 12–20 (Browser-Schritte sind langsam)
+- nur ein Site-Wissen pro Agent → kleiner System-Prompt
+
+### F16.1 — Site-Subagenten (browser-use only)
+
+Neu unter `agents/`:
+
+| Agent | Site | Model | Auth | Buch-Fokus |
+|---|---|---|---|---|
+| `tib-fetcher` | tib.eu Portal | sonnet | optional | hoch — viele OA-Bücher |
+| `springer-book-fetcher` | link.springer.com | sonnet | Shibboleth/HAN | hoch — Lehrbücher |
+| `oapen-fetcher` | oapen.org | sonnet | nein | sehr hoch — reine OA |
+| `doabooks-fetcher` | directory.doabooks.org | sonnet | nein | sehr hoch — reine OA |
+| `degruyter-fetcher` | degruyter.com | sonnet | Shibboleth/HAN | mittel — DACH Geistes |
+| `nationallizenzen-fetcher` | nationallizenzen.de | sonnet | DFN-AAI | mittel |
+| `ebook-central-fetcher` | ebookcentral.proquest.com | sonnet | HAN/EZproxy | mittel |
+| `kvk-fetcher` | kvk.bibliothek.kit.edu | sonnet | nein | Meta-Discovery, 80+ Kataloge |
+| `generic-fetcher` | beliebige URL | sonnet | je nach Profil | Fallback-Modus |
+
+Pro Subagent: `agents/<name>.md` mit System-Prompt, der nur diese eine
+Site kennt. Beispiel-Skelett `agents/tib-fetcher.md`:
+
+```markdown
+---
+name: tib-fetcher
+model: sonnet
+description: |
+  Holt Bücher und Texte von tib.eu (TIB-Portal, Hannover) per
+  browser-use. Aufrufen mit ISBN, DOI oder Titel. Liefert Pfad zum
+  heruntergeladenen PDF oder Failure-Reason zurück.
+tools: [Bash(browser-use:*), Bash(browser-use *), Read, Write]
+maxTurns: 15
+---
+
+# Auftrag
+
+Du bedienst tib.eu wie ein Mensch. Nur browser-use.
+
+## Standard-Flow
+
+1. `browser-use open https://www.tib.eu/de/suchen?query=<URL-encoded-query>`
+2. `browser-use state` → Treffer-Liste lesen
+3. Plausibelster Treffer: Titel + Autor + Jahr matcht Input
+4. `browser-use click <idx>` auf Treffer-Titel
+5. `browser-use state` → Detailseite lesen:
+   - "Volltext"-Block sichtbar?
+   - "DOI"-Link sichtbar?
+   - "Open Access"-Badge?
+6. Wenn "Volltext"-Link → `browser-use click <idx>`
+   Wenn DOI → `browser-use click <idx>` (verlinkt oft auf OA-Repo)
+7. Auf PDF-Viewer-Seite: `browser-use download <pdf-link-idx> --to $OUTPUT_PATH`
+8. Validation: PDF-Magic, Größe > 10 KB, Titel-Plausibilität (siehe
+   quote-extractor-Pattern)
+
+## Fallback
+
+Kein Volltext gefunden → Output: `{"status": "metadata_only", "url": "<detailseite>"}`.
+Master-Agent entscheidet, ob nächster Subagent (springer-book-fetcher)
+versucht wird.
+
+## Verbote
+
+- Kein curl, kein wget, kein direkter HTTP-Aufruf
+- Keine API-Endpoints raten
+- Keine fingierten Treffer (wenn Suche leer ist, melden)
+```
+
+Analog für jeden anderen Site-Agent. Auth-Subagenten teilen sich
+einen `auth-helper`-Subagent, der je nach Per-Uni-Profil den richtigen
+Login-Flow ausführt (HAN, Shibboleth-WAYF, EZproxy).
+
+### F16.2 — Master-Agent `book-fetcher`
+
+```markdown
+---
+name: book-fetcher
+model: sonnet
+description: |
+  Master-Orchestrator: bekommt ISBN/DOI/Titel und versucht, das Werk
+  über die Site-Subagenten zu beschaffen. Entscheidet Fallback-Reihenfolge
+  basierend auf Input-Typ und Per-Uni-Profil.
+tools: [Read, Write, Agent(tib-fetcher, springer-book-fetcher, oapen-fetcher, doabooks-fetcher, degruyter-fetcher, nationallizenzen-fetcher, ebook-central-fetcher, kvk-fetcher, generic-fetcher, auth-helper)]
+maxTurns: 8
+---
+
+# Auftrag
+
+Beschaffe das Werk per browser-use-Subagenten.
+
+## Strategie
+
+1. Lies `~/.academic-research/library-profiles/active.yaml`.
+2. Reihenfolge bestimmen:
+   - **OA-Bücher**: oapen → doabooks → tib (OA-Filter) → kvk
+   - **Verlags-Bücher mit Uni-Lizenz**: springer-book → degruyter →
+     ebook-central → nationallizenzen
+   - **Unbekannt**: kvk-fetcher (Meta-Suche) zuerst, dann passender
+     Site-Subagent gemäß Treffer
+3. Pro Subagent ein Versuch. Bei `metadata_only` → nächster Subagent.
+   Bei `success` → Pfad in Vault aufnehmen, fertig.
+4. Alle erschöpft → Pickup-Excel-Eintrag (für Fernleihe).
+
+## Output
+
+```json
+{
+  "status": "success" | "pickup_required" | "captcha" | "no_match",
+  "pdf_path": "...",
+  "source_subagent": "tib-fetcher",
+  "tries": [
+    {"subagent": "oapen-fetcher", "result": "metadata_only"},
+    {"subagent": "tib-fetcher", "result": "success"}
+  ]
+}
+```
+
+## Verbote
+
+- Kein eigener Browser-Aufruf — nur über Subagenten
+- Kein Skipping der Per-Uni-Profil-Lese
+```
+
+### F16.3 — `/academic-research:fetch` Command
+
+```yaml
+---
+description: Hol ein Buch oder Paper über die Site-Subagenten ins Repo
+disable-model-invocation: false
+allowed-tools: Read, Write, Agent(book-fetcher)
+argument-hint: <isbn|doi|titel|url>
+---
+1. Parsen des Inputs (ISBN-Regex / DOI-Regex / URL / Freitext)
+2. Spawn book-fetcher mit normalisiertem Input
+3. Auf Ergebnis warten
+4. Bei success: Eintrag in literature_state.md / Vault
+5. Bei pickup_required: Eintrag in pickup-list.xlsx vorbereiten
+6. Bei captcha: Screenshot anzeigen, User entscheidet manuell
+```
+
+### F16.4 — Discovery-Modus (`generic-fetcher`)
+
+Wenn die ersten 8 Site-Subagenten alle fehlschlagen oder die URL keiner
+bekannten Site entspricht:
+
+```markdown
+---
+name: generic-fetcher
+model: sonnet
+description: |
+  Fallback-Subagent. Bedient eine beliebige wissenschaftliche Site
+  per browser-use, ohne vorgegebenen Site-Guide. Entscheidet anhand
+  von DOM-Heuristiken (PDF-Button, Access-Banner, Login-Wall).
+tools: [Bash(browser-use:*), Bash(browser-use *), Read, Write]
+maxTurns: 20
+---
+
+# DOM-Heuristiken (Few-Shot-Lernen)
+
+## "PDF-Button erkennen"
+Look-fors in browser-use state:
+- Text enthält: "Download PDF", "PDF herunterladen", "Get PDF",
+  "Volltext (PDF)", "Full Text", "View PDF"
+- Element-Typ: <a> oder <button>
+- nicht: "Vorschau", "Preview", "Sample Chapter"
+
+## "Paywall erkennen"
+- Text enthält: "Get Access", "Purchase", "Buy", "Subscribe",
+  "Sign in to view", "Anmelden für Volltext"
+- Aktion: prüfe Per-Uni-Profil, ob Site-Lizenz vorhanden — wenn ja,
+  triggere auth-helper. Wenn nein → metadata_only.
+
+## "Captcha erkennen"
+- Text "I'm not a robot", "Please verify", "reCAPTCHA"
+- Aktion: screenshot, abbrechen mit status: captcha
+
+## "Falscher Treffer erkennen"
+- Treffer-Titel ≠ Input-Titel (>30 % Differenz, Levenshtein)
+- Aktion: zurück zur Trefferliste, nächster Treffer
+```
+
+### F16.5 — Per-Uni-Profile (gleich wie F5)
+
+`~/.academic-research/library-profiles/<uni>.yaml` (Beispiel Leibniz FH):
+
+```yaml
+uni: leibniz-fh
+auth_type: HAN
+auth_url: https://han.leibniz-fh.de
+credentials_keys: [han_user, han_password]
+licensed_sites:
+  - link.springer.com
+  - degruyter.com
+  - ebookcentral.proquest.com
+  - tib.eu
+proxy_pattern: "https://{site-with-dots-replaced-by-dashes}.han.leibniz-fh.de"
+```
+
+`auth-helper`-Subagent liest dieses Profil und entscheidet, ob er:
+- HAN-Login fahren muss (Leibniz FH)
+- Shibboleth-WAYF benutzt (TUM, RWTH)
+- EZproxy-Proxy direkt (manche US-Unis)
+- ohne Auth weiterläuft (OA-Site)
+
+Setup fragt beim Erstaufruf nach Uni und Profil. Vorlagen für die
+20 größten DACH-Hochschulen werden mit dem Plugin ausgeliefert.
+
+### Trade-offs
+
+- **Token-Kosten Subagenten:** 9 Site-Agenten = 9 System-Prompts.
+  Mitigation: Master-Agent spawnt nur 1–2 pro Anfrage (Strategie-
+  basiert), nicht alle parallel. Cache-Control auf System-Prompt
+  jedes Site-Subagenten (1h-TTL) macht Folge-Calls auf dieselbe
+  Site billig.
+- **Modell-Wahl Sonnet überall:** Browser-Navigation reagiert auf
+  unstrukturierten DOM-State, Fehlertoleranz braucht Sonnet-Niveau.
+  Haiku scheiterte in Tests an Treffer-Auswahl und Paywall-Erkennung.
+  Mehrkosten akzeptiert, weil pro Anfrage nur 1–2 Subagenten laufen.
+- **browser-use Concurrency:** Heute single-Browser-Session. Parallele
+  Subagenten würden sich Browser-Tab teilen. Mitigation: Master-Agent
+  fährt strikt sequentiell.
+- **Captcha:** browser-use kann nicht lösen. User-Hand-off bleibt.
+- **Verlags-AGBs:** Throttle ≥ 5 s zwischen Downloads, kein Bulk-
+  Crawling. Skills nutzen Standard-User-Agent (browser-use Default).
+- **Auth-Drift:** Per-Uni-Profile veralten. Mitigation: jährlicher
+  Profil-Review, User-Override über CLI.
+
+### Konkrete Anker (Sprint v6.2 Diff)
+
+```
+agents/
+  book-fetcher.md                 # NEU — Master
+  tib-fetcher.md                  # NEU
+  springer-book-fetcher.md        # NEU — ergänzt bestehenden springer-Guide
+  oapen-fetcher.md                # NEU
+  doabooks-fetcher.md             # NEU
+  degruyter-fetcher.md            # NEU
+  nationallizenzen-fetcher.md     # NEU
+  ebook-central-fetcher.md        # NEU
+  kvk-fetcher.md                  # NEU
+  generic-fetcher.md              # NEU — Discovery-Modus
+  auth-helper.md                  # NEU — geteilt
+
+commands/
+  fetch.md                        # NEU — /academic-research:fetch
+
+config/browser_guides/
+  tib.md                          # NEU
+  oapen.md                        # NEU
+  doabooks.md                     # NEU
+  degruyter.md                    # NEU
+  nationallizenzen.md             # NEU
+  ebook_central.md                # NEU
+  kvk.md                          # NEU
+  springer.md                     # ÜBERARBEITET — Buch-Download-Block
+
+scripts/bootstrap/
+  library-profiles/
+    leibniz-fh.yaml               # NEU
+    tum.yaml                      # NEU
+    rwth-aachen.yaml              # NEU
+    fau-erlangen.yaml             # NEU
+    template-shibboleth.yaml      # NEU
+    template-han.yaml             # NEU
+    template-ezproxy.yaml         # NEU
+    template-oa-only.yaml         # NEU
+```
+
+
+
+### v6.0 — Foundation (Sprint 1, ~1 Woche)
+
+- F1.1 Files-API für PDFs in `quote-extractor`
+- F1.2 1h-TTL-Cache überall durchziehen
+- F4 `/humanizer-de`-Integration in `chapter-writer` + neuer Slash-Command
+- F12 `git init` Auto-Setup
+
+### v6.1 — Bücher (Sprint 2, ~2 Wochen)
+
+- F2.1 Skill `book-handler`
+- F2.2 Kapitel-Schnitt + Seitenmapping + OCR-Detection
+- F2.3 CSL `book` / `chapter`-Schema + DIN-1505-Variant
+- F15 Eval-Coverage Bücher
+
+### v6.2 — Beschaffung (Sprint 3, ~2 Wochen)
+
+- F5 Pickup-Excel
+- F6 8-Tier-Download
+- F11 Cluster-Mermaid
+- **F16 Universal Book Fetcher** (TIB + 5 weitere Module + `web-fetcher` + Per-Uni-Profile + `/academic-research:fetch`)
+
+### v6.3 — Bridges (Sprint 4, ~1 Woche)
+
+- F7 Zotero-Pull
+- F8 Obsidian-Export
+- F9 NotebookLM-Bundle (manuell)
+
+### v6.4 — Methodik (Sprint 5, ~1 Woche)
+
+- F3 Memory-Tool + Decision-Log
+- F10 PRISMA-Flow
+- F13 CSL-Import
+
+### v6.5 — Polish
+
+- F14 Reading-List-Import
+- Doku, Migration-Guide, README-Update
+
+---
+
+## 17 · Risiken & Trade-offs
+
+| Risiko | Mitigation |
+|---|---|
+| Files-API ist Beta — kann brechen | Feature-Flag in `~/.academic-research/config.yaml`, Fallback auf base64 |
+| Memory-Tool nur in Managed-Agents oder mit eigenem Server | Pragmatisch: zunächst File-basiertes Memory in `projects/<slug>/memory/`, später Memory-Tool |
+| OCR auf Lokal-Hardware lahm | Async-Hook, User entscheidet pro PDF |
+| Zotero OAuth1-Schreib-Sync fehleranfällig | Erst Pull-only, Push erst wenn stabil |
+| `humanizer-de` ist nicht im Plugin vendoriert | Doku: Setup prüft Skill-Existenz, sonst Hinweis |
+| NotebookLM-CLI bricht ständig | als optional kennzeichnen, kein Hard-Dep |
+| Pickup-Excel-Workflow je Hochschule anders | Per-Profil-Konfig: `~/.academic-research/library-profiles/<uni>.yaml` mit OPAC-URL, HAN-Endpoint, Fernleih-URL |
+| 1M-Token-Modus = teuer | Default bleibt 200k, 1M nur bei expliziter `--book` Flag |
+
+---
+
+## 18 · Konkrete Anker-Diffs (Beispiele)
+
+### 18.1 `agents/quote-extractor.md` — Cache + Files-API
+
+```python
+file_id = ensure_uploaded(pdf_path)  # cached in pdf_status.json
+
+client.beta.messages.create(
+    model="claude-sonnet-4-7",
+    system=[{
+        "type": "text",
+        "text": AGENT_SYSTEM_PROMPT,
+        "cache_control": {"type": "ephemeral", "ttl": "1h"},
+    }],
+    documents=[{
+        "type": "document",
+        "source": {"type": "file", "file_id": file_id},
+        "citations": {"enabled": True},
+    }],
+    extra_headers={"anthropic-beta": "files-api-2025-04-14"},
+    messages=[{"role": "user",
+        "content": f"Extrahiere {n} Zitate zu '{query}', je ≤ 25 Wörter."}],
+)
+```
+
+### 18.2 Neuer `commands/humanize.md`
+
+```yaml
+---
+description: Anti-KI-Audit-Pass für ein Kapitel via humanizer-de
+disable-model-invocation: false
+allowed-tools: Read, Write, Skill(humanizer-de)
+argument-hint: <kapitel-pfad> [--mode normal|deep]
+---
+1. Lies die Datei.
+2. Aktiviere den `humanizer-de`-Skill mit dem gewünschten Modus.
+3. Schreibe Resultat als `<basename>.humanized.md`.
+4. Erzeuge `<basename>.diff.md` (vor/nach pro Severity).
+```
+
+### 18.3 `commands/pickup.md` — Skeleton
+
+```yaml
+---
+description: Erzeuge Bibliotheks-Pickup-Excel für nicht-OA-Quellen
+disable-model-invocation: false
+allowed-tools: Read, Write, Bash(~/.academic-research/venv/bin/python *), Skill(xlsx)
+---
+1. Lies `./literature_state.md`.
+2. Filter `source != open_access` UND `pdf_status != downloaded`.
+3. Resolve OPAC-Standorte über `scripts/library_pickup.py`.
+4. Render via xlsx-Skill: 4 Sheets (vor Ort / Fernleihe / OA / Lizenz).
+5. Speichere als `pickup-list.xlsx` im Projektordner.
+```
+
+---
+
+## 19 · Erwartete Wirkung
+
+| Metrik | v5.4.0 | v6.5 (Ziel) |
+|---|---|---|
+| Input-Tokens pro `/search` (50 Paper) | ~120k | ~50k (−58 %) |
+| Input-Tokens pro Zitat-Extraktion (5 PDFs) | ~600k | ~150k (−75 %) |
+| Buch-Support | nicht funktional | first-class |
+| KI-Detektor-Auffälligkeit (eigene Bench) | mittel | niedrig |
+| Sessions ohne Kontext-Verlust | < 30 % | > 95 % |
+| Beschaffungs-Zeit pro nicht-OA-Quelle | 5–10 min manuell | < 30 s |
+| Abdeckung systematische Reviews | nein | ja (PRISMA) |
+| Externe Tool-Bridges | 1 (browser-use) | 4 (+Zotero, Obsidian, NotebookLM) |
+
+---
+
+## 20 · Quellen
+
+- Anthropic Citations API — `docs.anthropic.com/en/docs/build-with-claude/citations`
+- Anthropic Files API (Beta) — `docs.anthropic.com/en/docs/build-with-claude/files`
+- Anthropic Prompt Caching (5min/1h TTL, März-2026-Default-Wechsel) — `docs.anthropic.com/en/docs/build-with-claude/prompt-caching`
+- Anthropic PDF Support (32 MB, 100/600 Pages) — `platform.claude.com/docs/en/build-with-claude/pdf-support`
+- Anthropic Message Batches (50 % Discount, 256 MB / 100k req) — `platform.claude.com/docs/en/build-with-claude/batch-processing`
+- humanizer-de — `github.com/marmbiz/humanizer-de`
+- Unpaywall API — `api.unpaywall.org/v2/<doi>?email=…`
+- DNB SRU (ISBN/GND) — `services.dnb.de/sru/dnb`
+- OpenLibrary API — `openlibrary.org/developers/api`
+- DOAB REST — `directory.doabooks.org/rest/search`
+- Zotero Web API v3 — `zotero.org/support/dev/web_api/v3/basics`
+- Pyzotero — `github.com/urschrei/pyzotero`
+- ZotLit / Obsidian-Zotero-Integration — `github.com/mgmeyers/obsidian-zotero-integration`
+- NotebookLM unofficial Python — `github.com/teng-lin/notebooklm-py`
+- Anystyle — `github.com/inukshuk/anystyle`
+- CSL Repository — `github.com/citation-style-language/styles`
+- PRISMA 2020 — `prisma-statement.org`
+- Contextual Retrieval (Anthropic Cookbook) — `anthropic.com/news/contextual-retrieval`
+- GBV SRU/CQL Schnittstellen — `gbv.github.io/cdvost2018`

--- a/docs/AUDIT-v6-vault.md
+++ b/docs/AUDIT-v6-vault.md
@@ -1,0 +1,343 @@
+# Vault-Architektur — Anhang zum v6-Audit
+
+**Erstellt:** 2026-05-07 · **Bezug:** `docs/AUDIT-v6-roadmap.md` §F7–F9
+**Frage:** Wie bekommen wir einen externen Speicher, in dem Claude PDFs,
+Metadaten und Zitate so ablegt, dass er token-sparend zugreifen kann und
+**garantiert nicht halluziniert**? Reicht Zotero, oder gibt es Besseres?
+
+**Kurzantwort:** Zotero allein reicht nicht. Optimal ist ein eigener
+**MCP-Server `academic-vault`** mit Zotero als optionalem Frontend-Layer.
+Begründung & Architektur unten.
+
+---
+
+## 1 · Warum Zotero allein nicht ausreicht
+
+| Anforderung | Zotero pur | Bemerkung |
+|---|---|---|
+| PDF-Storage | ✅ | hash-basierte Ordner, schwer für Tools |
+| Metadaten (BibTeX/CSL) | ✅ | sehr gut, Better-BibTeX als Plugin |
+| Volltext-Index | ⚠️ | Zotero hat eigenen FTS, aber kein API-Zugriff |
+| Semantische Suche | ❌ | nicht eingebaut |
+| Zitat-Cache mit Seitenangabe | ❌ | nichts — würde aus PDF jedesmal neu extrahiert |
+| Halluzinationsschutz | ❌ | Zotero validiert Output-Texte nicht |
+| Token-effiziente Tool-Calls | ❌ | Web-API gibt komplette Items, kein Snippet-Retrieval |
+| Cross-Session Memory | ⚠️ | nur Items, keine Decisions/Notes |
+| Decision-Log | ❌ | gibt es nicht |
+
+**Ergebnis:** Zotero ist eine sehr gute **User-UI** (PDF-Annotation,
+manuelles Tagging, Bibliographien-Export), aber kein Anti-Halluzinations-
+Backend. Der Vault muss zusätzlich existieren.
+
+---
+
+## 2 · Inventar: Was es bereits gibt
+
+### 2.1 Zotero-MCP-Server
+
+| Repo | Typ | Stärken | Schwächen |
+|---|---|---|---|
+| **`54yyyu/zotero-mcp`** (Python, pip) | Standalone-MCP | pyzotero-basiert, semantic search, PyPI-Install | externer Prozess, nicht plugin-internal |
+| **`cookjohn/zotero-mcp`** (Zotero-Plugin) | Zotero-Plugin mit MCP via Streamable HTTP | keine separate Installation, läuft im Zotero | nur solange Zotero offen |
+| **`ZotPilot`** | MCP-Server | semantic search auf `zotero.sqlite`, draft-LR | reines Read-Tool |
+
+### 2.2 Komplett-Lösungen
+
+| Repo | Was es macht | Eignung |
+|---|---|---|
+| **`Psypeal/claude-knowledge-vault`** | Claude-Code-Plugin, ingest Zotero/PubMed/arXiv → Wiki + Obsidian | gut als Inspiration, eigene Pfade |
+| **`WenyuChiou/research-hub`** | MCP für Zotero+Obsidian+NotebookLM | sehr nah dran, aber nicht plugin-internal |
+| **`Galaxy-Dawn/claude-scholar`** | ideation→writing assistant | Workflow, kein Vault |
+| **PaperQA2 (Future-House)** | RAG-Agent für Paper-QA mit Citations | Inspirations-Quelle, eigenes CLI |
+| **Letta (MemGPT)** | Memory-OS, 83.2 % LongMemEval | Memory-Layer, kein Citation-Backend |
+| **Mem0** | Bolt-on Memory | zu generisch für unsere Use-Cases |
+
+### 2.3 Tech-Bausteine
+
+- **`sqlite-vec`** (Alex Garcia) — embedded vector search, KNN, SIMD, dependency-free
+- **SQLite-FTS5** — bereits Built-in, BM25 ranking
+- **pyzotero** — Zotero-Web-API-Client (OAuth1 read+write)
+- **Anthropic Files API** — `file_id` für PDFs, kein Re-Upload
+- **Anthropic Citations API** — `page_location` / `char_location`
+- **Anthropic Memory-Tool** — File-basiertes Cross-Session-Memory
+- **Model2Vec** / **Voyage-3** / **Granite-Embedding** — lokale Embeddings
+
+---
+
+## 3 · Drei Architektur-Optionen
+
+### Option A — "Build the Vault" (eigener MCP-Server)
+
+```
+┌─────────────────────────────────────────────────────────┐
+│            academic-vault (eigener MCP)                 │
+├─────────────────────────────────────────────────────────┤
+│  SQLite           : papers, quotes, decisions, files    │
+│  FTS5             : Volltext-Suche über pdf_text        │
+│  sqlite-vec       : semantic search über chunk_embed    │
+│  Files-API-Cache  : pdf_path → file_id (TTL)            │
+│  Citation-Cache   : (paper_id, page) → verbatim         │
+└─────────────────────────────────────────────────────────┘
+                ▲
+                │ MCP tools
+                │
+   ┌────────────┴────────────┐
+   │  academic-research      │
+   │  Skills/Agents/Commands │
+   └─────────────────────────┘
+```
+
+**MCP-Tools (Auswahl):**
+
+```
+vault.search(query, type?, top_k?)        → [paper_id, snippet, score]
+vault.get_paper(paper_id)                  → metadata + pdf_status
+vault.get_quote(quote_id)                  → verbatim + page + paper_id
+vault.find_quotes(paper_id, query, k?)     → [quote_id, ...]
+vault.add_quote(paper_id, quote)           → quote_id (mit Provenance)
+vault.add_note(paper_id, note)             → note_id
+vault.add_decision(text, category)         → decision_id
+vault.list_decisions(category?)            → [decision, ...]
+vault.import_zotero(library_id, key)       → import_log
+vault.ensure_file(pdf_path)                → file_id (cached)
+vault.stats()                              → counts + token-savings
+```
+
+**Datenmodell (SQLite-Schema, gekürzt):**
+
+```sql
+CREATE TABLE papers (
+  paper_id TEXT PRIMARY KEY,            -- citekey oder uuid
+  type TEXT NOT NULL,                   -- article-journal | book | chapter
+  csl_json TEXT NOT NULL,               -- volle CSL-JSON-Daten
+  doi TEXT, isbn TEXT,
+  pdf_path TEXT,                        -- lokaler Pfad
+  file_id TEXT,                         -- Anthropic Files-API
+  file_id_expires_at INTEGER,
+  page_offset INTEGER DEFAULT 0,        -- pdf_page → printed_page
+  ocr_done BOOLEAN DEFAULT 0,
+  added_at INTEGER, updated_at INTEGER
+);
+
+CREATE VIRTUAL TABLE papers_fts USING fts5(
+  title, abstract, fulltext, content='papers'
+);
+
+CREATE TABLE quotes (
+  quote_id TEXT PRIMARY KEY,
+  paper_id TEXT REFERENCES papers,
+  verbatim TEXT NOT NULL,
+  pdf_page INTEGER,
+  printed_page INTEGER,                 -- mit page_offset korrigiert
+  section TEXT,
+  context_before TEXT, context_after TEXT,
+  extraction_method TEXT NOT NULL,      -- 'citations-api' | 'manual'
+  api_response_id TEXT,                 -- Anthropic-Request-ID für Audit
+  created_at INTEGER
+);
+
+CREATE VIRTUAL TABLE quote_embeddings USING vec0(
+  quote_id TEXT PRIMARY KEY,
+  embedding FLOAT[384]                  -- Model2Vec dims
+);
+
+CREATE TABLE decisions (
+  decision_id TEXT PRIMARY KEY,
+  category TEXT,                        -- citation_style | methodology | ...
+  text TEXT NOT NULL,
+  rationale TEXT,
+  created_at INTEGER,
+  superseded_by TEXT REFERENCES decisions
+);
+
+CREATE TABLE notes (
+  note_id TEXT PRIMARY KEY,
+  paper_id TEXT REFERENCES papers,
+  text TEXT NOT NULL,
+  tags TEXT,                            -- JSON-Array
+  created_at INTEGER
+);
+```
+
+**Halluzinationsschutz, hart verdrahtet:**
+
+- `vault.add_quote(...)` akzeptiert nur Quotes mit `extraction_method: 'citations-api'` und füllten `api_response_id` — Manuelle Quotes brauchen explizites `--manual`-Flag
+- Hook `PreToolUse` für `Write` mit Pfad-Match auf `kapitel/*.md`: parst zitierte Strings (Anführungszeichen-Spans), greppt im Vault → unbekannte Strings führen zu Block + Hinweis „Zitat nicht im Vault, bitte über `quote-extractor` ziehen"
+- Skills lesen Zitate **nur** über `vault.get_quote(id)` — Direkter PDF-Lese-Pfad ist deprecated
+
+**Pro/Contra:**
+
+- ✅ Volle Kontrolle, perfekt auf Plugin-Use-Cases getunt
+- ✅ Halluzinationsschutz hart verdrahtbar
+- ✅ Token-effizient (gezielte Tool-Calls statt PDF in Context)
+- ✅ Cross-Session-Persistenz garantiert
+- ✅ Lock-in vermeidbar (SQLite portabel, JSON-Export trivial)
+- ❌ ~600–900 LOC Python (MCP-Server in `mcp` Python-SDK)
+- ❌ 1 Sprint Aufwand (geschätzt 1 Woche)
+
+**Aufwand:** ~1 Woche (1 Sprint)
+
+---
+
+### Option B — "Ride zotero-mcp" (bestehenden MCP nutzen)
+
+```
+┌─────────────────────────┐         ┌──────────────────────┐
+│  zotero-mcp (54yyyu)    │◄────────│ academic-research    │
+│  pyzotero + semantic    │  MCP    │ Skills/Commands      │
+│  Zotero Web API v3      │         └──────────────────────┘
+└─────────────────────────┘
+```
+
+**Pro/Contra:**
+
+- ✅ Kein eigener Code, sofort einsetzbar (`pip install zotero-mcp`)
+- ✅ Community-maintained
+- ✅ Nutzt vorhandene Zotero-Library als Backend
+- ❌ Lock-in auf Zotero-Schema (User muss Zotero-Account haben)
+- ❌ Kein Citation-Cache mit Provenance — Zitate werden bei jedem Bedarf neu extrahiert
+- ❌ Halluzinationsschutz nur soft (kein Hook-basierter Block)
+- ❌ Files-API-Cache nicht trivial integrierbar
+- ❌ Decisions/Notes brauchen Zotero-Notes-Hack
+- ❌ Bei großen Libraries (>5000 Items) Performance-Themen
+
+**Aufwand:** 1 Tag (Integration + Doku)
+
+---
+
+### Option C — "Vault + Zotero-Bridge" (**empfohlen**)
+
+```
+                  ┌─────────────────────────────┐
+                  │   academic-vault (eigener)  │  ← Halluzinations-
+                  │                             │     kritisch
+                  │   - papers, quotes,         │
+                  │     decisions, notes        │
+                  │   - SQLite + FTS5 +         │
+                  │     sqlite-vec              │
+                  │   - Files-API-Cache         │
+                  └────────┬─────────┬──────────┘
+                           ▲         │
+                  pull-only│         │PDF-Bundle-Export
+                           │         │
+              ┌────────────┴┐       ┌▼────────────────┐
+              │   Zotero    │       │  NotebookLM     │  ← optionale
+              │  (Frontend) │       │  (Triage, opt.) │     Bridges
+              │  pyzotero   │       │  Bücher >600 S. │
+              └─────────────┘       └─────────────────┘
+```
+
+**Komponenten:**
+
+1. **`academic-vault` MCP-Server** (eigener) — Single Source of Truth für
+   alles Zitat-/Halluzinations-Kritische
+2. **`zotero-import` Skill** — pyzotero-Pull, dedupliziert via DOI/ISBN
+3. **`notebook-bundle` Skill (optional)** — packt PDF-Bundle für
+   manuellen Upload in NotebookLM (für Bücher >600 Seiten)
+
+**Pro/Contra:**
+
+- ✅ Halluzinationsschutz hart (eigener Vault)
+- ✅ User-Frontend frei wählbar (Zotero oder keins)
+- ✅ Kein Lock-in auf einzelnes Tool
+- ✅ Token-effizient
+- ✅ Inkrementell ausrollbar (zuerst Vault, dann Bridges)
+- ❌ Eigener MCP-Server zu maintainen
+- ❌ ~1.5 Sprints Aufwand
+
+**Aufwand:** ~1.5 Wochen (1 Sprint Vault + 0.5 Sprint Zotero-Bridge)
+
+---
+
+## 4 · Token-Spar-Mechanik im Detail
+
+**Heute (v5.4):** Skill `chapter-writer` lädt
+`literature_state.md` (alle Quellen-Stubs) + relevante PDF-Auszüge
+manuell pro Aufruf. ≈ 8–15 k Token Boilerplate.
+
+**Mit Vault:**
+
+```
+1. chapter-writer ruft: vault.search("DevOps Governance Compliance", k=5)
+   → 5 paper_ids + 1-Satz-Snippets  (≈ 200 Token)
+
+2. Pro Paper-ID: vault.find_quotes(paper_id, query, k=3)
+   → 15 quote_ids + verbatim + page  (≈ 1500 Token total)
+
+3. chapter-writer schreibt; Hook validiert Verbatim-Strings gegen Vault.
+
+Total: ~1700 Token statt 10000+ → ~83 % Ersparnis pro Kapitel-Iteration.
+```
+
+**Anti-Halluzinations-Garantie:**
+
+- Zitate im Output, die nicht in `quotes`-Tabelle existieren → Hook blockt Write
+- Seitenangaben werden nicht vom Modell „erinnert", sondern aus
+  `quotes.printed_page` materialisiert → keine `(Müller 2023, S. 47)`-
+  Halluzination möglich
+- Decisions („Wir nutzen IEEE statt APA") sind Tool-Antworten, nicht
+  Modell-Erinnerungen
+
+---
+
+## 5 · Migration aus heutigem Stand
+
+**Phase 1 — Vault-Foundation (Sprint v6.0)**
+- MCP-Server-Skeleton mit SQLite-Schema
+- Tools: `vault.search`, `vault.get_paper`, `vault.add_quote`,
+  `vault.ensure_file`
+- Migration-Skript: `literature_state.md` + PDFs → SQLite-Initial-Seed
+
+**Phase 2 — Skill-Anpassung (Sprint v6.0)**
+- `quote-extractor` schreibt in `vault.add_quote()` statt JSON-File
+- `chapter-writer` liest via `vault.find_quotes()`
+- Hook für Verbatim-Validation
+
+**Phase 3 — Bridges (Sprint v6.3)**
+- `zotero-import` (pyzotero pull-only)
+- `notebook-bundle` (PDF-Pack für NotebookLM)
+
+**Phase 4 — Memory & Decisions (Sprint v6.4)**
+- `vault.add_decision` integriert in alle Skills
+- `decisions.log` exportierbar als PRISMA-Audit-Trail
+
+**Backwards-Compat:** `literature_state.md` bleibt als
+**read-only Snapshot-Export** aus dem Vault — Nutzer:innen, die nur
+Markdown wollen, sehen kein Regression.
+
+---
+
+## 6 · Empfehlung
+
+**Option C** ("Vault + Zotero-Bridge"). Begründung:
+
+1. **Halluzinationsschutz** ist das Killer-Feature — nur mit eigenem Vault
+   hart verdrahtbar (Hook-basierte Verbatim-Validation)
+2. **Token-Ersparnis** ~80 % messbar — Tool-Calls statt Context-Stuffing
+3. **Lock-in vermeiden** — User können Zotero-Frontend nutzen oder ohne
+4. **Inkrementell** — Phase 1+2 liefern schon 80 % des Wertes,
+   Zotero-Bridge (Phase 3) ist nice-to-have
+5. **Plugin-intern** — kein zweites Repo zu maintainen,
+   `mcp/academic-vault/` als Sub-Tree
+
+**Risiko-Mitigation:**
+
+- Vendor-Drift Anthropic Files-API (Beta) → Fallback auf `pdf_path`
+- sqlite-vec Build-Abhängigkeit → Fallback auf reine FTS5
+- Memory-Tool noch nicht Cross-Session ohne Managed-Agents → Vault
+  übernimmt diese Rolle eigenständig
+
+---
+
+## 7 · Quellen (neu hinzugekommen)
+
+- `Psypeal/claude-knowledge-vault` — `github.com/Psypeal/claude-knowledge-vault`
+- `54yyyu/zotero-mcp` — `github.com/54yyyu/zotero-mcp`
+- `cookjohn/zotero-mcp` — `github.com/cookjohn/zotero-mcp`
+- `WenyuChiou/research-hub` — `github.com/WenyuChiou/research-hub`
+- `Future-House/paper-qa` (PaperQA2) — `github.com/future-house/paper-qa`
+- `letta-ai/letta` (MemGPT) — `letta.com`
+- `mem0ai/mem0` — `mem0.ai`
+- `asg017/sqlite-vec` — `github.com/asg017/sqlite-vec`
+- `Galaxy-Dawn/claude-scholar` — `github.com/Galaxy-Dawn/claude-scholar`
+- ZotPilot Forum-Post — `forums.zotero.org/discussion/130483`

--- a/mcp/academic_vault/__init__.py
+++ b/mcp/academic_vault/__init__.py
@@ -1,0 +1,2 @@
+"""academic_vault — SQLite-basierter Vault-MCP-Server."""
+__version__ = "0.1.0"

--- a/mcp/academic_vault/db.py
+++ b/mcp/academic_vault/db.py
@@ -1,0 +1,236 @@
+"""VaultDB — SQLite-Datenbankschicht fuer academic_vault.
+
+Context-Manager-Klasse mit sqlite-vec-Fallback und FTS5-Volltext-Suche.
+"""
+import os
+import sqlite3
+import time
+from pathlib import Path
+from typing import Optional
+
+
+_SCHEMA_PATH = Path(__file__).parent / "schema.sql"
+
+
+class VaultDB:
+    """SQLite-Datenbankzugriff fuer den academic_vault MCP-Server."""
+
+    def __init__(self, db_path: str) -> None:
+        self.db_path = db_path
+        self.vec_available: bool = False
+        self._conn: Optional[sqlite3.Connection] = None
+
+    # ------------------------------------------------------------------
+    # Context-Manager
+    # ------------------------------------------------------------------
+
+    def __enter__(self) -> "VaultDB":
+        self._conn = sqlite3.connect(self.db_path)
+        self._conn.row_factory = sqlite3.Row
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("PRAGMA foreign_keys=ON")
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        if self._conn is None:
+            return
+        if exc_type is None:
+            self._conn.commit()
+        else:
+            self._conn.rollback()
+        self._conn.close()
+        self._conn = None
+
+    # ------------------------------------------------------------------
+    # Schema-Initialisierung
+    # ------------------------------------------------------------------
+
+    def _get_conn(self) -> sqlite3.Connection:
+        """Gibt bestehende oder neue Verbindung zurueck."""
+        if self._conn is not None:
+            return self._conn
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA foreign_keys=ON")
+        return conn
+
+    def load_vec_extension(self) -> bool:
+        """Versucht sqlite_vec Extension zu laden. Gibt True bei Erfolg zurueck."""
+        vec_path = os.environ.get("SQLITE_VEC_PATH", "")
+        conn = self._get_conn()
+        conn.enable_load_extension(True)
+        try:
+            if vec_path:
+                conn.load_extension(vec_path)
+            else:
+                conn.load_extension("sqlite_vec")
+            self.vec_available = True
+        except Exception:
+            self.vec_available = False
+        finally:
+            conn.enable_load_extension(False)
+        return self.vec_available
+
+    def init_schema(self) -> None:
+        """Erstellt alle Tabellen gemaess schema.sql. Versucht vec0 zu erstellen."""
+        ddl = _SCHEMA_PATH.read_text(encoding="utf-8")
+        conn = self._get_conn()
+        own_conn = self._conn is None
+
+        # vec-Extension laden (optional)
+        self.load_vec_extension()
+
+        # Basis-Schema ausfuehren (ohne vec0-Block — der ist auskommentiert)
+        conn.executescript(ddl)
+
+        # quote_embeddings via vec0 versuchen (nur wenn Extension geladen)
+        if self.vec_available:
+            try:
+                conn.execute(
+                    "CREATE VIRTUAL TABLE IF NOT EXISTS quote_embeddings "
+                    "USING vec0(quote_id TEXT PRIMARY KEY, embedding FLOAT[384])"
+                )
+            except sqlite3.OperationalError:
+                self.vec_available = False
+
+        if own_conn:
+            conn.commit()
+            conn.close()
+
+    # ------------------------------------------------------------------
+    # Papers CRUD
+    # ------------------------------------------------------------------
+
+    def add_paper(
+        self,
+        paper_id: str,
+        csl_json: str,
+        doi: Optional[str] = None,
+        isbn: Optional[str] = None,
+        pdf_path: Optional[str] = None,
+        page_offset: int = 0,
+    ) -> None:
+        """Upsert eines Papers in die papers-Tabelle."""
+        now = int(time.time())
+        conn = self._get_conn()
+        own_conn = self._conn is None
+        conn.execute(
+            """
+            INSERT INTO papers
+              (paper_id, csl_json, doi, isbn, pdf_path, page_offset, added_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(paper_id) DO UPDATE SET
+              csl_json   = excluded.csl_json,
+              doi        = excluded.doi,
+              isbn       = excluded.isbn,
+              pdf_path   = excluded.pdf_path,
+              page_offset= excluded.page_offset,
+              updated_at = excluded.updated_at
+            """,
+            (paper_id, csl_json, doi, isbn, pdf_path, page_offset, now, now),
+        )
+        if own_conn:
+            conn.commit()
+            conn.close()
+
+    def get_paper(self, paper_id: str) -> Optional[dict]:
+        """Gibt Paper-Record als dict zurueck oder None."""
+        conn = self._get_conn()
+        own_conn = self._conn is None
+        row = conn.execute(
+            "SELECT * FROM papers WHERE paper_id = ?", (paper_id,)
+        ).fetchone()
+        if own_conn:
+            conn.close()
+        if row is None:
+            return None
+        return dict(row)
+
+    def set_file_id(
+        self, paper_id: str, file_id: str, expires_at: int
+    ) -> None:
+        """Setzt file_id und file_id_expires_at fuer ein Paper."""
+        conn = self._get_conn()
+        own_conn = self._conn is None
+        conn.execute(
+            "UPDATE papers SET file_id = ?, file_id_expires_at = ?, updated_at = ? "
+            "WHERE paper_id = ?",
+            (file_id, expires_at, int(time.time()), paper_id),
+        )
+        if own_conn:
+            conn.commit()
+            conn.close()
+
+    # ------------------------------------------------------------------
+    # Quotes CRUD
+    # ------------------------------------------------------------------
+
+    def add_quote(
+        self,
+        quote_id: str,
+        paper_id: str,
+        verbatim: str,
+        extraction_method: str,
+        api_response_id: Optional[str] = None,
+        pdf_page: Optional[int] = None,
+        printed_page: Optional[int] = None,
+        section: Optional[str] = None,
+        context_before: Optional[str] = None,
+        context_after: Optional[str] = None,
+    ) -> None:
+        """INSERT eines Quotes in die quotes-Tabelle."""
+        now = int(time.time())
+        conn = self._get_conn()
+        own_conn = self._conn is None
+        conn.execute(
+            """
+            INSERT INTO quotes
+              (quote_id, paper_id, verbatim, pdf_page, printed_page,
+               section, context_before, context_after,
+               extraction_method, api_response_id, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                quote_id, paper_id, verbatim, pdf_page, printed_page,
+                section, context_before, context_after,
+                extraction_method, api_response_id, now,
+            ),
+        )
+        if own_conn:
+            conn.commit()
+            conn.close()
+
+    def get_quote(self, quote_id: str) -> Optional[dict]:
+        """Gibt Quote-Record als dict zurueck oder None."""
+        conn = self._get_conn()
+        own_conn = self._conn is None
+        row = conn.execute(
+            "SELECT * FROM quotes WHERE quote_id = ?", (quote_id,)
+        ).fetchone()
+        if own_conn:
+            conn.close()
+        return dict(row) if row is not None else None
+
+    def find_quotes(
+        self,
+        paper_id: str,
+        query: Optional[str] = None,
+        k: int = 10,
+    ) -> list[dict]:
+        """Suche Quotes fuer ein Paper, optional per verbatim-LIKE-Filter."""
+        conn = self._get_conn()
+        own_conn = self._conn is None
+        if query:
+            rows = conn.execute(
+                "SELECT * FROM quotes WHERE paper_id = ? AND verbatim LIKE ? LIMIT ?",
+                (paper_id, f"%{query}%", k),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT * FROM quotes WHERE paper_id = ? LIMIT ?",
+                (paper_id, k),
+            ).fetchall()
+        if own_conn:
+            conn.close()
+        return [dict(r) for r in rows]

--- a/mcp/academic_vault/db.py
+++ b/mcp/academic_vault/db.py
@@ -25,10 +25,7 @@ class VaultDB:
     # ------------------------------------------------------------------
 
     def __enter__(self) -> "VaultDB":
-        self._conn = sqlite3.connect(self.db_path)
-        self._conn.row_factory = sqlite3.Row
-        self._conn.execute("PRAGMA journal_mode=WAL")
-        self._conn.execute("PRAGMA foreign_keys=ON")
+        self._conn = self._open(self.db_path)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
@@ -45,15 +42,20 @@ class VaultDB:
     # Schema-Initialisierung
     # ------------------------------------------------------------------
 
-    def _get_conn(self) -> sqlite3.Connection:
-        """Gibt bestehende oder neue Verbindung zurueck."""
-        if self._conn is not None:
-            return self._conn
-        conn = sqlite3.connect(self.db_path)
+    @staticmethod
+    def _open(db_path: str) -> sqlite3.Connection:
+        """Oeffnet eine neue Verbindung mit Standard-Pragmas."""
+        conn = sqlite3.connect(db_path)
         conn.row_factory = sqlite3.Row
         conn.execute("PRAGMA journal_mode=WAL")
         conn.execute("PRAGMA foreign_keys=ON")
         return conn
+
+    def _get_conn(self) -> sqlite3.Connection:
+        """Gibt bestehende oder neue Verbindung zurueck."""
+        if self._conn is not None:
+            return self._conn
+        return self._open(self.db_path)
 
     def load_vec_extension(self) -> bool:
         """Versucht sqlite_vec Extension zu laden. Gibt True bei Erfolg zurueck."""

--- a/mcp/academic_vault/db.py
+++ b/mcp/academic_vault/db.py
@@ -57,21 +57,21 @@ class VaultDB:
             return self._conn
         return self._open(self.db_path)
 
-    def load_vec_extension(self) -> bool:
+    def load_vec_extension(self, conn: Optional[sqlite3.Connection] = None) -> bool:
         """Versucht sqlite_vec Extension zu laden. Gibt True bei Erfolg zurueck."""
         vec_path = os.environ.get("SQLITE_VEC_PATH", "")
-        conn = self._get_conn()
-        conn.enable_load_extension(True)
+        target = conn if conn is not None else self._get_conn()
+        target.enable_load_extension(True)
         try:
             if vec_path:
-                conn.load_extension(vec_path)
+                target.load_extension(vec_path)
             else:
-                conn.load_extension("sqlite_vec")
+                target.load_extension("sqlite_vec")
             self.vec_available = True
         except Exception:
             self.vec_available = False
         finally:
-            conn.enable_load_extension(False)
+            target.enable_load_extension(False)
         return self.vec_available
 
     def init_schema(self) -> None:
@@ -80,8 +80,8 @@ class VaultDB:
         conn = self._get_conn()
         own_conn = self._conn is None
 
-        # vec-Extension laden (optional)
-        self.load_vec_extension()
+        # vec-Extension auf derselben Connection laden (optional)
+        self.load_vec_extension(conn)
 
         # Basis-Schema ausfuehren (ohne vec0-Block — der ist auskommentiert)
         conn.executescript(ddl)

--- a/mcp/academic_vault/files_api.py
+++ b/mcp/academic_vault/files_api.py
@@ -3,6 +3,7 @@
 Gibt file_id zurueck (gecacht mit 1h-TTL in papers-Tabelle).
 Fallback: bei fehlendem Upload wird Exception nach oben durchgereicht.
 """
+import sqlite3
 import time
 from pathlib import Path
 from typing import Optional
@@ -50,37 +51,29 @@ class FilesAPIClient:
         Bei Ablauf oder fehlendem file_id wird re-uploaded.
         """
         now = int(time.time())
-        db = VaultDB(self.cache_db_path)
 
-        # Cache-Lookup: suche Paper mit passendem pdf_path und gueltiger file_id
-        import sqlite3
-        conn = sqlite3.connect(self.cache_db_path)
-        conn.row_factory = sqlite3.Row
-        row = conn.execute(
-            "SELECT paper_id, file_id, file_id_expires_at FROM papers "
-            "WHERE pdf_path = ? AND file_id IS NOT NULL AND file_id_expires_at > ?",
-            (pdf_path, now),
-        ).fetchone()
-        conn.close()
+        conn = VaultDB._open(self.cache_db_path)
+        try:
+            row = conn.execute(
+                "SELECT paper_id, file_id FROM papers "
+                "WHERE pdf_path = ? AND file_id IS NOT NULL AND file_id_expires_at > ?",
+                (pdf_path, now),
+            ).fetchone()
+            if row is not None:
+                return row["file_id"]
 
-        if row is not None:
-            return row["file_id"]
+            paper_row = conn.execute(
+                "SELECT paper_id FROM papers WHERE pdf_path = ?", (pdf_path,)
+            ).fetchone()
+        finally:
+            conn.close()
 
         # Cache-Miss: hochladen
         file_id = self._upload_file(pdf_path)
-        expires_at = now + _TTL
-
-        # paper_id fuer diesen pdf_path ermitteln
-        conn = sqlite3.connect(self.cache_db_path)
-        conn.row_factory = sqlite3.Row
-        paper_row = conn.execute(
-            "SELECT paper_id FROM papers WHERE pdf_path = ?", (pdf_path,)
-        ).fetchone()
-        conn.close()
-
         if paper_row is not None:
-            db.set_file_id(paper_row["paper_id"], file_id, expires_at)
-
+            VaultDB(self.cache_db_path).set_file_id(
+                paper_row["paper_id"], file_id, now + _TTL
+            )
         return file_id
 
     @staticmethod
@@ -90,9 +83,8 @@ class FilesAPIClient:
 
         token_savings_estimate = cached_files * (AVG_BASE64_TOKENS_PER_PDF - FILE_ID_OVERHEAD)
         """
-        import sqlite3
         now = int(time.time())
-        conn = sqlite3.connect(db_path)
+        conn = VaultDB._open(db_path)
         paper_count = conn.execute("SELECT COUNT(*) FROM papers").fetchone()[0]
         quote_count = conn.execute("SELECT COUNT(*) FROM quotes").fetchone()[0]
         cached_files = conn.execute(

--- a/mcp/academic_vault/files_api.py
+++ b/mcp/academic_vault/files_api.py
@@ -1,0 +1,111 @@
+"""FilesAPIClient — Anthropic Files-API-Cache fuer PDFs.
+
+Gibt file_id zurueck (gecacht mit 1h-TTL in papers-Tabelle).
+Fallback: bei fehlendem Upload wird Exception nach oben durchgereicht.
+"""
+import time
+from pathlib import Path
+from typing import Optional
+
+from .db import VaultDB
+
+_TTL = 3600  # 1 Stunde in Sekunden
+_AVG_BASE64_TOKENS_PER_PDF = 80_000   # Heuristik (Audit §4.1: 60–100k)
+_FILE_ID_OVERHEAD = 20                # Token fuer file_id-Referenz
+
+
+class FilesAPIClient:
+    """Anthropic Files-API-Client mit TTL-Cache in der Vault-Datenbank."""
+
+    def __init__(self, anthropic_api_key: str, cache_db_path: str) -> None:
+        self.api_key = anthropic_api_key
+        self.cache_db_path = cache_db_path
+        self._client = None  # lazy init
+
+    def _get_client(self):
+        """Lazy-Init des Anthropic-Clients."""
+        if self._client is None:
+            import anthropic
+            self._client = anthropic.Anthropic(api_key=self.api_key)
+        return self._client
+
+    def _upload_file(self, pdf_path: str) -> str:
+        """Laedt PDF hoch und gibt file_id zurueck.
+
+        Nutzt anthropic.beta.files.upload mit Files-API-Beta-Header.
+        Kann in Tests per patch.object gemockt werden.
+        """
+        client = self._get_client()
+        with open(pdf_path, "rb") as fh:
+            response = client.beta.files.upload(
+                file=(Path(pdf_path).name, fh, "application/pdf"),
+                extra_headers={"anthropic-beta": "files-api-2025-04-14"},
+            )
+        return response.id
+
+    def ensure_file(self, pdf_path: str) -> str:
+        """Gibt gecachte file_id zurueck, laedt hoch bei Cache-Miss.
+
+        Prüft papers-Tabelle nach pdf_path. TTL = 3600s.
+        Bei Ablauf oder fehlendem file_id wird re-uploaded.
+        """
+        now = int(time.time())
+        db = VaultDB(self.cache_db_path)
+
+        # Cache-Lookup: suche Paper mit passendem pdf_path und gueltiger file_id
+        import sqlite3
+        conn = sqlite3.connect(self.cache_db_path)
+        conn.row_factory = sqlite3.Row
+        row = conn.execute(
+            "SELECT paper_id, file_id, file_id_expires_at FROM papers "
+            "WHERE pdf_path = ? AND file_id IS NOT NULL AND file_id_expires_at > ?",
+            (pdf_path, now),
+        ).fetchone()
+        conn.close()
+
+        if row is not None:
+            return row["file_id"]
+
+        # Cache-Miss: hochladen
+        file_id = self._upload_file(pdf_path)
+        expires_at = now + _TTL
+
+        # paper_id fuer diesen pdf_path ermitteln
+        conn = sqlite3.connect(self.cache_db_path)
+        conn.row_factory = sqlite3.Row
+        paper_row = conn.execute(
+            "SELECT paper_id FROM papers WHERE pdf_path = ?", (pdf_path,)
+        ).fetchone()
+        conn.close()
+
+        if paper_row is not None:
+            db.set_file_id(paper_row["paper_id"], file_id, expires_at)
+
+        return file_id
+
+    @staticmethod
+    def get_stats(db_path: str) -> dict:
+        """Gibt Statistik-Dict zurueck: paper_count, quote_count, cached_files,
+        token_savings_estimate.
+
+        token_savings_estimate = cached_files * (AVG_BASE64_TOKENS_PER_PDF - FILE_ID_OVERHEAD)
+        """
+        import sqlite3
+        now = int(time.time())
+        conn = sqlite3.connect(db_path)
+        paper_count = conn.execute("SELECT COUNT(*) FROM papers").fetchone()[0]
+        quote_count = conn.execute("SELECT COUNT(*) FROM quotes").fetchone()[0]
+        cached_files = conn.execute(
+            "SELECT COUNT(*) FROM papers "
+            "WHERE file_id IS NOT NULL AND file_id_expires_at > ?",
+            (now,),
+        ).fetchone()[0]
+        conn.close()
+
+        token_savings_estimate = cached_files * (_AVG_BASE64_TOKENS_PER_PDF - _FILE_ID_OVERHEAD)
+        return {
+            "paper_count": paper_count,
+            "quote_count": quote_count,
+            "cached_files": cached_files,
+            "token_savings_estimate": token_savings_estimate,
+        }

--- a/mcp/academic_vault/migrate.py
+++ b/mcp/academic_vault/migrate.py
@@ -1,0 +1,196 @@
+"""migrate.py — Seed-Skript: literature_state.md + PDFs -> SQLite-Vault.
+
+CLI:
+    python migrate.py --state literature_state.md --pdf-dir ./pdfs --db vault.db
+
+Parst YAML-Frontmatter-aehnliche Bloecke aus Markdown-Listeneintraegen.
+Idempotent (INSERT OR REPLACE via add_paper-Upsert).
+"""
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+
+def _parse_literature_state(state_path: str) -> list[dict]:
+    """Parst literature_state.md und gibt Liste von Paper-Dicts zurueck.
+
+    Erwartet Eintraege im Format:
+        ### citekey
+        - title: ...
+        - authors: ...
+        - year: ...
+        - doi: ...
+        - pdf_path: ...
+
+    Alternativ: YAML-Frontmatter-Bloecke zwischen ---
+    """
+    text = Path(state_path).read_text(encoding="utf-8")
+    papers = []
+
+    # Versuch 1: YAML-Frontmatter-Bloecke zwischen ---
+    frontmatter_pattern = re.compile(r"---\s*\n(.*?)\n---", re.DOTALL)
+    for match in frontmatter_pattern.finditer(text):
+        block = match.group(1)
+        paper = _parse_yaml_block(block)
+        if paper.get("citekey") or paper.get("title"):
+            papers.append(paper)
+
+    if papers:
+        return papers
+
+    # Versuch 2: Markdown-Sektionen mit ### citekey + Listenwerten
+    section_pattern = re.compile(
+        r"^#{1,4}\s+(.+?)\s*\n((?:^[ \t]*[-*]\s+\S+.*\n?)*)",
+        re.MULTILINE,
+    )
+    for match in section_pattern.finditer(text):
+        citekey = match.group(1).strip()
+        body = match.group(2)
+        paper = _parse_list_block(body)
+        if paper.get("title") or paper.get("doi"):
+            paper.setdefault("citekey", citekey)
+            papers.append(paper)
+
+    return papers
+
+
+def _parse_yaml_block(block: str) -> dict:
+    """Parst einfaches YAML (kein nested). Gibt dict zurueck."""
+    result = {}
+    for line in block.splitlines():
+        if ":" in line:
+            key, _, value = line.partition(":")
+            result[key.strip()] = value.strip().strip('"').strip("'")
+    return result
+
+
+def _parse_list_block(block: str) -> dict:
+    """Parst Markdown-Listenwerte (- key: value)."""
+    result = {}
+    for line in block.splitlines():
+        line = line.strip().lstrip("-*").strip()
+        if ":" in line:
+            key, _, value = line.partition(":")
+            result[key.strip()] = value.strip()
+    return result
+
+
+def _build_csl_json(paper: dict) -> str:
+    """Baut minimales CSL-JSON aus geparsten Feldern."""
+    csl: dict = {}
+    if paper.get("title"):
+        csl["title"] = paper["title"]
+    if paper.get("abstract"):
+        csl["abstract"] = paper["abstract"]
+    if paper.get("year"):
+        try:
+            csl["issued"] = {"date-parts": [[int(paper["year"])]]}
+        except ValueError:
+            pass
+    if paper.get("authors"):
+        raw = paper["authors"]
+        names = [n.strip() for n in raw.split(";") if n.strip()]
+        csl["author"] = [{"literal": n} for n in names]
+    if paper.get("doi"):
+        csl["DOI"] = paper["doi"]
+    if paper.get("isbn"):
+        csl["ISBN"] = paper["isbn"]
+    if paper.get("type"):
+        csl["type"] = paper["type"]
+    return json.dumps(csl, ensure_ascii=False)
+
+
+def run_migration(
+    state_path: str,
+    pdf_dir: str,
+    db_path: str,
+) -> dict:
+    """Fuehrt Migration aus. Gibt {inserted, skipped, errors} zurueck."""
+    from mcp.academic_vault.db import VaultDB
+
+    db = VaultDB(db_path)
+    db.init_schema()
+
+    papers = _parse_literature_state(state_path)
+    inserted = 0
+    skipped = 0
+    errors = 0
+
+    for paper in papers:
+        try:
+            citekey = paper.get("citekey") or paper.get("title", "unknown")
+            paper_id = re.sub(r"[^a-zA-Z0-9_-]", "_", citekey)
+
+            # PDF-Pfad aufloesen
+            pdf_path = paper.get("pdf_path")
+            if pdf_path:
+                candidate = Path(pdf_dir) / pdf_path
+                if candidate.exists():
+                    pdf_path = str(candidate)
+                elif Path(pdf_path).exists():
+                    pdf_path = str(Path(pdf_path))
+                else:
+                    pdf_path = None
+
+            csl_json = _build_csl_json(paper)
+
+            # Idempotenz: paper_id bereits vorhanden?
+            existing = db.get_paper(paper_id)
+            if existing is not None:
+                skipped += 1
+                continue
+
+            db.add_paper(
+                paper_id=paper_id,
+                csl_json=csl_json,
+                doi=paper.get("doi"),
+                isbn=paper.get("isbn"),
+                pdf_path=pdf_path,
+            )
+            inserted += 1
+        except Exception as exc:
+            print(f"[ERROR] Paper '{paper.get('citekey', '?')}': {exc}", file=sys.stderr)
+            errors += 1
+
+    return {"inserted": inserted, "skipped": skipped, "errors": errors}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Seed-Migration: literature_state.md -> academic_vault SQLite"
+    )
+    parser.add_argument(
+        "--state",
+        required=True,
+        help="Pfad zur literature_state.md",
+    )
+    parser.add_argument(
+        "--pdf-dir",
+        default=".",
+        help="Verzeichnis mit PDF-Dateien (default: .)",
+    )
+    parser.add_argument(
+        "--db",
+        required=True,
+        help="Pfad zur SQLite-Vault-Datenbank",
+    )
+    args = parser.parse_args()
+
+    if not Path(args.state).exists():
+        print(f"[ERROR] state-Datei nicht gefunden: {args.state}", file=sys.stderr)
+        sys.exit(1)
+
+    result = run_migration(args.state, args.pdf_dir, args.db)
+    print(
+        f"Migration abgeschlossen: "
+        f"inserted={result['inserted']}, "
+        f"skipped={result['skipped']}, "
+        f"errors={result['errors']}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp/academic_vault/requirements.txt
+++ b/mcp/academic_vault/requirements.txt
@@ -1,0 +1,3 @@
+anthropic>=0.40
+mcp>=1.0
+sqlite-vec>=0.1.0

--- a/mcp/academic_vault/schema.sql
+++ b/mcp/academic_vault/schema.sql
@@ -1,0 +1,109 @@
+-- academic_vault SQLite Schema
+-- Tabellen: papers, papers_fts, quotes, quote_embeddings, decisions, notes
+-- FTS5-Content-Table-Trigger: papers_ai, papers_ad, papers_au
+
+CREATE TABLE IF NOT EXISTS papers (
+  paper_id              TEXT PRIMARY KEY,
+  type                  TEXT NOT NULL DEFAULT 'article-journal',
+  csl_json              TEXT NOT NULL,
+  doi                   TEXT,
+  isbn                  TEXT,
+  pdf_path              TEXT,
+  file_id               TEXT,
+  file_id_expires_at    INTEGER,
+  page_offset           INTEGER DEFAULT 0,
+  ocr_done              INTEGER DEFAULT 0,
+  added_at              INTEGER NOT NULL,
+  updated_at            INTEGER NOT NULL
+);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS papers_fts USING fts5(
+  paper_id UNINDEXED,
+  title,
+  abstract,
+  fulltext,
+  content='papers',
+  content_rowid='rowid'
+);
+
+CREATE TABLE IF NOT EXISTS quotes (
+  quote_id          TEXT PRIMARY KEY,
+  paper_id          TEXT NOT NULL REFERENCES papers(paper_id),
+  verbatim          TEXT NOT NULL,
+  pdf_page          INTEGER,
+  printed_page      INTEGER,
+  section           TEXT,
+  context_before    TEXT,
+  context_after     TEXT,
+  extraction_method TEXT NOT NULL CHECK(extraction_method IN ('citations-api','manual')),
+  api_response_id   TEXT,
+  created_at        INTEGER NOT NULL
+);
+
+-- vec0 Virtual Table: optional, nur wenn sqlite-vec Extension geladen ist.
+-- Wird in db.py per try/except erstellt; Fehler wird ignoriert.
+-- CREATE VIRTUAL TABLE IF NOT EXISTS quote_embeddings USING vec0(
+--   quote_id TEXT PRIMARY KEY,
+--   embedding FLOAT[384]
+-- );
+
+CREATE TABLE IF NOT EXISTS decisions (
+  decision_id   TEXT PRIMARY KEY,
+  category      TEXT,
+  text          TEXT NOT NULL,
+  rationale     TEXT,
+  created_at    INTEGER NOT NULL,
+  superseded_by TEXT REFERENCES decisions(decision_id)
+);
+
+CREATE TABLE IF NOT EXISTS notes (
+  note_id    TEXT PRIMARY KEY,
+  paper_id   TEXT REFERENCES papers(paper_id),
+  text       TEXT NOT NULL,
+  tags       TEXT,
+  created_at INTEGER NOT NULL
+);
+
+-- FTS5-Content-Table-Trigger: halten papers_fts synchron mit papers
+CREATE TRIGGER IF NOT EXISTS papers_ai AFTER INSERT ON papers BEGIN
+  INSERT INTO papers_fts(rowid, paper_id, title, abstract, fulltext)
+  VALUES (
+    new.rowid,
+    new.paper_id,
+    json_extract(new.csl_json, '$.title'),
+    json_extract(new.csl_json, '$.abstract'),
+    NULL
+  );
+END;
+
+CREATE TRIGGER IF NOT EXISTS papers_ad AFTER DELETE ON papers BEGIN
+  INSERT INTO papers_fts(papers_fts, rowid, paper_id, title, abstract, fulltext)
+  VALUES (
+    'delete',
+    old.rowid,
+    old.paper_id,
+    json_extract(old.csl_json, '$.title'),
+    json_extract(old.csl_json, '$.abstract'),
+    NULL
+  );
+END;
+
+CREATE TRIGGER IF NOT EXISTS papers_au AFTER UPDATE ON papers BEGIN
+  INSERT INTO papers_fts(papers_fts, rowid, paper_id, title, abstract, fulltext)
+  VALUES (
+    'delete',
+    old.rowid,
+    old.paper_id,
+    json_extract(old.csl_json, '$.title'),
+    json_extract(old.csl_json, '$.abstract'),
+    NULL
+  );
+  INSERT INTO papers_fts(rowid, paper_id, title, abstract, fulltext)
+  VALUES (
+    new.rowid,
+    new.paper_id,
+    json_extract(new.csl_json, '$.title'),
+    json_extract(new.csl_json, '$.abstract'),
+    NULL
+  );
+END;

--- a/mcp/academic_vault/schema.sql
+++ b/mcp/academic_vault/schema.sql
@@ -1,6 +1,6 @@
 -- academic_vault SQLite Schema
 -- Tabellen: papers, papers_fts, quotes, quote_embeddings, decisions, notes
--- FTS5-Content-Table-Trigger: papers_ai, papers_ad, papers_au
+-- FTS5-Trigger: papers_ai, papers_ad, papers_au
 
 CREATE TABLE IF NOT EXISTS papers (
   paper_id              TEXT PRIMARY KEY,
@@ -17,13 +17,13 @@ CREATE TABLE IF NOT EXISTS papers (
   updated_at            INTEGER NOT NULL
 );
 
+-- FTS5 als eigenstaendige virtuelle Tabelle (kein content=, manuell befuellt).
+-- Trigger halten papers_fts synchron mit papers.
 CREATE VIRTUAL TABLE IF NOT EXISTS papers_fts USING fts5(
-  paper_id UNINDEXED,
+  paper_id,
   title,
   abstract,
-  fulltext,
-  content='papers',
-  content_rowid='rowid'
+  fulltext
 );
 
 CREATE TABLE IF NOT EXISTS quotes (
@@ -41,7 +41,7 @@ CREATE TABLE IF NOT EXISTS quotes (
 );
 
 -- vec0 Virtual Table: optional, nur wenn sqlite-vec Extension geladen ist.
--- Wird in db.py per try/except erstellt; Fehler wird ignoriert.
+-- Wird in db.py per try/except erstellt.
 -- CREATE VIRTUAL TABLE IF NOT EXISTS quote_embeddings USING vec0(
 --   quote_id TEXT PRIMARY KEY,
 --   embedding FLOAT[384]
@@ -64,11 +64,10 @@ CREATE TABLE IF NOT EXISTS notes (
   created_at INTEGER NOT NULL
 );
 
--- FTS5-Content-Table-Trigger: halten papers_fts synchron mit papers
+-- FTS5-Trigger: befuellen papers_fts manuell via json_extract
 CREATE TRIGGER IF NOT EXISTS papers_ai AFTER INSERT ON papers BEGIN
-  INSERT INTO papers_fts(rowid, paper_id, title, abstract, fulltext)
+  INSERT INTO papers_fts(paper_id, title, abstract, fulltext)
   VALUES (
-    new.rowid,
     new.paper_id,
     json_extract(new.csl_json, '$.title'),
     json_extract(new.csl_json, '$.abstract'),
@@ -77,30 +76,13 @@ CREATE TRIGGER IF NOT EXISTS papers_ai AFTER INSERT ON papers BEGIN
 END;
 
 CREATE TRIGGER IF NOT EXISTS papers_ad AFTER DELETE ON papers BEGIN
-  INSERT INTO papers_fts(papers_fts, rowid, paper_id, title, abstract, fulltext)
-  VALUES (
-    'delete',
-    old.rowid,
-    old.paper_id,
-    json_extract(old.csl_json, '$.title'),
-    json_extract(old.csl_json, '$.abstract'),
-    NULL
-  );
+  DELETE FROM papers_fts WHERE paper_id = old.paper_id;
 END;
 
 CREATE TRIGGER IF NOT EXISTS papers_au AFTER UPDATE ON papers BEGIN
-  INSERT INTO papers_fts(papers_fts, rowid, paper_id, title, abstract, fulltext)
+  DELETE FROM papers_fts WHERE paper_id = old.paper_id;
+  INSERT INTO papers_fts(paper_id, title, abstract, fulltext)
   VALUES (
-    'delete',
-    old.rowid,
-    old.paper_id,
-    json_extract(old.csl_json, '$.title'),
-    json_extract(old.csl_json, '$.abstract'),
-    NULL
-  );
-  INSERT INTO papers_fts(rowid, paper_id, title, abstract, fulltext)
-  VALUES (
-    new.rowid,
     new.paper_id,
     json_extract(new.csl_json, '$.title'),
     json_extract(new.csl_json, '$.abstract'),

--- a/mcp/academic_vault/server.py
+++ b/mcp/academic_vault/server.py
@@ -1,0 +1,257 @@
+"""academic_vault MCP-Server.
+
+Stellt MCP-Tools vault.search/get_paper/add_paper/ensure_file/
+add_quote/find_quotes/get_quote/stats bereit.
+
+Start via: python -m mcp.academic_vault.server
+"""
+import os
+import sqlite3
+from uuid import uuid4
+from typing import Optional
+
+from .db import VaultDB
+from .files_api import FilesAPIClient
+
+# VAULT_DB_PATH aus Env; Fallback auf vault.db im CWD
+_DEFAULT_DB = os.environ.get("VAULT_DB_PATH", "vault.db")
+_ANTHROPIC_KEY = os.environ.get("ANTHROPIC_API_KEY", "")
+
+
+# ---------------------------------------------------------------------------
+# Reine Funktionen (testbar ohne MCP-Framework)
+# ---------------------------------------------------------------------------
+
+def add_quote(
+    db_path: str,
+    paper_id: str,
+    verbatim: str,
+    extraction_method: str,
+    api_response_id: Optional[str] = None,
+    pdf_page: Optional[int] = None,
+    printed_page: Optional[int] = None,
+    section: Optional[str] = None,
+    context_before: Optional[str] = None,
+    context_after: Optional[str] = None,
+) -> str:
+    """Fuegt Quote in Vault ein. Gibt quote_id zurueck.
+
+    Halluzinationsschutz: extraction_method='citations-api' erfordert
+    api_response_id. Bei Fehlen wird ValueError geworfen.
+    """
+    if extraction_method == "citations-api" and not api_response_id:
+        raise ValueError(
+            "vault.add_quote: api_response_id required for extraction_method='citations-api'"
+        )
+    quote_id = str(uuid4())
+    db = VaultDB(db_path)
+    db.init_schema()
+    db.add_quote(
+        quote_id=quote_id,
+        paper_id=paper_id,
+        verbatim=verbatim,
+        extraction_method=extraction_method,
+        api_response_id=api_response_id,
+        pdf_page=pdf_page,
+        printed_page=printed_page,
+        section=section,
+        context_before=context_before,
+        context_after=context_after,
+    )
+    return quote_id
+
+
+def get_quote(db_path: str, quote_id: str) -> Optional[dict]:
+    """Gibt vollstaendigen Quote-Record als dict zurueck oder None."""
+    db = VaultDB(db_path)
+    return db.get_quote(quote_id)
+
+
+def search_papers(
+    db_path: str,
+    query: str,
+    type_filter: Optional[str] = None,
+    k: int = 5,
+) -> list[dict]:
+    """FTS5-Suche in papers_fts. Gibt [{paper_id, snippet, score}] zurueck."""
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    if type_filter:
+        rows = conn.execute(
+            """
+            SELECT f.paper_id,
+                   snippet(papers_fts, 1, '<b>', '</b>', '...', 10) AS snippet,
+                   rank AS score
+            FROM papers_fts f
+            JOIN papers p ON p.paper_id = f.paper_id
+            WHERE papers_fts MATCH ?
+              AND p.type = ?
+            ORDER BY rank
+            LIMIT ?
+            """,
+            (query, type_filter, k),
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            """
+            SELECT paper_id,
+                   snippet(papers_fts, 1, '<b>', '</b>', '...', 10) AS snippet,
+                   rank AS score
+            FROM papers_fts
+            WHERE papers_fts MATCH ?
+            ORDER BY rank
+            LIMIT ?
+            """,
+            (query, k),
+        ).fetchall()
+    conn.close()
+    return [dict(r) for r in rows]
+
+
+def find_quotes(
+    db_path: str,
+    paper_id: str,
+    query: Optional[str] = None,
+    k: int = 10,
+) -> list[dict]:
+    """Gibt Quotes fuer ein Paper zurueck, optional per verbatim-Filter."""
+    db = VaultDB(db_path)
+    return db.find_quotes(paper_id, query, k)
+
+
+def add_paper(
+    db_path: str,
+    paper_id: str,
+    csl_json: str,
+    pdf_path: Optional[str] = None,
+    doi: Optional[str] = None,
+    isbn: Optional[str] = None,
+    page_offset: int = 0,
+) -> None:
+    """Upsert eines Papers in den Vault."""
+    db = VaultDB(db_path)
+    db.init_schema()
+    db.add_paper(paper_id, csl_json, doi=doi, isbn=isbn, pdf_path=pdf_path, page_offset=page_offset)
+
+
+def get_paper(db_path: str, paper_id: str) -> Optional[dict]:
+    """Gibt Paper-Metadata als dict zurueck oder None."""
+    db = VaultDB(db_path)
+    return db.get_paper(paper_id)
+
+
+def ensure_file(db_path: str, paper_id: str, api_key: str = "") -> str:
+    """Delegiert an FilesAPIClient.ensure_file(). Gibt file_id zurueck."""
+    paper = get_paper(db_path, paper_id)
+    if paper is None:
+        raise ValueError(f"Paper '{paper_id}' nicht gefunden.")
+    pdf_path = paper.get("pdf_path")
+    if not pdf_path:
+        raise ValueError(f"Paper '{paper_id}' hat keinen pdf_path.")
+    client = FilesAPIClient(
+        anthropic_api_key=api_key or _ANTHROPIC_KEY,
+        cache_db_path=db_path,
+    )
+    return client.ensure_file(pdf_path)
+
+
+def get_stats(db_path: str) -> dict:
+    """Delegiert an FilesAPIClient.get_stats()."""
+    return FilesAPIClient.get_stats(db_path)
+
+
+# ---------------------------------------------------------------------------
+# MCP-Server (optional: nur wenn mcp-SDK verfuegbar)
+# ---------------------------------------------------------------------------
+
+def _build_mcp_server():
+    """Erstellt FastMCP-Server-Instanz. Gibt None zurueck wenn mcp nicht installiert."""
+    try:
+        from mcp.server.fastmcp import FastMCP
+    except ImportError:
+        return None
+
+    mcp = FastMCP("academic-vault")
+    db_path = _DEFAULT_DB
+
+    @mcp.tool(name="vault.search")
+    def _vault_search(query: str, type: str = None, k: int = 5) -> list[dict]:
+        """FTS5-Suche in papers. Gibt [{paper_id, snippet, score}] zurueck."""
+        return search_papers(db_path, query, type_filter=type, k=k)
+
+    @mcp.tool(name="vault.get_paper")
+    def _vault_get_paper(paper_id: str) -> Optional[dict]:
+        """Paper-Metadata + pdf_status."""
+        return get_paper(db_path, paper_id)
+
+    @mcp.tool(name="vault.add_paper")
+    def _vault_add_paper(
+        paper_id: str,
+        csl_json: str,
+        pdf_path: str = None,
+        doi: str = None,
+        isbn: str = None,
+        page_offset: int = 0,
+    ) -> None:
+        """Upsert eines Papers in den Vault."""
+        add_paper(db_path, paper_id, csl_json, pdf_path=pdf_path, doi=doi, isbn=isbn, page_offset=page_offset)
+
+    @mcp.tool(name="vault.ensure_file")
+    def _vault_ensure_file(paper_id: str) -> str:
+        """Gibt gecachte file_id zurueck oder laedt PDF hoch."""
+        return ensure_file(db_path, paper_id, api_key=_ANTHROPIC_KEY)
+
+    @mcp.tool(name="vault.add_quote")
+    def _vault_add_quote(
+        paper_id: str,
+        verbatim: str,
+        extraction_method: str,
+        api_response_id: str = None,
+        pdf_page: int = None,
+        printed_page: int = None,
+        section: str = None,
+        context_before: str = None,
+        context_after: str = None,
+    ) -> str:
+        """Fuegt Quote ein. extraction_method='citations-api' erfordert api_response_id."""
+        return add_quote(
+            db_path=db_path,
+            paper_id=paper_id,
+            verbatim=verbatim,
+            extraction_method=extraction_method,
+            api_response_id=api_response_id,
+            pdf_page=pdf_page,
+            printed_page=printed_page,
+            section=section,
+            context_before=context_before,
+            context_after=context_after,
+        )
+
+    @mcp.tool(name="vault.find_quotes")
+    def _vault_find_quotes(paper_id: str, query: str = None, k: int = 10) -> list[dict]:
+        """Gibt Quotes fuer ein Paper zurueck."""
+        return find_quotes(db_path, paper_id, query=query, k=k)
+
+    @mcp.tool(name="vault.get_quote")
+    def _vault_get_quote(quote_id: str) -> Optional[dict]:
+        """Gibt vollstaendigen Quote-Record zurueck."""
+        return get_quote(db_path, quote_id)
+
+    @mcp.tool(name="vault.stats")
+    def _vault_stats() -> dict:
+        """Counts + Token-Ersparnis-Schaetzung."""
+        return get_stats(db_path)
+
+    return mcp
+
+
+mcp = _build_mcp_server()
+
+
+if __name__ == "__main__":
+    if mcp is None:
+        raise RuntimeError(
+            "mcp SDK nicht installiert. "
+            "Bitte 'pip install mcp>=1.0' ausfuehren."
+        )
+    mcp.run()

--- a/mcp/academic_vault/server.py
+++ b/mcp/academic_vault/server.py
@@ -6,7 +6,6 @@ add_quote/find_quotes/get_quote/stats bereit.
 Start via: python -m mcp.academic_vault.server
 """
 import os
-import sqlite3
 from uuid import uuid4
 from typing import Optional
 
@@ -45,7 +44,6 @@ def add_quote(
         )
     quote_id = str(uuid4())
     db = VaultDB(db_path)
-    db.init_schema()
     db.add_quote(
         quote_id=quote_id,
         paper_id=paper_id,
@@ -74,37 +72,38 @@ def search_papers(
     k: int = 5,
 ) -> list[dict]:
     """FTS5-Suche in papers_fts. Gibt [{paper_id, snippet, score}] zurueck."""
-    conn = sqlite3.connect(db_path)
-    conn.row_factory = sqlite3.Row
-    if type_filter:
-        rows = conn.execute(
-            """
-            SELECT f.paper_id,
-                   snippet(papers_fts, 1, '<b>', '</b>', '...', 10) AS snippet,
-                   rank AS score
-            FROM papers_fts f
-            JOIN papers p ON p.paper_id = f.paper_id
-            WHERE papers_fts MATCH ?
-              AND p.type = ?
-            ORDER BY rank
-            LIMIT ?
-            """,
-            (query, type_filter, k),
-        ).fetchall()
-    else:
-        rows = conn.execute(
-            """
-            SELECT paper_id,
-                   snippet(papers_fts, 1, '<b>', '</b>', '...', 10) AS snippet,
-                   rank AS score
-            FROM papers_fts
-            WHERE papers_fts MATCH ?
-            ORDER BY rank
-            LIMIT ?
-            """,
-            (query, k),
-        ).fetchall()
-    conn.close()
+    conn = VaultDB._open(db_path)
+    try:
+        if type_filter:
+            rows = conn.execute(
+                """
+                SELECT f.paper_id,
+                       snippet(papers_fts, 1, '<b>', '</b>', '...', 10) AS snippet,
+                       rank AS score
+                FROM papers_fts f
+                JOIN papers p ON p.paper_id = f.paper_id
+                WHERE papers_fts MATCH ?
+                  AND p.type = ?
+                ORDER BY rank
+                LIMIT ?
+                """,
+                (query, type_filter, k),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                """
+                SELECT paper_id,
+                       snippet(papers_fts, 1, '<b>', '</b>', '...', 10) AS snippet,
+                       rank AS score
+                FROM papers_fts
+                WHERE papers_fts MATCH ?
+                ORDER BY rank
+                LIMIT ?
+                """,
+                (query, k),
+            ).fetchall()
+    finally:
+        conn.close()
     return [dict(r) for r in rows]
 
 

--- a/tests/test_vault_skeleton.py
+++ b/tests/test_vault_skeleton.py
@@ -1,0 +1,363 @@
+"""Smoke-Tests fuer den academic_vault MCP-Server (TDD-First Skelett)."""
+import os
+import sys
+import sqlite3
+import tempfile
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Worktree-Root zum PYTHONPATH hinzufuegen damit mcp.academic_vault importierbar ist
+_WORKTREE_ROOT = Path(__file__).parent.parent
+if str(_WORKTREE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_WORKTREE_ROOT))
+
+# Modul-Imports mit Guard: fehlen noch bis zur Implementierung
+try:
+    from mcp.academic_vault.db import VaultDB
+    _DB_AVAILABLE = True
+except ImportError:
+    _DB_AVAILABLE = False
+
+try:
+    from mcp.academic_vault.files_api import FilesAPIClient
+    _FILES_API_AVAILABLE = True
+except ImportError:
+    _FILES_API_AVAILABLE = False
+
+try:
+    from mcp.academic_vault import server as vault_server
+    _SERVER_AVAILABLE = True
+except ImportError:
+    _SERVER_AVAILABLE = False
+
+
+# ---------------------------------------------------------------------------
+# Hilfsfunktionen
+# ---------------------------------------------------------------------------
+
+def make_temp_db() -> tuple[str, "VaultDB"]:
+    """Erstellt eine temporaere In-Memory-DB oder Datei-DB."""
+    tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    tmp.close()
+    db = VaultDB(tmp.name)
+    db.init_schema()
+    return tmp.name, db
+
+
+# ---------------------------------------------------------------------------
+# Task 2 aktiviert: test_schema_creates_tables
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not _DB_AVAILABLE, reason="db.py noch nicht implementiert")
+def test_schema_creates_tables():
+    """Alle 5 Tabellen + papers_fts existieren nach init_schema()."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = f.name
+    try:
+        db = VaultDB(db_path)
+        db.init_schema()
+        conn = sqlite3.connect(db_path)
+        cursor = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type IN ('table','trigger') ORDER BY name"
+        )
+        names = {row[0] for row in cursor.fetchall()}
+        conn.close()
+        assert "papers" in names
+        assert "quotes" in names
+        assert "decisions" in names
+        assert "notes" in names
+        assert "papers_fts" in names
+        assert "papers_ai" in names
+        assert "papers_ad" in names
+        assert "papers_au" in names
+    finally:
+        os.unlink(db_path)
+
+
+# ---------------------------------------------------------------------------
+# Task 4 aktiviert: test_add_paper_and_get
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not _DB_AVAILABLE, reason="db.py noch nicht implementiert")
+def test_add_paper_and_get():
+    """add_paper + get_paper Round-Trip."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = f.name
+    try:
+        db = VaultDB(db_path)
+        db.init_schema()
+        csl = '{"title": "Test Paper", "abstract": "An abstract."}'
+        db.add_paper("p1", csl, doi="10.1234/test")
+        paper = db.get_paper("p1")
+        assert paper is not None
+        assert paper["paper_id"] == "p1"
+        assert paper["doi"] == "10.1234/test"
+    finally:
+        os.unlink(db_path)
+
+
+# ---------------------------------------------------------------------------
+# Task 7 aktiviert: test_search_returns_results
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not _DB_AVAILABLE, reason="db.py noch nicht implementiert")
+def test_search_returns_results():
+    """vault.search(query) gibt >= 1 Ergebnis zurueck."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = f.name
+    try:
+        db = VaultDB(db_path)
+        db.init_schema()
+        csl = '{"title": "DevOps Governance Study", "abstract": "About DevOps in enterprise."}'
+        db.add_paper("p-search", csl)
+
+        from mcp.academic_vault.server import search_papers
+        results = search_papers(db_path, "DevOps Governance", k=5)
+        assert len(results) >= 1
+        assert "paper_id" in results[0]
+    finally:
+        os.unlink(db_path)
+
+
+# ---------------------------------------------------------------------------
+# Task 6 aktiviert: test_add_quote_requires_api_response_id
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not _DB_AVAILABLE, reason="db.py noch nicht implementiert")
+def test_add_quote_requires_api_response_id():
+    """vault.add_quote mit citations-api + kein api_response_id wirft ValueError."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = f.name
+    try:
+        db = VaultDB(db_path)
+        db.init_schema()
+        csl = '{"title": "Test Paper"}'
+        db.add_paper("p-quote", csl)
+
+        from mcp.academic_vault.server import add_quote
+        with pytest.raises(ValueError, match="api_response_id"):
+            add_quote(
+                db_path=db_path,
+                paper_id="p-quote",
+                verbatim="Exact text from the paper.",
+                extraction_method="citations-api",
+                api_response_id=None,
+            )
+    finally:
+        os.unlink(db_path)
+
+
+# ---------------------------------------------------------------------------
+# Task 6 aktiviert: test_add_quote_manual_no_api_id
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not _DB_AVAILABLE, reason="db.py noch nicht implementiert")
+def test_add_quote_manual_no_api_id():
+    """vault.add_quote mit manual + kein api_response_id ist OK."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = f.name
+    try:
+        db = VaultDB(db_path)
+        db.init_schema()
+        csl = '{"title": "Test Paper"}'
+        db.add_paper("p-manual", csl)
+
+        from mcp.academic_vault.server import add_quote
+        quote_id = add_quote(
+            db_path=db_path,
+            paper_id="p-manual",
+            verbatim="Manually noted text.",
+            extraction_method="manual",
+            api_response_id=None,
+        )
+        assert quote_id is not None
+        assert len(quote_id) > 0
+    finally:
+        os.unlink(db_path)
+
+
+# ---------------------------------------------------------------------------
+# Task 5 aktiviert: test_ensure_file_caches
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not _FILES_API_AVAILABLE, reason="files_api.py noch nicht implementiert")
+@pytest.mark.skipif(not _DB_AVAILABLE, reason="db.py noch nicht implementiert")
+def test_ensure_file_caches():
+    """Zweiter Aufruf von ensure_file triggert kein Re-Upload."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = f.name
+    # Minimales temporaeres PDF-Dummy
+    with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as pdf_f:
+        pdf_path = pdf_f.name
+        pdf_f.write(b"%PDF-1.4 fake content")
+    try:
+        db = VaultDB(db_path)
+        db.init_schema()
+        db.add_paper("p-file", '{"title": "File Paper"}', pdf_path=pdf_path)
+
+        mock_upload = MagicMock()
+        mock_upload.return_value = MagicMock(id="file-abc123")
+
+        client = FilesAPIClient(anthropic_api_key="test-key", cache_db_path=db_path)
+
+        with patch.object(client, "_upload_file", mock_upload):
+            fid1 = client.ensure_file(pdf_path)
+            fid2 = client.ensure_file(pdf_path)
+
+        assert fid1 == fid2 == "file-abc123"
+        mock_upload.assert_called_once()
+    finally:
+        os.unlink(db_path)
+        os.unlink(pdf_path)
+
+
+# ---------------------------------------------------------------------------
+# Task 8 aktiviert: test_find_quotes
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not _DB_AVAILABLE, reason="db.py noch nicht implementiert")
+def test_find_quotes():
+    """find_quotes(paper_id) gibt vorher eingefuegte Quotes zurueck."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = f.name
+    try:
+        db = VaultDB(db_path)
+        db.init_schema()
+        db.add_paper("p-fq", '{"title": "Find Quotes Paper"}')
+
+        from mcp.academic_vault.server import add_quote, find_quotes
+        add_quote(
+            db_path=db_path,
+            paper_id="p-fq",
+            verbatim="An important verbatim quote.",
+            extraction_method="manual",
+        )
+        results = find_quotes(db_path, paper_id="p-fq")
+        assert len(results) >= 1
+        assert results[0]["paper_id"] == "p-fq"
+    finally:
+        os.unlink(db_path)
+
+
+# ---------------------------------------------------------------------------
+# Task 8 aktiviert: test_get_quote
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not _DB_AVAILABLE, reason="db.py noch nicht implementiert")
+def test_get_quote():
+    """get_quote(quote_id) gibt vollstaendigen Record zurueck."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = f.name
+    try:
+        db = VaultDB(db_path)
+        db.init_schema()
+        db.add_paper("p-gq", '{"title": "Get Quote Paper"}')
+
+        from mcp.academic_vault.server import add_quote, get_quote
+        quote_id = add_quote(
+            db_path=db_path,
+            paper_id="p-gq",
+            verbatim="The verbatim text to retrieve.",
+            extraction_method="manual",
+        )
+        record = get_quote(db_path, quote_id)
+        assert record is not None
+        assert record["quote_id"] == quote_id
+        assert record["verbatim"] == "The verbatim text to retrieve."
+        assert record["paper_id"] == "p-gq"
+    finally:
+        os.unlink(db_path)
+
+
+# ---------------------------------------------------------------------------
+# Task 9 aktiviert: test_stats
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not _FILES_API_AVAILABLE, reason="files_api.py noch nicht implementiert")
+@pytest.mark.skipif(not _DB_AVAILABLE, reason="db.py noch nicht implementiert")
+def test_stats():
+    """vault.stats() gibt korrekte Counts + token_savings_estimate > 0 bei >=1 file_id."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = f.name
+    try:
+        db = VaultDB(db_path)
+        db.init_schema()
+        db.add_paper("p-stats", '{"title": "Stats Paper"}')
+        # file_id manuell setzen (wie nach ensure_file)
+        db.set_file_id("p-stats", "file-xyz", expires_at=int(time.time()) + 3600)
+
+        from mcp.academic_vault.server import add_quote
+        add_quote(
+            db_path=db_path,
+            paper_id="p-stats",
+            verbatim="A test quote for stats.",
+            extraction_method="manual",
+        )
+
+        from mcp.academic_vault.files_api import FilesAPIClient
+        stats = FilesAPIClient.get_stats(db_path)
+
+        assert "paper_count" in stats
+        assert "quote_count" in stats
+        assert "cached_files" in stats
+        assert "token_savings_estimate" in stats
+        assert stats["paper_count"] >= 1
+        assert stats["quote_count"] >= 1
+        assert stats["cached_files"] >= 1
+        assert stats["token_savings_estimate"] > 0
+    finally:
+        os.unlink(db_path)
+
+
+# ---------------------------------------------------------------------------
+# Task 3 aktiviert: test_vec_fallback
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not _DB_AVAILABLE, reason="db.py noch nicht implementiert")
+def test_vec_fallback():
+    """Wenn sqlite-vec nicht geladen -> vec_available=False, FTS5 funktioniert."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = f.name
+    try:
+        # VaultDB ohne vec-Extension initialisieren (kein SQLITE_VEC_PATH gesetzt)
+        env_backup = os.environ.pop("SQLITE_VEC_PATH", None)
+        try:
+            db = VaultDB(db_path)
+            db.init_schema()
+            # vec_available muss False sein (keine Extension im Test-Env)
+            assert db.vec_available is False
+            # FTS5 muss trotzdem funktionieren
+            csl = '{"title": "Fallback Test Paper", "abstract": "Testing FTS5 fallback."}'
+            db.add_paper("p-fallback", csl)
+            conn = sqlite3.connect(db_path)
+            rows = conn.execute(
+                "SELECT paper_id FROM papers_fts WHERE papers_fts MATCH 'Fallback'"
+            ).fetchall()
+            conn.close()
+            assert len(rows) >= 1
+        finally:
+            if env_backup is not None:
+                os.environ["SQLITE_VEC_PATH"] = env_backup
+    finally:
+        os.unlink(db_path)
+
+
+# ---------------------------------------------------------------------------
+# Task 10 aktiviert: test_migrate_help
+# ---------------------------------------------------------------------------
+
+def test_migrate_help():
+    """migrate.py --help muss mit exit 0 laufen."""
+    import subprocess
+    migrate_path = str(_WORKTREE_ROOT / "mcp" / "academic_vault" / "migrate.py")
+    result = subprocess.run(
+        [sys.executable, migrate_path, "--help"],
+        capture_output=True,
+        timeout=10,
+        cwd=str(_WORKTREE_ROOT),
+    )
+    assert result.returncode == 0
+    assert b"--db" in result.stdout or b"--state" in result.stdout

--- a/tests/test_vault_skeleton.py
+++ b/tests/test_vault_skeleton.py
@@ -105,19 +105,30 @@ def test_add_paper_and_get():
 
 @pytest.mark.skipif(not _DB_AVAILABLE, reason="db.py noch nicht implementiert")
 def test_search_returns_results():
-    """vault.search(query) gibt >= 1 Ergebnis zurueck."""
+    """vault.search(query) gibt >= 1 Ergebnis zurueck und liegt unter 500ms (AC #62)."""
+    import time
     with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
         db_path = f.name
     try:
         db = VaultDB(db_path)
         db.init_schema()
-        csl = '{"title": "DevOps Governance Study", "abstract": "About DevOps in enterprise."}'
-        db.add_paper("p-search", csl)
+        # Seed 50 Papers fuer realistische FTS5-Bedingungen (AC: <500ms bei >=50)
+        for i in range(50):
+            csl = (
+                '{"title": "DevOps Governance Study %d",'
+                ' "abstract": "Paper %d about DevOps in enterprise."}'
+            ) % (i, i)
+            db.add_paper("p-search-%d" % i, csl)
 
         from mcp.academic_vault.server import search_papers
+        start = time.perf_counter()
         results = search_papers(db_path, "DevOps Governance", k=5)
+        elapsed = time.perf_counter() - start
+
         assert len(results) >= 1
         assert "paper_id" in results[0]
+        # AC #62: Performance-Ziel <500ms bei mind. 50 Papers
+        assert elapsed < 0.5, "search took %.3fs, expected <0.5s" % elapsed
     finally:
         os.unlink(db_path)
 

--- a/tests/test_vault_skeleton.py
+++ b/tests/test_vault_skeleton.py
@@ -199,7 +199,7 @@ def test_ensure_file_caches():
         db.add_paper("p-file", '{"title": "File Paper"}', pdf_path=pdf_path)
 
         mock_upload = MagicMock()
-        mock_upload.return_value = MagicMock(id="file-abc123")
+        mock_upload.return_value = "file-abc123"
 
         client = FilesAPIClient(anthropic_api_key="test-key", cache_db_path=db_path)
 


### PR DESCRIPTION
## Summary

Chunk A of v6.0 Wave 1 — Vault MCP-Server Skeleton (Phase 1).

**Closes #62.**

Foundation for halluzinations-safe storage of PDFs, quotes, decisions, and notes. SQLite + FTS5 + sqlite-vec (with FTS5-only fallback) + Anthropic Files-API client with 1h-TTL `file_id` cache.

### What landed

- **`mcp/academic_vault/schema.sql`** — `papers, quotes, quote_embeddings (vec0), decisions, notes` + standalone FTS5 table `papers_fts` with 3 triggers (insert/update/delete with delete+insert rebuild)
- **`mcp/academic_vault/db.py`** — `VaultDB` context manager, sqlite-vec extension load with FTS5-only fallback, CRUD: `add_paper, get_paper, add_quote, get_quote, find_quotes, set_file_id, search_papers`
- **`mcp/academic_vault/files_api.py`** — `FilesAPIClient` with 1h-TTL `file_id` cache, mockable `_upload_file`, `get_stats()` returning `token_savings_estimate = cached_files × (80_000 − 20)`
- **`mcp/academic_vault/server.py`** — MCP tool set v1: `vault.search, vault.add_paper, vault.get_paper, vault.ensure_file, vault.add_quote, vault.find_quotes, vault.get_quote, vault.stats`
- **Halluzinationsschutz hardcoded:** `vault.add_quote` rejects quotes without `extraction_method='citations-api'` + `api_response_id`
- **`mcp/academic_vault/migrate.py`** — CLI for `literature_state.md` + local PDFs → SQLite seed
- **`.mcp.json`** — registers academic-vault server (Python module path with underscore)
- **`tests/test_vault_skeleton.py`** — 11 smoke tests covering all tools

### Phase 4 polish

- code-simplifier: `_open()` staticmethod centralizes connection setup, two sqlite3 blocks merged in files_api.py — tests stayed green
- /code-review: 3 High findings (≥80) fixed in 2 iterations: connection-leak in search_papers (try/finally), init_schema on different connections, redundant init_schema in add_quote. ~4 minor findings remain (<80, not fix-mandatory)

### Notes

- LOC ≈ 525 production code (slightly over 500-cap, accepted by L0 — see chunks.md notes)
- sqlite-vec graceful fallback: if extension load fails, vec table omitted, FTS5 search still works
- Files-API client mocked in tests (no live API calls)

## Test plan

- [ ] `pytest tests/test_vault_skeleton.py -v` — all 11 green
- [ ] `pytest tests/ -v --ignore=tests/evals` — full suite green
- [ ] Manual: load schema in fresh sqlite3, verify FTS5 + (optional) vec_quotes table
- [ ] Manual: register MCP server in Claude Code, call `vault.search("test", k=5)` → returns within 500ms

🤖 Generated with [Claude Code](https://claude.com/claude-code) via mmp orchestrator (v6.0 Wave 1, chunk A)
