### PR TITLE
v6.0: F1.3 Skills schlanker — shared preamble extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,13 @@ firebase-debug.log
 # Brainstorming-Artefakte (persönliche Arbeitsprodukte, nicht Release-Inhalt)
 docs/superpowers/specs/
 docs/superpowers/plans/
+
+# mmp orchestrator state — track config, archives, original ticket backups; ignore runtime
+.orchestrator/*
+.orchestrator/.sync/
+!.orchestrator/config.yaml
+!.orchestrator/README.md
+!.orchestrator/archive/
+!.orchestrator/improved-tickets/
+.orchestrator/improved-tickets/*
+!.orchestrator/improved-tickets/*.original.md

--- a/.orchestrator/README.md
+++ b/.orchestrator/README.md
@@ -1,0 +1,45 @@
+# .orchestrator/
+
+This directory holds runtime state for the `mmp` plugin in this repo.
+
+## Files
+
+- `config.yaml` — project-specific configuration for the orchestrator
+- `status.yaml` — live state of the current wave (don't edit by hand)
+- `<milestone>-context.md` — milestone dossier built by Phase 0
+- `infra-brief.md` — repo conventions snapshot for subagents
+- `chunks.md` — Phase 1 decomposition output (user-approved)
+- `improved-tickets/<id>.{original,draft}.md` — Phase 0.5 audit trail
+- `archive/<milestone>-w<N>-<date>/` — completed wave snapshots
+
+## Git tracking policy
+
+The shipped `.gitignore` snippet enforces the following:
+
+| Path | Tracked? | Reason |
+|---|---|---|
+| `config.yaml` | YES | shared project configuration |
+| `README.md` | YES | this file |
+| `archive/` | YES | historical wave snapshots — useful for audit |
+| `improved-tickets/*.original.md` | YES | disaster-recovery backups of upstream tickets |
+| `improved-tickets/*.draft.md` | NO | regenerable per-run scratch |
+| `status.yaml` | NO | live runtime state, single-machine |
+| `<milestone>-context.md` | NO | regenerable per-run snapshot |
+| `infra-brief.md` | NO | regenerable per-run snapshot |
+| `chunks.md` | NO | regenerable per-run snapshot |
+| `status.yaml.bak` / tmp files | NO | atomic-write artifacts |
+
+If you need to share runtime state across machines, override the snippet
+manually — but note that `mmp` assumes a single-user / single-machine
+workflow.
+
+## Recovering from a crash
+
+Run `/mmp:doctor` to see where things stand, then `/mmp:resume` (or
+`/mmp:run <milestone> --resume`).
+
+## Manual cleanup
+
+`/mmp:archive <milestone>` archives a completed wave. Delete `.orchestrator/`
+entirely to start fresh — but ensure no PRs are still open referencing
+worktrees that will be removed.

--- a/.orchestrator/config.yaml
+++ b/.orchestrator/config.yaml
@@ -1,0 +1,70 @@
+# .orchestrator/config.yaml
+# Project-specific config for mmp. Plugin defaults apply for any field omitted.
+
+ticket_source:
+  strategy: milestone           # milestone | label | project
+  milestone_pattern: "{name}"
+  label_pattern: "milestone:{name}"
+  project_number: null
+  state: open
+
+docs:
+  paths:
+    - "docs/milestones/{name}.md"
+    - "docs/{name}.md"
+
+branching:
+  pattern: "feat/{milestone}-{chunk_id}"
+  base: main
+
+ci:
+  provider: github-actions
+  poll_timeout_minutes: 30
+
+decomposition:
+  max_files_per_chunk: 15
+  max_loc_per_chunk: 500
+  max_hours_per_chunk: 8
+
+caps:
+  review_fix_iterations: 3
+  spec_revision_rounds: 2
+  plan_revision_rounds: 2
+  ci_fix_iterations: 3
+  coverage_fix_rounds: 2
+
+required_plugins:
+  # Plain plugin names (no owner/marketplace prefix). The pre-flight glob
+  # `~/.claude/plugins/cache/*/<name>/` resolves them regardless of which
+  # marketplace they came from.
+  - superpowers
+  - code-simplifier
+  - code-review
+
+ticket_improvement:
+  enabled: true
+  mode: live                    # live | local | ask
+  skip_labels:
+    - well-defined
+    - spec-ready
+    - wip
+    - do-not-improve
+  diff_preview: per_ticket      # per_ticket (required if mode=live) | batched | none
+
+gates:
+  # question_buffer_seconds is INFORMATIONAL only — L0 is single-threaded
+  # and cannot wait by clock. Q&A batching happens naturally per
+  # Tool-Result block / phase boundary. See skill reference gates.md.
+  question_buffer_seconds: 30
+  question_buffer_count: 5
+
+pr:
+  draft_initially: true
+  title_pattern: "{milestone}: {chunk_summary}"
+  body_template_path: null
+
+concurrency:
+  lock_timeout_hours: 8        # 1-24 (hard timeout for stale lock detection)
+  steal_on_expired: true       # auto-take expired locks; false → require /mmp:unlock
+  state_sync_branch_prefix: "mmp/state"
+  archive_branch_prefix: "mmp/archive"

--- a/.orchestrator/improved-tickets/65.original.md
+++ b/.orchestrator/improved-tickets/65.original.md
@@ -1,0 +1,11 @@
+**Audit-Bezug:** [`docs/AUDIT-v6-roadmap.md`](../blob/main/docs/AUDIT-v6-roadmap.md) §4.1 + §18.1
+
+## Scope
+- [ ] `agents/quote-extractor.md`: `source.type: "file"` mit `file_id`
+- [ ] `extra_headers={"anthropic-beta": "files-api-2025-04-14"}`
+- [ ] Fallback auf base64 bei Feature-Flag-OFF
+- [ ] anthropic SDK ≥ 0.40 in `scripts/requirements.txt`
+
+## Akzeptanzkriterien
+- [ ] 5 PDFs × 3 Iterationen → -75 % Input-Tokens vs. base64
+- [ ] Fehlende Beta-Header → graceful Fallback

--- a/.orchestrator/improved-tickets/67.original.md
+++ b/.orchestrator/improved-tickets/67.original.md
@@ -1,0 +1,11 @@
+**Audit-Bezug:** [`docs/AUDIT-v6-roadmap.md`](../blob/main/docs/AUDIT-v6-roadmap.md) §4.3
+
+## Scope
+- [ ] `skills/_common/preamble.md` mit Pflicht-Blöcken (Vorbedingungen, Keine Fabrikation, Aktivierung, Abgrenzung)
+- [ ] Markdown-Include oder Frontmatter-Reference in allen 13 Skills
+- [ ] `references/<variant>.md` lazy laden
+- [ ] Browser-Modul: nur Schema-Result in Modell-Context, Raw-DOM in `\$SESSION_DIR/raw/`
+
+## Akzeptanzkriterien
+- [ ] Skill-Aktivierung -500 Token pro Skill
+- [ ] `tests/test_skills_manifest.py` weiter grün

--- a/.orchestrator/improved-tickets/69.original.md
+++ b/.orchestrator/improved-tickets/69.original.md
@@ -1,0 +1,11 @@
+**Audit-Bezug:** [`docs/AUDIT-v6-roadmap.md`](../blob/main/docs/AUDIT-v6-roadmap.md) §7.2 + §18.2
+
+## Scope
+- [ ] `commands/humanize.md` mit YAML-Frontmatter (`Skill(humanizer-de)`)
+- [ ] Argument: `<kapitel-pfad> [--mode normal|deep]`
+- [ ] Output: `<basename>.humanized.md` + `<basename>.diff.md` (Severity-gegliedert)
+- [ ] Voice-Calibration: `~/.academic-research/projects/<slug>/voice-samples/`
+
+## Akzeptanzkriterien
+- [ ] `/academic-research:humanize kapitel/3.md --mode deep` produziert beide Files
+- [ ] Diff-File listet pro Severity die Änderungen

--- a/.orchestrator/improved-tickets/70.original.md
+++ b/.orchestrator/improved-tickets/70.original.md
@@ -1,0 +1,11 @@
+**Audit-Bezug:** [`docs/AUDIT-v6-roadmap.md`](../blob/main/docs/AUDIT-v6-roadmap.md) §12
+
+## Scope
+- [ ] `scripts/project_bootstrap.py`: Frage "Git aktivieren?" (y/n)
+- [ ] Bei y: `git init` + initial commit (`academic_context.md`, `CLAUDE.md`, `.gitignore`)
+- [ ] `hooks/hooks.json`: Stop-Hook prüft `academic_context.md`-Diff > 0 → User-Hinweis
+- [ ] `.gitignore`-Erweiterung: `pdfs/`, `sessions/`, `credentials.json`
+
+## Akzeptanzkriterien
+- [ ] Setup in leerem Ordner zeigt git-Repo nach y
+- [ ] Ohne git installiert → graceful Skip

--- a/docs/AUDIT-v6-roadmap.md
+++ b/docs/AUDIT-v6-roadmap.md
@@ -1,0 +1,956 @@
+# Academic-Research v6 — Audit & Roadmap
+
+**Erstellt:** 2026-05-07 · **Bezugsversion:** v5.4.0 · **Branch:** main
+**Ziel:** Token-Halbierung, Buch-Handling auf Citations-API-Niveau, neuer
+`/humanizer-de`-Workflow, semi-automatische Beschaffung nicht-OA-Quellen,
+optionale Obsidian/Zotero/NotebookLM-Bridges.
+
+---
+
+## 1 · Executive Summary
+
+Das Plugin macht heute, was es soll. Drei Schmerzpunkte limitieren den Sprung
+auf das nächste Level:
+
+1. **Token-Hunger.** Viele Skills laden komplette `references/`-Varianten,
+   `chapter-writer` baut den Kontext jedes Mal neu auf, `relevance-scorer`
+   batched zwar, aber PDFs werden bei jedem Folgecall re-uploaded statt
+   per Files-API referenziert. **Ziel:** −50–70 % Input-Tokens auf typischen
+   Sessions.
+2. **Buch-Handling.** Der Pfad `quote-extractor` → `citation-extraction`
+   funktioniert für Paper, aber nicht für Bücher: keine ISBN-Resolution,
+   keine Kapitel-Schnitte, Seitenangaben aus Scan-PDFs unzuverlässig,
+   PyPDF2 kann keine OCR. **Ziel:** Buch-Pfad mit korrekten Seitenangaben
+   und Verbatim-Zitaten gleichwertig zu Papern.
+3. **Kontext-Drift.** `academic_context.md` / `literature_state.md` /
+   `writing_state.md` werden nicht versioniert oder bei langer Session
+   nachgezogen. Bei Compaction gehen Entscheidungen (Zitierstil-Wahl,
+   abgelehnte Quellen, Variant-References) verloren. **Ziel:** Memory-Tool
+   + state-events.log + Snapshot-Hooks.
+
+Plus 12 weitere Felder (siehe §4–§15).
+
+---
+
+## 2 · Schwachstellen heute (Befund)
+
+### 2.1 Token-Lecks
+
+| Stelle | Befund | Hebel |
+|---|---|---|
+| `chapter-writer` lädt `academic_context.md` + `literature_state.md` + Style-Variant pro Aufruf | ~6–10k Tokens fix | cache_control + Files-API |
+| `quote-extractor` PDF base64 pro Call | 1 PDF ≈ 60–100 k Token, x N Aufrufe | `file_id` referenzieren statt base64 |
+| `relevance-scorer` 10er-Batch nutzt 5min-TTL | Cache läuft bei Pause aus | `cache_control: {type: "ephemeral", ttl: "1h"}` |
+| 13 Skills duplizieren `## Vorbedingungen` / `## Keine Fabrikation` / `## Aktivierung` | ~500 Token Overhead pro Skill | Shared `references/_common.md` per Hot-Link |
+| Browser-Search-Schritt liefert volle DOM-Snapshots in Modell-Context | je Modul bis 30k Token | nur strukturierte Felder zurückgeben, raw Snapshot in `$SESSION_DIR/raw/` |
+| `search.py` schreibt API-Roh-Antwort in `api_results.json` und Modell liest mit | unnötig | Modell liest nur das normalisierte Schema |
+
+### 2.2 Buch-Schwachstellen
+
+- **Kein Buch-Pfad in `search.py`.** APIs sind auf Paper getunt; Bücher
+  haben oft keine DOI, dafür aber ISBN/OCLC.
+- **Seitenangaben:** Die Citations-API ist seitengenau für **PDF-Pages**.
+  Bei Scan-PDFs ohne Text-Layer stimmt aber `start_page_number` nicht
+  zwingend mit der **gedruckten** Seitenzahl überein (PDF-Seite vs.
+  Buchseite — Vorwort/Inhalt verschieben Indizes oft um 10–30).
+- **Zitat-Verbatim:** PyPDF2 produziert bei Zwei-Spalten-Layout und
+  Hyphenation Wort-Salat → der Verbatim-Match aus Citations-API zeigt
+  den korrekten Text, aber `paper.pdf_text` (heuristik-Pfad ohne
+  Citations) liefert verstümmelte Zitate.
+- **Lange Bücher:** Über 600 Seiten reißt die PDF-Page-Limit-Grenze
+  (200k-Modell: 100 Seiten max, 1M-Modell: 600 Seiten max). Kein
+  Chunk-by-Chapter-Pfad vorhanden.
+- **Kapitel-Granularität:** Bücher zitieren oft pro Kapitel mit
+  eigenen Editor:innen. CSL-Felder `container-title`, `editor`,
+  `chapter-number`, `page` werden im aktuellen Schema nicht erfasst.
+- **OCR fehlt.** Scans aus dem Hochschul-OPAC (Tip-2-Online-Scans) sind
+  Bilddateien ohne Text-Layer. Aktuell stiller Fail.
+
+### 2.3 Kontext-/Erinnerungs-Drift
+
+- `academic_context.md` ist die Single Source of Truth, aber niemand
+  zwingt das Modell, sie nach Entscheidungen (z. B. „Wir nutzen IEEE
+  statt APA") zu **überschreiben**.
+- Nach Claude-Compaction verschwinden Bemerkungen wie „X habe ich
+  schon abgelehnt, weil Y" → Nachfolge-Calls schlagen dieselbe Quelle
+  wieder vor.
+- Kein Decision-Log (`decisions.log` o. Ä.).
+
+### 2.4 Workflow-Lücken
+
+- Beschaffung nicht-OA-Quellen (≈ 40–60 % der Treffer in Wirtschaft)
+  läuft heute manuell.
+- KI-Stil-Erkennung ist auf den `style-evaluator`-Skill verteilt
+  (`KI-Glanzschicht entfernen`), aber kein dedizierter `humanizer-de`-
+  Pass mit Severity-Ranking + zweitem Audit.
+- Keine Anbindung an Zotero/Obsidian/NotebookLM für Nutzer:innen, die
+  diese Tools sowieso einsetzen.
+- Kein PRISMA-Flow-Export für Systematic Reviews / Bachelorarbeiten,
+  die Methodik-Transparenz erfordern.
+
+---
+
+## 3 · Felder Übersicht
+
+| ID | Feld | Aufwand | Impact |
+|----|------|---------|--------|
+| F1 | Token-Effizienz (Cache + Files-API) | M | sehr hoch |
+| F2 | Buch-Pfad (ISBN, Kapitel, OCR, Seitenmapping) | L | sehr hoch |
+| F3 | Kontext-Persistenz (Memory-Tool + Decision-Log) | M | hoch |
+| F4 | `/humanizer-de` als first-class Workflow | S | hoch |
+| F5 | Beschaffungs-Excel (Fernleihe / Bibliotheks-Pickup) | S | hoch |
+| F6 | Auto-Download-Pipeline mit fail-soft | M | mittel |
+| F7 | Zotero-Bridge (Web-API v3) | M | mittel |
+| F8 | Obsidian-Bridge (Vault-Sync) | S | mittel |
+| F9 | NotebookLM-Bridge (manuell + optional CLI) | S | mittel |
+| F10 | PRISMA-Flow Diagramm + Inclusion-Log | M | hoch (für Bachelor/Master) |
+| F11 | Cluster-Visualisierung (Mermaid + Excel-Chart) | S | mittel |
+| F12 | Versionierung des Projekt-Kontexts (Git-Integration) | S | mittel |
+| F13 | Citation-Style-Erweiterung (CSL-JSON Import) | M | mittel |
+| F14 | Reading-List-Modus (kuratierte Quellen) | S | niedrig |
+| F15 | Eval-Suite Coverage (Buch-Cases) | M | hoch (Qualität) |
+| F16 | Universal Book Fetcher (TIB, autonomes Navigieren, Per-Uni-Profile) | L | sehr hoch |
+
+---
+
+## 4 · F1 — Token-Effizienz
+
+### 4.1 Files-API für PDFs
+
+**Problem:** `quote-extractor` schickt heute `source.type: "base64"`. Bei
+mehrfacher Verwendung desselben PDFs im selben Projekt wird dieselbe
+Datei mehrmals upgeloadet.
+
+**Lösung:**
+
+1. Beim ersten Verarbeiten eines PDFs `client.beta.files.upload(...)`
+   aufrufen, `file_id` in `pdf_status.json` schreiben.
+2. Folgenden Calls nur noch:
+   ```python
+   {"type": "document", "source": {"type": "file", "file_id": fid},
+    "citations": {"enabled": True}}
+   ```
+3. TTL-Tracking: file_ids ablaufen lassen wenn älter als Plugin-Konfig
+   (`~/.academic-research/files_ttl_days`, Default 30).
+
+**Trade-off:** Files-API ist Beta (`anthropic-beta: files-api-2025-04-14`)
+und erfordert anthropic SDK ≥ 0.40.
+
+### 4.2 Cache-Strategie umstellen
+
+- `relevance-scorer`, `quote-extractor`, `chapter-writer`, `quality-reviewer`:
+  `cache_control: {"type": "ephemeral", "ttl": "1h"}` auf System-Prompt
+  (Anthropic änderte 6. März 2026 den Default zurück auf 5 min — ohne
+  expliziten ttl zahlt man cache-write-Aufschlag mehrfach).
+- Cache-Breakpoint **vor** das `documents[]`-Array, nicht danach. So bleibt
+  der Agent-Prompt auch dann gecacht, wenn das PDF wechselt.
+
+### 4.3 Skills schlanker
+
+- Gemeinsame Pflicht-Blöcke (`Vorbedingungen`, `Keine Fabrikation`,
+  `Abgrenzung`) in `skills/_common/preamble.md` extrahieren und per
+  Markdown-Include linken.
+- `references/<variant>.md` lazy laden — nicht im Skill-Body listen,
+  sondern erst dann öffnen, wenn der Variant-Selector eine Datei
+  fixiert hat.
+- Browser-Snapshots **nicht** in Antwort-Context geben. Modell sieht
+  nur das Schema-normalisierte Ergebnis (`title`, `authors`, …),
+  Raw-DOM bleibt in `$SESSION_DIR/raw/` für Debug.
+
+**Erwartung:** −30–50 % Input-Tokens bei `/search` und `/score`,
+−60 % bei wiederholten Zitat-Extraktionen.
+
+### 4.4 Batch-API für Bulk-Scoring
+
+`relevance-scorer` über 50+ Papers → in Message-Batches-API auslagern.
+50 % Discount, 1h-Latenz. Hook im `/search`-Command:
+`--batch` Flag → Job submitten, Job-ID in `$SESSION_DIR/batch.json`,
+Pickup über `/academic-research:history --batch <id>`.
+
+---
+
+## 5 · F2 — Buch-Pfad
+
+### 5.1 Neuer Skill `book-handler`
+
+**Trigger:** „Buch", „Monografie", „Sammelband", „Kapitel von …",
+ISBN-Pattern (`\d{3}-\d{1,5}-\d{1,7}-\d{1,7}-\d`).
+
+**Pipeline:**
+
+```
+ISBN/Title → DNB SRU + OpenLibrary + GoogleBooks
+          → Metadaten (CSL: book / chapter)
+          → OPAC-Suche (verfügbar lokal? Standort? Signatur?)
+          → DOAB / OAPEN (OA-Bücher)
+          → falls PDF: Kapitel-Schnitt + OCR-Check + Seitenmapping
+          → Eintrag in literature_state.md (type: book|chapter)
+```
+
+### 5.2 Kapitel-Schnitt
+
+PDF-Inhaltsverzeichnis aus dem Outline-Tree (PyPDF2 `outline`) oder
+Textextraktion. Pro Kapitel:
+
+- `chunk_pdf.py --input book.pdf --chapter 3 --output chapter3.pdf`
+- separater Citations-API-Call mit nur diesem Kapitel als Document
+- spart Tokens (statt 600 Seiten nur 30) und hält die 100/600-Page-
+  Limits ein.
+
+### 5.3 Seitenmapping (PDF-Page ≠ Druck-Seite)
+
+**Problem:** `start_page_number` aus Citations-API ist die **PDF-Seite**.
+Druck-Seite kann um Vorwort/Inhalt versetzt sein.
+
+**Fix:**
+
+1. Beim ersten Buch-PDF-Verarbeiten: Modell scannt erste 30 PDF-Seiten,
+   findet die erste **gedruckte** Seitenzahl `1` und speichert
+   `page_offset = pdf_page - printed_page` in `pdf_status.json`.
+2. Bei Citation-Output:
+   `printed_page = api.start_page_number - page_offset`.
+3. Sanity-Check: Modell schaut auf 2 zufällige weitere Seiten, ob
+   das Offset stimmt — wenn nicht (Buch hat Doppelpaginierung,
+   römische Vorseiten etc.), Offset-Map als JSON.
+
+### 5.4 OCR-Path
+
+- Detektion: PDF erste Seite hat `< 100` extrahierbare Zeichen → OCR-Flag.
+- OCR-Tool: `ocrmypdf` (CLI) als Plugin-optional Dep.
+- Bei OCR-Flag → Modell warnt User, fragt ob OCR laufen soll
+  (lokal, dauert ~30 s/Seite). Nach OCR neuer PDF-Pfad.
+
+### 5.5 CSL-Felder erweitern
+
+`literature_state.md` Schema um `type: book | chapter | article-journal`
+und chapter-spezifische Felder (`container-title`, `editor[]`,
+`chapter`, `page-first`, `page-last`).
+
+`citation-extraction/references/` neue Variante: `book-chapter-de.md`
+mit Beispielen für DIN 1505, Harvard-de, APA-7 für Sammelbände.
+
+---
+
+## 6 · F3 — Kontext-Persistenz
+
+### 6.1 Memory-Tool
+
+`~/.academic-research/projects/<slug>/memory/` mit Anthropic-Memory-Tool
+befüllen. Schema:
+
+- `decisions.md` — chronologisch: Zitierstil, Methodik-Wahl, abgelehnte
+  Quellen, Cluster-Definitionen
+- `glossary.md` — projektspezifische Begriffe
+- `style-overrides.md` — User-spezifische Stil-Präferenzen
+  (z. B. „nutzt 'Wir' statt 'man'")
+
+Alle Skills lesen Memory-Tool **vor** dem Hauptprompt → 0 Tokens für
+Kontext-Wiederholung über Sessions hinweg.
+
+### 6.2 Decision-Log Hook
+
+Hook `PostToolUse` für `Write` mit Pfad-Match auf `*.md` im Projekt:
+schreibt 1-Zeile in `decisions.log` mit Timestamp + Skill + Δ. Hilft
+beim Auditing und ist die Vorlage für PRISMA-Flow.
+
+### 6.3 Auto-Snapshot vor Compaction
+
+Hook `PreCompact`: schreibt aktuellen `academic_context.md` +
+`literature_state.md` + `writing_state.md` als Tarball nach
+`~/.academic-research/snapshots/<slug>/<ts>.tgz`. Bei Bedarf
+mit `/academic-research:history --restore <ts>` zurück.
+
+---
+
+## 7 · F4 — `/humanizer-de` Integration
+
+### 7.1 Status
+
+`humanizer-de` ist als globaler Skill bereits unter
+`~/.codex/skills/humanizer-de/` (siehe Skill-Description: Anti-KI-Audit,
+Severity-Ranking, Modi-System, Stimmkalibrierung). Keine Re-Implementation
+nötig.
+
+### 7.2 Integration in academic-research
+
+Drei Punkte:
+
+1. **`style-evaluator`** triggert `humanizer-de` als Subagent-Skill,
+   wenn `output_target` ∈ {Bachelor, Master, Diplom, Dissertation}.
+2. **`chapter-writer`** ruft `humanizer-de` im **Mode `audit`** vor
+   `quality-reviewer` auf — Reihenfolge:
+   ```
+   draft → humanizer-de(audit) → quality-reviewer → final
+   ```
+3. **Neuer Slash-Command `/academic-research:humanize`** als
+   eigenständiger Pass: liest `kapitel/<n>.md`, läuft Mode `deep`
+   gegen humanizer-de, schreibt `kapitel/<n>.humanized.md` plus
+   `kapitel/<n>.diff.md`.
+
+### 7.3 Stimmkalibrierung
+
+`humanizer-de` kennt Voice-Calibration aus User-Schreibproben.
+Vorschlag: `~/.academic-research/projects/<slug>/voice-samples/`
+für 3–5 eigene Texte des Users (frühere Hausarbeiten). Erstaktivierung
+fragt nach Samples.
+
+### 7.4 Trade-off
+
+Weniger fluffige Symbolik = weniger LLM-Wow-Effekt. Funktion ist
+**Schutz** vor KI-Detektoren wie Turnitin / GPTZero / OriginalityAI.
+Default off in nicht-Hochschul-Projekten (siehe Best-Practice
+„Overhead in Nicht-Facharbeit-Projekten deaktivieren").
+
+---
+
+## 8 · F5/F6 — Beschaffung & Auto-Download
+
+### 8.1 5-Tier-Pipeline (heute) erweitern auf 8 Tiers
+
+Aktuell: Unpaywall → CORE → Module-OA-URL → Direct-PDF → arXiv-Title.
+
+Erweiterung:
+
+6. **OpenAccessButton** (`api.openaccessbutton.org/find`)
+7. **DOAB / OAPEN** für Bücher
+8. **EuropePMC** (`europepmc.org/api`) für Biomedizin
+
+### 8.2 Bibliotheks-Excel `pickup-list.xlsx`
+
+**Trigger:** `/academic-research:pickup` (neuer Command).
+
+Liest `literature_state.md`, filtert auf `source != open_access`,
+ergänzt:
+
+- OPAC-Standort + Signatur (über DAIA / `gbv.github.io/cdvost2018`)
+- Status (verfügbar / ausgeliehen / Fernleihe nötig)
+- Direktlink Fernleihe-Formular der Heim-Uni (User konfiguriert URL
+  in `~/.academic-research/config.yaml`)
+- ISBN-Barcode (Code128) als Excel-Bild für mobiles Scannen am Regal
+
+Sheets:
+
+1. **Vor Ort verfügbar** — Pickup-Reihenfolge nach Signatur sortiert
+2. **Fernleihe** — fertig formatierte Anfrage-Texte (Title, Author,
+   Year, ISBN/DOI) als Copy-Paste-Block pro Zeile
+3. **Online OA** — Direktlinks
+4. **Lizenz nötig** — proprietary, Hinweis auf Uni-VPN
+
+### 8.3 Browser-Modul `library-pickup`
+
+`browser-use`-Skript: loggt sich (HAN-Auth) ins Bibliotheks-Konto ein,
+trägt automatisch Fernleihe-Bestellungen ein. **Opt-in**, weil
+verbindlich (kostenpflichtig pro Anfrage).
+
+### 8.4 PDF-Status-Workflow
+
+```
+literature_state.md  ─┬─► auto_download (8-tier)
+                       ├─► via_opac (download-link)
+                       ├─► fernleihe (manual_followup)
+                       └─► self_uploaded (~/papers/)
+```
+
+Skill `source-quality-audit` warnt, wenn > 30 % der zitierten Quellen
+nur Metadaten sind (kein Volltext) → Risiko für `quote-extractor`.
+
+---
+
+## 9 · F7/F8/F9 — Knowledge-Tool-Bridges
+
+### 9.1 Zotero (F7)
+
+- **Einseitige Sync**: `pyzotero` als optionale Dep.
+- Neuer Skill `zotero-sync`: liest Zotero-Library (User-Key in
+  `~/.academic-research/config.yaml`), mappt auf
+  `literature_state.md`-Schema, dedupliziert per DOI/ISBN.
+- **Zwei-Wege-Sync**: erst v6.1, weil OAuth1-Schreib-Auth fehleranfällig.
+- Better-BibTeX-Export-File (`<vault>/zotero.bib`) auch ok für Pull-only.
+
+### 9.2 Obsidian (F8)
+
+- Neuer Skill `obsidian-export`: schreibt pro Paper eine Markdown-Datei
+  in `<vault>/lit/<citekey>.md` mit Frontmatter (`title`, `authors`,
+  `year`, `doi`, `tags: [academic-research, cluster-X]`) und Body
+  (Abstract, Top-3-Zitate, Notizen).
+- Cluster-MOC (`<vault>/lit/_clusters/<cluster>.md`) als Übersicht.
+- Kompatibel mit ZotLit-Templates.
+
+### 9.3 NotebookLM (F9)
+
+- Kein offizielles API. Optionen:
+  - **Manuell**: Skill `notebook-export` baut PDF-Bundle aus Top-N
+    Papern + Bibliographie als ein PDF (via xlsx-Skill-Pattern, nur
+    PDF-Pack), User uploadet selbst.
+  - **Halb-automatisch**: `notebooklm-py` (unofficial) als optionale
+    Dep für User mit Google-Account (Risiko: bricht bei UI-Updates).
+- Use-Case: 1M-Token-Source-Grounding bei Büchern, die für unsere
+  Citations-API zu groß sind. Abgrenzung: NotebookLM ersetzt **nicht**
+  unseren Zitat-Pfad — Output dort ist nicht verbatim-garantiert.
+
+### 9.4 Empfehlung
+
+Default: Obsidian-Bridge (Markdown ist null-Lock-in). Zotero-Pull-Sync
+für Nutzer:innen mit bestehender Library. NotebookLM nur bei
+Riesen-Büchern (> 600 PDF-Seiten) als Triage-Tool, **nie** als
+Zitationsquelle.
+
+---
+
+## 10 · F10 — PRISMA-Workflow
+
+Bachelor-/Master-Arbeiten mit Methodik „Systematic Review" brauchen
+einen PRISMA-Flow:
+
+```
+Identifikation (n=) → Screening (n=) → Eligibility (n=) → Included (n=)
+```
+
+**Implementierung:**
+
+1. `/search` schreibt `n_identified` pro Modul.
+2. Dedup-Schritt schreibt `n_after_dedup`.
+3. `relevance-scorer` < 0.5 → `excluded_screening`.
+4. `quality-reviewer` Ablehnung → `excluded_eligibility`.
+5. Neuer Skill `prisma-flow` rendert Mermaid-Diagramm in
+   `kapitel/methodik.md` und exportiert als PNG via
+   Mermaid-CLI.
+6. Begleitend `prisma-checklist.md` (27-Punkte-PRISMA-2020).
+
+---
+
+## 11 · F11 — Cluster-Visualisierung
+
+- Excel-Sheet bereits da, aber statisch.
+- Mermaid-Diagramm aus 5D-Scoring-Output: Cluster als Knoten,
+  Querverbindungen (Co-Authors, Co-Citations) als Kanten. Im
+  `kapitel/literatur.md` einbettbar.
+- Optional: D3-HTML-Export für Browser-Browse (lokales File).
+
+---
+
+## 12 · F12 — Projekt-Versionierung
+
+- Setup legt heute schon `.gitignore` an. Erweiterung:
+  `git init` + initial commit der Bootstrap-Files automatisch
+  (User-Opt-in im Setup).
+- Hook `Stop`: Diff `academic_context.md` seit letztem Commit > 0
+  → Modell schlägt `/academic-research:commit "..."` vor.
+- Branch-Strategie für Methodik-Experimente
+  („was wäre wenn ich qualitativ statt quantitativ arbeite") in
+  Best-Practices dokumentieren.
+
+---
+
+## 13 · F13 — CSL-JSON Import
+
+Aktuelle Variant-Selector-Logik (`apa.md`, `harvard.md` …) ist
+hand-curated. CSL-Repository auf GitHub hat 10.000+ Stile.
+
+**Lösung:** Skill `citation-style-import` lädt eine `.csl`-Datei
+aus dem Repo (User gibt Stil-Name an), parst sie zu prompt-fähigen
+Regeln. Ergebnis als neue Variant `references/custom-<style>.md`.
+
+Trade-off: Volle CSL-Spec ist groß. Pragmatischer Ansatz: nur die
+Felder formatieren, die `literature_state.md` kennt
+(book, chapter, journal, conference).
+
+---
+
+## 14 · F14 — Reading-List-Modus
+
+Manche Profs geben eine Lese-Liste vor. Aktuell muss der User die
+händisch in `literature_state.md` tippen.
+
+**Skill `reading-list-import`:**
+
+- Input: PDF / Markdown / Plaintext mit Liste von Quellen.
+- Pipeline: Anystyle (Ruby) oder eigener LLM-Parser → strukturierte
+  Liste → DOI-/ISBN-Resolution → `literature_state.md`.
+
+---
+
+## 15 · F15 — Eval-Coverage
+
+Heute: 16 Eval-Verzeichnisse, aber Buch-Cases fehlen. Neue Eval-Sets:
+
+- `evals/book-handler/` — 5 Bücher (1 OA, 2 ISBN-only, 1 Scan-PDF,
+  1 Sammelband mit Editor-Kapiteln)
+- `evals/humanizer-de-pipeline/` — 3 Drafts vor/nach humanizer-de
+- `evals/prisma-flow/` — 1 Mini-Review-Beispiel
+
+Bestehende Evals um Token-Counts erweitern → Regression-Tests gegen
+F1.
+
+---
+
+## 15a · F16 — Universal Book Fetcher (browser-use only)
+
+### Constraint
+
+**Nur `browser-use` CLI + Subagenten.** Keine API-basierte Discovery,
+kein curl/wget, kein direktes Anthropic-Files-Upload. Jede Quelle wird
+wie ein Mensch im Browser bedient. Begründung:
+
+- Verlags-Auth (Shibboleth, HAN, EZproxy) liefert nur Browser-Sessions
+- DNB/OpenLibrary-APIs sind nice-to-have, aber nicht der Kern-Wunsch
+- User will ein **autonomes Subagenten-System** das auf Sites navigiert
+- Memory-Direktive: "browser-use statt Playwright/MCP-API"
+
+### Befund (Status quo)
+
+- 9 Browser-Guides in `config/browser_guides/`, alle **such-zentriert**
+  — Metadaten + URL holen, dann zurück. Kein Download-Step.
+- Springer-Guide erwähnt "Download PDF"-Button, aber kein dokumentierter
+  `browser-use`-Workflow für lokales Speichern.
+- HAN-Login auf **Leibniz FH** hardcoded
+- TIB.eu fehlt komplett — wichtigste DACH-Quelle (143 Mio Records,
+  71 Mio Volltexte)
+- Keine Subagenten für Site-Navigation. Heute macht das der Master-
+  Modell-Loop selbst → frisst Tokens und ist fragil.
+
+### Architektur (Subagenten-System)
+
+```
+                      ┌─────────────────────────┐
+                      │  /academic-research:    │
+                      │  fetch <isbn|doi|titel> │
+                      └────────────┬────────────┘
+                                   │
+                      ┌────────────▼────────────┐
+                      │  book-fetcher           │  ← Master-Subagent
+                      │  (Sonnet)               │     entscheidet,
+                      │  - Site-Strategie       │     wo gesucht wird
+                      │  - Fallback-Kette       │
+                      └─┬───┬───┬───┬───┬───┬──┘
+                        │   │   │   │   │   │
+       ┌────────────────┘   │   │   │   │   └────────────────┐
+       ▼                    ▼   ▼   ▼   ▼                    ▼
+   tib-fetcher       springer-fetcher   oapen-fetcher    generic-fetcher
+   (Haiku)              (Sonnet)         (Haiku)         (Sonnet)
+   nur tib.eu         nur SpringerLink   nur oapen.org   beliebige URL
+   browser-use        browser-use        browser-use     browser-use
+```
+
+Jeder Site-Subagent ist ein **eigener Agent in `agents/`** mit:
+- `tools: [Bash(browser-use:*), Bash(browser-use *), Read, Write]`
+- `model: sonnet` für alle Site-Subagenten (browser-Navigation braucht
+  zuverlässige DOM-Heuristik und Fehlertoleranz; Haiku scheitert hier
+  zu oft an State-Output-Drift)
+- maxTurns: 12–20 (Browser-Schritte sind langsam)
+- nur ein Site-Wissen pro Agent → kleiner System-Prompt
+
+### F16.1 — Site-Subagenten (browser-use only)
+
+Neu unter `agents/`:
+
+| Agent | Site | Model | Auth | Buch-Fokus |
+|---|---|---|---|---|
+| `tib-fetcher` | tib.eu Portal | sonnet | optional | hoch — viele OA-Bücher |
+| `springer-book-fetcher` | link.springer.com | sonnet | Shibboleth/HAN | hoch — Lehrbücher |
+| `oapen-fetcher` | oapen.org | sonnet | nein | sehr hoch — reine OA |
+| `doabooks-fetcher` | directory.doabooks.org | sonnet | nein | sehr hoch — reine OA |
+| `degruyter-fetcher` | degruyter.com | sonnet | Shibboleth/HAN | mittel — DACH Geistes |
+| `nationallizenzen-fetcher` | nationallizenzen.de | sonnet | DFN-AAI | mittel |
+| `ebook-central-fetcher` | ebookcentral.proquest.com | sonnet | HAN/EZproxy | mittel |
+| `kvk-fetcher` | kvk.bibliothek.kit.edu | sonnet | nein | Meta-Discovery, 80+ Kataloge |
+| `generic-fetcher` | beliebige URL | sonnet | je nach Profil | Fallback-Modus |
+
+Pro Subagent: `agents/<name>.md` mit System-Prompt, der nur diese eine
+Site kennt. Beispiel-Skelett `agents/tib-fetcher.md`:
+
+```markdown
+---
+name: tib-fetcher
+model: sonnet
+description: |
+  Holt Bücher und Texte von tib.eu (TIB-Portal, Hannover) per
+  browser-use. Aufrufen mit ISBN, DOI oder Titel. Liefert Pfad zum
+  heruntergeladenen PDF oder Failure-Reason zurück.
+tools: [Bash(browser-use:*), Bash(browser-use *), Read, Write]
+maxTurns: 15
+---
+
+# Auftrag
+
+Du bedienst tib.eu wie ein Mensch. Nur browser-use.
+
+## Standard-Flow
+
+1. `browser-use open https://www.tib.eu/de/suchen?query=<URL-encoded-query>`
+2. `browser-use state` → Treffer-Liste lesen
+3. Plausibelster Treffer: Titel + Autor + Jahr matcht Input
+4. `browser-use click <idx>` auf Treffer-Titel
+5. `browser-use state` → Detailseite lesen:
+   - "Volltext"-Block sichtbar?
+   - "DOI"-Link sichtbar?
+   - "Open Access"-Badge?
+6. Wenn "Volltext"-Link → `browser-use click <idx>`
+   Wenn DOI → `browser-use click <idx>` (verlinkt oft auf OA-Repo)
+7. Auf PDF-Viewer-Seite: `browser-use download <pdf-link-idx> --to $OUTPUT_PATH`
+8. Validation: PDF-Magic, Größe > 10 KB, Titel-Plausibilität (siehe
+   quote-extractor-Pattern)
+
+## Fallback
+
+Kein Volltext gefunden → Output: `{"status": "metadata_only", "url": "<detailseite>"}`.
+Master-Agent entscheidet, ob nächster Subagent (springer-book-fetcher)
+versucht wird.
+
+## Verbote
+
+- Kein curl, kein wget, kein direkter HTTP-Aufruf
+- Keine API-Endpoints raten
+- Keine fingierten Treffer (wenn Suche leer ist, melden)
+```
+
+Analog für jeden anderen Site-Agent. Auth-Subagenten teilen sich
+einen `auth-helper`-Subagent, der je nach Per-Uni-Profil den richtigen
+Login-Flow ausführt (HAN, Shibboleth-WAYF, EZproxy).
+
+### F16.2 — Master-Agent `book-fetcher`
+
+```markdown
+---
+name: book-fetcher
+model: sonnet
+description: |
+  Master-Orchestrator: bekommt ISBN/DOI/Titel und versucht, das Werk
+  über die Site-Subagenten zu beschaffen. Entscheidet Fallback-Reihenfolge
+  basierend auf Input-Typ und Per-Uni-Profil.
+tools: [Read, Write, Agent(tib-fetcher, springer-book-fetcher, oapen-fetcher, doabooks-fetcher, degruyter-fetcher, nationallizenzen-fetcher, ebook-central-fetcher, kvk-fetcher, generic-fetcher, auth-helper)]
+maxTurns: 8
+---
+
+# Auftrag
+
+Beschaffe das Werk per browser-use-Subagenten.
+
+## Strategie
+
+1. Lies `~/.academic-research/library-profiles/active.yaml`.
+2. Reihenfolge bestimmen:
+   - **OA-Bücher**: oapen → doabooks → tib (OA-Filter) → kvk
+   - **Verlags-Bücher mit Uni-Lizenz**: springer-book → degruyter →
+     ebook-central → nationallizenzen
+   - **Unbekannt**: kvk-fetcher (Meta-Suche) zuerst, dann passender
+     Site-Subagent gemäß Treffer
+3. Pro Subagent ein Versuch. Bei `metadata_only` → nächster Subagent.
+   Bei `success` → Pfad in Vault aufnehmen, fertig.
+4. Alle erschöpft → Pickup-Excel-Eintrag (für Fernleihe).
+
+## Output
+
+```json
+{
+  "status": "success" | "pickup_required" | "captcha" | "no_match",
+  "pdf_path": "...",
+  "source_subagent": "tib-fetcher",
+  "tries": [
+    {"subagent": "oapen-fetcher", "result": "metadata_only"},
+    {"subagent": "tib-fetcher", "result": "success"}
+  ]
+}
+```
+
+## Verbote
+
+- Kein eigener Browser-Aufruf — nur über Subagenten
+- Kein Skipping der Per-Uni-Profil-Lese
+```
+
+### F16.3 — `/academic-research:fetch` Command
+
+```yaml
+---
+description: Hol ein Buch oder Paper über die Site-Subagenten ins Repo
+disable-model-invocation: false
+allowed-tools: Read, Write, Agent(book-fetcher)
+argument-hint: <isbn|doi|titel|url>
+---
+1. Parsen des Inputs (ISBN-Regex / DOI-Regex / URL / Freitext)
+2. Spawn book-fetcher mit normalisiertem Input
+3. Auf Ergebnis warten
+4. Bei success: Eintrag in literature_state.md / Vault
+5. Bei pickup_required: Eintrag in pickup-list.xlsx vorbereiten
+6. Bei captcha: Screenshot anzeigen, User entscheidet manuell
+```
+
+### F16.4 — Discovery-Modus (`generic-fetcher`)
+
+Wenn die ersten 8 Site-Subagenten alle fehlschlagen oder die URL keiner
+bekannten Site entspricht:
+
+```markdown
+---
+name: generic-fetcher
+model: sonnet
+description: |
+  Fallback-Subagent. Bedient eine beliebige wissenschaftliche Site
+  per browser-use, ohne vorgegebenen Site-Guide. Entscheidet anhand
+  von DOM-Heuristiken (PDF-Button, Access-Banner, Login-Wall).
+tools: [Bash(browser-use:*), Bash(browser-use *), Read, Write]
+maxTurns: 20
+---
+
+# DOM-Heuristiken (Few-Shot-Lernen)
+
+## "PDF-Button erkennen"
+Look-fors in browser-use state:
+- Text enthält: "Download PDF", "PDF herunterladen", "Get PDF",
+  "Volltext (PDF)", "Full Text", "View PDF"
+- Element-Typ: <a> oder <button>
+- nicht: "Vorschau", "Preview", "Sample Chapter"
+
+## "Paywall erkennen"
+- Text enthält: "Get Access", "Purchase", "Buy", "Subscribe",
+  "Sign in to view", "Anmelden für Volltext"
+- Aktion: prüfe Per-Uni-Profil, ob Site-Lizenz vorhanden — wenn ja,
+  triggere auth-helper. Wenn nein → metadata_only.
+
+## "Captcha erkennen"
+- Text "I'm not a robot", "Please verify", "reCAPTCHA"
+- Aktion: screenshot, abbrechen mit status: captcha
+
+## "Falscher Treffer erkennen"
+- Treffer-Titel ≠ Input-Titel (>30 % Differenz, Levenshtein)
+- Aktion: zurück zur Trefferliste, nächster Treffer
+```
+
+### F16.5 — Per-Uni-Profile (gleich wie F5)
+
+`~/.academic-research/library-profiles/<uni>.yaml` (Beispiel Leibniz FH):
+
+```yaml
+uni: leibniz-fh
+auth_type: HAN
+auth_url: https://han.leibniz-fh.de
+credentials_keys: [han_user, han_password]
+licensed_sites:
+  - link.springer.com
+  - degruyter.com
+  - ebookcentral.proquest.com
+  - tib.eu
+proxy_pattern: "https://{site-with-dots-replaced-by-dashes}.han.leibniz-fh.de"
+```
+
+`auth-helper`-Subagent liest dieses Profil und entscheidet, ob er:
+- HAN-Login fahren muss (Leibniz FH)
+- Shibboleth-WAYF benutzt (TUM, RWTH)
+- EZproxy-Proxy direkt (manche US-Unis)
+- ohne Auth weiterläuft (OA-Site)
+
+Setup fragt beim Erstaufruf nach Uni und Profil. Vorlagen für die
+20 größten DACH-Hochschulen werden mit dem Plugin ausgeliefert.
+
+### Trade-offs
+
+- **Token-Kosten Subagenten:** 9 Site-Agenten = 9 System-Prompts.
+  Mitigation: Master-Agent spawnt nur 1–2 pro Anfrage (Strategie-
+  basiert), nicht alle parallel. Cache-Control auf System-Prompt
+  jedes Site-Subagenten (1h-TTL) macht Folge-Calls auf dieselbe
+  Site billig.
+- **Modell-Wahl Sonnet überall:** Browser-Navigation reagiert auf
+  unstrukturierten DOM-State, Fehlertoleranz braucht Sonnet-Niveau.
+  Haiku scheiterte in Tests an Treffer-Auswahl und Paywall-Erkennung.
+  Mehrkosten akzeptiert, weil pro Anfrage nur 1–2 Subagenten laufen.
+- **browser-use Concurrency:** Heute single-Browser-Session. Parallele
+  Subagenten würden sich Browser-Tab teilen. Mitigation: Master-Agent
+  fährt strikt sequentiell.
+- **Captcha:** browser-use kann nicht lösen. User-Hand-off bleibt.
+- **Verlags-AGBs:** Throttle ≥ 5 s zwischen Downloads, kein Bulk-
+  Crawling. Skills nutzen Standard-User-Agent (browser-use Default).
+- **Auth-Drift:** Per-Uni-Profile veralten. Mitigation: jährlicher
+  Profil-Review, User-Override über CLI.
+
+### Konkrete Anker (Sprint v6.2 Diff)
+
+```
+agents/
+  book-fetcher.md                 # NEU — Master
+  tib-fetcher.md                  # NEU
+  springer-book-fetcher.md        # NEU — ergänzt bestehenden springer-Guide
+  oapen-fetcher.md                # NEU
+  doabooks-fetcher.md             # NEU
+  degruyter-fetcher.md            # NEU
+  nationallizenzen-fetcher.md     # NEU
+  ebook-central-fetcher.md        # NEU
+  kvk-fetcher.md                  # NEU
+  generic-fetcher.md              # NEU — Discovery-Modus
+  auth-helper.md                  # NEU — geteilt
+
+commands/
+  fetch.md                        # NEU — /academic-research:fetch
+
+config/browser_guides/
+  tib.md                          # NEU
+  oapen.md                        # NEU
+  doabooks.md                     # NEU
+  degruyter.md                    # NEU
+  nationallizenzen.md             # NEU
+  ebook_central.md                # NEU
+  kvk.md                          # NEU
+  springer.md                     # ÜBERARBEITET — Buch-Download-Block
+
+scripts/bootstrap/
+  library-profiles/
+    leibniz-fh.yaml               # NEU
+    tum.yaml                      # NEU
+    rwth-aachen.yaml              # NEU
+    fau-erlangen.yaml             # NEU
+    template-shibboleth.yaml      # NEU
+    template-han.yaml             # NEU
+    template-ezproxy.yaml         # NEU
+    template-oa-only.yaml         # NEU
+```
+
+
+
+### v6.0 — Foundation (Sprint 1, ~1 Woche)
+
+- F1.1 Files-API für PDFs in `quote-extractor`
+- F1.2 1h-TTL-Cache überall durchziehen
+- F4 `/humanizer-de`-Integration in `chapter-writer` + neuer Slash-Command
+- F12 `git init` Auto-Setup
+
+### v6.1 — Bücher (Sprint 2, ~2 Wochen)
+
+- F2.1 Skill `book-handler`
+- F2.2 Kapitel-Schnitt + Seitenmapping + OCR-Detection
+- F2.3 CSL `book` / `chapter`-Schema + DIN-1505-Variant
+- F15 Eval-Coverage Bücher
+
+### v6.2 — Beschaffung (Sprint 3, ~2 Wochen)
+
+- F5 Pickup-Excel
+- F6 8-Tier-Download
+- F11 Cluster-Mermaid
+- **F16 Universal Book Fetcher** (TIB + 5 weitere Module + `web-fetcher` + Per-Uni-Profile + `/academic-research:fetch`)
+
+### v6.3 — Bridges (Sprint 4, ~1 Woche)
+
+- F7 Zotero-Pull
+- F8 Obsidian-Export
+- F9 NotebookLM-Bundle (manuell)
+
+### v6.4 — Methodik (Sprint 5, ~1 Woche)
+
+- F3 Memory-Tool + Decision-Log
+- F10 PRISMA-Flow
+- F13 CSL-Import
+
+### v6.5 — Polish
+
+- F14 Reading-List-Import
+- Doku, Migration-Guide, README-Update
+
+---
+
+## 17 · Risiken & Trade-offs
+
+| Risiko | Mitigation |
+|---|---|
+| Files-API ist Beta — kann brechen | Feature-Flag in `~/.academic-research/config.yaml`, Fallback auf base64 |
+| Memory-Tool nur in Managed-Agents oder mit eigenem Server | Pragmatisch: zunächst File-basiertes Memory in `projects/<slug>/memory/`, später Memory-Tool |
+| OCR auf Lokal-Hardware lahm | Async-Hook, User entscheidet pro PDF |
+| Zotero OAuth1-Schreib-Sync fehleranfällig | Erst Pull-only, Push erst wenn stabil |
+| `humanizer-de` ist nicht im Plugin vendoriert | Doku: Setup prüft Skill-Existenz, sonst Hinweis |
+| NotebookLM-CLI bricht ständig | als optional kennzeichnen, kein Hard-Dep |
+| Pickup-Excel-Workflow je Hochschule anders | Per-Profil-Konfig: `~/.academic-research/library-profiles/<uni>.yaml` mit OPAC-URL, HAN-Endpoint, Fernleih-URL |
+| 1M-Token-Modus = teuer | Default bleibt 200k, 1M nur bei expliziter `--book` Flag |
+
+---
+
+## 18 · Konkrete Anker-Diffs (Beispiele)
+
+### 18.1 `agents/quote-extractor.md` — Cache + Files-API
+
+```python
+file_id = ensure_uploaded(pdf_path)  # cached in pdf_status.json
+
+client.beta.messages.create(
+    model="claude-sonnet-4-7",
+    system=[{
+        "type": "text",
+        "text": AGENT_SYSTEM_PROMPT,
+        "cache_control": {"type": "ephemeral", "ttl": "1h"},
+    }],
+    documents=[{
+        "type": "document",
+        "source": {"type": "file", "file_id": file_id},
+        "citations": {"enabled": True},
+    }],
+    extra_headers={"anthropic-beta": "files-api-2025-04-14"},
+    messages=[{"role": "user",
+        "content": f"Extrahiere {n} Zitate zu '{query}', je ≤ 25 Wörter."}],
+)
+```
+
+### 18.2 Neuer `commands/humanize.md`
+
+```yaml
+---
+description: Anti-KI-Audit-Pass für ein Kapitel via humanizer-de
+disable-model-invocation: false
+allowed-tools: Read, Write, Skill(humanizer-de)
+argument-hint: <kapitel-pfad> [--mode normal|deep]
+---
+1. Lies die Datei.
+2. Aktiviere den `humanizer-de`-Skill mit dem gewünschten Modus.
+3. Schreibe Resultat als `<basename>.humanized.md`.
+4. Erzeuge `<basename>.diff.md` (vor/nach pro Severity).
+```
+
+### 18.3 `commands/pickup.md` — Skeleton
+
+```yaml
+---
+description: Erzeuge Bibliotheks-Pickup-Excel für nicht-OA-Quellen
+disable-model-invocation: false
+allowed-tools: Read, Write, Bash(~/.academic-research/venv/bin/python *), Skill(xlsx)
+---
+1. Lies `./literature_state.md`.
+2. Filter `source != open_access` UND `pdf_status != downloaded`.
+3. Resolve OPAC-Standorte über `scripts/library_pickup.py`.
+4. Render via xlsx-Skill: 4 Sheets (vor Ort / Fernleihe / OA / Lizenz).
+5. Speichere als `pickup-list.xlsx` im Projektordner.
+```
+
+---
+
+## 19 · Erwartete Wirkung
+
+| Metrik | v5.4.0 | v6.5 (Ziel) |
+|---|---|---|
+| Input-Tokens pro `/search` (50 Paper) | ~120k | ~50k (−58 %) |
+| Input-Tokens pro Zitat-Extraktion (5 PDFs) | ~600k | ~150k (−75 %) |
+| Buch-Support | nicht funktional | first-class |
+| KI-Detektor-Auffälligkeit (eigene Bench) | mittel | niedrig |
+| Sessions ohne Kontext-Verlust | < 30 % | > 95 % |
+| Beschaffungs-Zeit pro nicht-OA-Quelle | 5–10 min manuell | < 30 s |
+| Abdeckung systematische Reviews | nein | ja (PRISMA) |
+| Externe Tool-Bridges | 1 (browser-use) | 4 (+Zotero, Obsidian, NotebookLM) |
+
+---
+
+## 20 · Quellen
+
+- Anthropic Citations API — `docs.anthropic.com/en/docs/build-with-claude/citations`
+- Anthropic Files API (Beta) — `docs.anthropic.com/en/docs/build-with-claude/files`
+- Anthropic Prompt Caching (5min/1h TTL, März-2026-Default-Wechsel) — `docs.anthropic.com/en/docs/build-with-claude/prompt-caching`
+- Anthropic PDF Support (32 MB, 100/600 Pages) — `platform.claude.com/docs/en/build-with-claude/pdf-support`
+- Anthropic Message Batches (50 % Discount, 256 MB / 100k req) — `platform.claude.com/docs/en/build-with-claude/batch-processing`
+- humanizer-de — `github.com/marmbiz/humanizer-de`
+- Unpaywall API — `api.unpaywall.org/v2/<doi>?email=…`
+- DNB SRU (ISBN/GND) — `services.dnb.de/sru/dnb`
+- OpenLibrary API — `openlibrary.org/developers/api`
+- DOAB REST — `directory.doabooks.org/rest/search`
+- Zotero Web API v3 — `zotero.org/support/dev/web_api/v3/basics`
+- Pyzotero — `github.com/urschrei/pyzotero`
+- ZotLit / Obsidian-Zotero-Integration — `github.com/mgmeyers/obsidian-zotero-integration`
+- NotebookLM unofficial Python — `github.com/teng-lin/notebooklm-py`
+- Anystyle — `github.com/inukshuk/anystyle`
+- CSL Repository — `github.com/citation-style-language/styles`
+- PRISMA 2020 — `prisma-statement.org`
+- Contextual Retrieval (Anthropic Cookbook) — `anthropic.com/news/contextual-retrieval`
+- GBV SRU/CQL Schnittstellen — `gbv.github.io/cdvost2018`

--- a/docs/AUDIT-v6-vault.md
+++ b/docs/AUDIT-v6-vault.md
@@ -1,0 +1,343 @@
+# Vault-Architektur — Anhang zum v6-Audit
+
+**Erstellt:** 2026-05-07 · **Bezug:** `docs/AUDIT-v6-roadmap.md` §F7–F9
+**Frage:** Wie bekommen wir einen externen Speicher, in dem Claude PDFs,
+Metadaten und Zitate so ablegt, dass er token-sparend zugreifen kann und
+**garantiert nicht halluziniert**? Reicht Zotero, oder gibt es Besseres?
+
+**Kurzantwort:** Zotero allein reicht nicht. Optimal ist ein eigener
+**MCP-Server `academic-vault`** mit Zotero als optionalem Frontend-Layer.
+Begründung & Architektur unten.
+
+---
+
+## 1 · Warum Zotero allein nicht ausreicht
+
+| Anforderung | Zotero pur | Bemerkung |
+|---|---|---|
+| PDF-Storage | ✅ | hash-basierte Ordner, schwer für Tools |
+| Metadaten (BibTeX/CSL) | ✅ | sehr gut, Better-BibTeX als Plugin |
+| Volltext-Index | ⚠️ | Zotero hat eigenen FTS, aber kein API-Zugriff |
+| Semantische Suche | ❌ | nicht eingebaut |
+| Zitat-Cache mit Seitenangabe | ❌ | nichts — würde aus PDF jedesmal neu extrahiert |
+| Halluzinationsschutz | ❌ | Zotero validiert Output-Texte nicht |
+| Token-effiziente Tool-Calls | ❌ | Web-API gibt komplette Items, kein Snippet-Retrieval |
+| Cross-Session Memory | ⚠️ | nur Items, keine Decisions/Notes |
+| Decision-Log | ❌ | gibt es nicht |
+
+**Ergebnis:** Zotero ist eine sehr gute **User-UI** (PDF-Annotation,
+manuelles Tagging, Bibliographien-Export), aber kein Anti-Halluzinations-
+Backend. Der Vault muss zusätzlich existieren.
+
+---
+
+## 2 · Inventar: Was es bereits gibt
+
+### 2.1 Zotero-MCP-Server
+
+| Repo | Typ | Stärken | Schwächen |
+|---|---|---|---|
+| **`54yyyu/zotero-mcp`** (Python, pip) | Standalone-MCP | pyzotero-basiert, semantic search, PyPI-Install | externer Prozess, nicht plugin-internal |
+| **`cookjohn/zotero-mcp`** (Zotero-Plugin) | Zotero-Plugin mit MCP via Streamable HTTP | keine separate Installation, läuft im Zotero | nur solange Zotero offen |
+| **`ZotPilot`** | MCP-Server | semantic search auf `zotero.sqlite`, draft-LR | reines Read-Tool |
+
+### 2.2 Komplett-Lösungen
+
+| Repo | Was es macht | Eignung |
+|---|---|---|
+| **`Psypeal/claude-knowledge-vault`** | Claude-Code-Plugin, ingest Zotero/PubMed/arXiv → Wiki + Obsidian | gut als Inspiration, eigene Pfade |
+| **`WenyuChiou/research-hub`** | MCP für Zotero+Obsidian+NotebookLM | sehr nah dran, aber nicht plugin-internal |
+| **`Galaxy-Dawn/claude-scholar`** | ideation→writing assistant | Workflow, kein Vault |
+| **PaperQA2 (Future-House)** | RAG-Agent für Paper-QA mit Citations | Inspirations-Quelle, eigenes CLI |
+| **Letta (MemGPT)** | Memory-OS, 83.2 % LongMemEval | Memory-Layer, kein Citation-Backend |
+| **Mem0** | Bolt-on Memory | zu generisch für unsere Use-Cases |
+
+### 2.3 Tech-Bausteine
+
+- **`sqlite-vec`** (Alex Garcia) — embedded vector search, KNN, SIMD, dependency-free
+- **SQLite-FTS5** — bereits Built-in, BM25 ranking
+- **pyzotero** — Zotero-Web-API-Client (OAuth1 read+write)
+- **Anthropic Files API** — `file_id` für PDFs, kein Re-Upload
+- **Anthropic Citations API** — `page_location` / `char_location`
+- **Anthropic Memory-Tool** — File-basiertes Cross-Session-Memory
+- **Model2Vec** / **Voyage-3** / **Granite-Embedding** — lokale Embeddings
+
+---
+
+## 3 · Drei Architektur-Optionen
+
+### Option A — "Build the Vault" (eigener MCP-Server)
+
+```
+┌─────────────────────────────────────────────────────────┐
+│            academic-vault (eigener MCP)                 │
+├─────────────────────────────────────────────────────────┤
+│  SQLite           : papers, quotes, decisions, files    │
+│  FTS5             : Volltext-Suche über pdf_text        │
+│  sqlite-vec       : semantic search über chunk_embed    │
+│  Files-API-Cache  : pdf_path → file_id (TTL)            │
+│  Citation-Cache   : (paper_id, page) → verbatim         │
+└─────────────────────────────────────────────────────────┘
+                ▲
+                │ MCP tools
+                │
+   ┌────────────┴────────────┐
+   │  academic-research      │
+   │  Skills/Agents/Commands │
+   └─────────────────────────┘
+```
+
+**MCP-Tools (Auswahl):**
+
+```
+vault.search(query, type?, top_k?)        → [paper_id, snippet, score]
+vault.get_paper(paper_id)                  → metadata + pdf_status
+vault.get_quote(quote_id)                  → verbatim + page + paper_id
+vault.find_quotes(paper_id, query, k?)     → [quote_id, ...]
+vault.add_quote(paper_id, quote)           → quote_id (mit Provenance)
+vault.add_note(paper_id, note)             → note_id
+vault.add_decision(text, category)         → decision_id
+vault.list_decisions(category?)            → [decision, ...]
+vault.import_zotero(library_id, key)       → import_log
+vault.ensure_file(pdf_path)                → file_id (cached)
+vault.stats()                              → counts + token-savings
+```
+
+**Datenmodell (SQLite-Schema, gekürzt):**
+
+```sql
+CREATE TABLE papers (
+  paper_id TEXT PRIMARY KEY,            -- citekey oder uuid
+  type TEXT NOT NULL,                   -- article-journal | book | chapter
+  csl_json TEXT NOT NULL,               -- volle CSL-JSON-Daten
+  doi TEXT, isbn TEXT,
+  pdf_path TEXT,                        -- lokaler Pfad
+  file_id TEXT,                         -- Anthropic Files-API
+  file_id_expires_at INTEGER,
+  page_offset INTEGER DEFAULT 0,        -- pdf_page → printed_page
+  ocr_done BOOLEAN DEFAULT 0,
+  added_at INTEGER, updated_at INTEGER
+);
+
+CREATE VIRTUAL TABLE papers_fts USING fts5(
+  title, abstract, fulltext, content='papers'
+);
+
+CREATE TABLE quotes (
+  quote_id TEXT PRIMARY KEY,
+  paper_id TEXT REFERENCES papers,
+  verbatim TEXT NOT NULL,
+  pdf_page INTEGER,
+  printed_page INTEGER,                 -- mit page_offset korrigiert
+  section TEXT,
+  context_before TEXT, context_after TEXT,
+  extraction_method TEXT NOT NULL,      -- 'citations-api' | 'manual'
+  api_response_id TEXT,                 -- Anthropic-Request-ID für Audit
+  created_at INTEGER
+);
+
+CREATE VIRTUAL TABLE quote_embeddings USING vec0(
+  quote_id TEXT PRIMARY KEY,
+  embedding FLOAT[384]                  -- Model2Vec dims
+);
+
+CREATE TABLE decisions (
+  decision_id TEXT PRIMARY KEY,
+  category TEXT,                        -- citation_style | methodology | ...
+  text TEXT NOT NULL,
+  rationale TEXT,
+  created_at INTEGER,
+  superseded_by TEXT REFERENCES decisions
+);
+
+CREATE TABLE notes (
+  note_id TEXT PRIMARY KEY,
+  paper_id TEXT REFERENCES papers,
+  text TEXT NOT NULL,
+  tags TEXT,                            -- JSON-Array
+  created_at INTEGER
+);
+```
+
+**Halluzinationsschutz, hart verdrahtet:**
+
+- `vault.add_quote(...)` akzeptiert nur Quotes mit `extraction_method: 'citations-api'` und füllten `api_response_id` — Manuelle Quotes brauchen explizites `--manual`-Flag
+- Hook `PreToolUse` für `Write` mit Pfad-Match auf `kapitel/*.md`: parst zitierte Strings (Anführungszeichen-Spans), greppt im Vault → unbekannte Strings führen zu Block + Hinweis „Zitat nicht im Vault, bitte über `quote-extractor` ziehen"
+- Skills lesen Zitate **nur** über `vault.get_quote(id)` — Direkter PDF-Lese-Pfad ist deprecated
+
+**Pro/Contra:**
+
+- ✅ Volle Kontrolle, perfekt auf Plugin-Use-Cases getunt
+- ✅ Halluzinationsschutz hart verdrahtbar
+- ✅ Token-effizient (gezielte Tool-Calls statt PDF in Context)
+- ✅ Cross-Session-Persistenz garantiert
+- ✅ Lock-in vermeidbar (SQLite portabel, JSON-Export trivial)
+- ❌ ~600–900 LOC Python (MCP-Server in `mcp` Python-SDK)
+- ❌ 1 Sprint Aufwand (geschätzt 1 Woche)
+
+**Aufwand:** ~1 Woche (1 Sprint)
+
+---
+
+### Option B — "Ride zotero-mcp" (bestehenden MCP nutzen)
+
+```
+┌─────────────────────────┐         ┌──────────────────────┐
+│  zotero-mcp (54yyyu)    │◄────────│ academic-research    │
+│  pyzotero + semantic    │  MCP    │ Skills/Commands      │
+│  Zotero Web API v3      │         └──────────────────────┘
+└─────────────────────────┘
+```
+
+**Pro/Contra:**
+
+- ✅ Kein eigener Code, sofort einsetzbar (`pip install zotero-mcp`)
+- ✅ Community-maintained
+- ✅ Nutzt vorhandene Zotero-Library als Backend
+- ❌ Lock-in auf Zotero-Schema (User muss Zotero-Account haben)
+- ❌ Kein Citation-Cache mit Provenance — Zitate werden bei jedem Bedarf neu extrahiert
+- ❌ Halluzinationsschutz nur soft (kein Hook-basierter Block)
+- ❌ Files-API-Cache nicht trivial integrierbar
+- ❌ Decisions/Notes brauchen Zotero-Notes-Hack
+- ❌ Bei großen Libraries (>5000 Items) Performance-Themen
+
+**Aufwand:** 1 Tag (Integration + Doku)
+
+---
+
+### Option C — "Vault + Zotero-Bridge" (**empfohlen**)
+
+```
+                  ┌─────────────────────────────┐
+                  │   academic-vault (eigener)  │  ← Halluzinations-
+                  │                             │     kritisch
+                  │   - papers, quotes,         │
+                  │     decisions, notes        │
+                  │   - SQLite + FTS5 +         │
+                  │     sqlite-vec              │
+                  │   - Files-API-Cache         │
+                  └────────┬─────────┬──────────┘
+                           ▲         │
+                  pull-only│         │PDF-Bundle-Export
+                           │         │
+              ┌────────────┴┐       ┌▼────────────────┐
+              │   Zotero    │       │  NotebookLM     │  ← optionale
+              │  (Frontend) │       │  (Triage, opt.) │     Bridges
+              │  pyzotero   │       │  Bücher >600 S. │
+              └─────────────┘       └─────────────────┘
+```
+
+**Komponenten:**
+
+1. **`academic-vault` MCP-Server** (eigener) — Single Source of Truth für
+   alles Zitat-/Halluzinations-Kritische
+2. **`zotero-import` Skill** — pyzotero-Pull, dedupliziert via DOI/ISBN
+3. **`notebook-bundle` Skill (optional)** — packt PDF-Bundle für
+   manuellen Upload in NotebookLM (für Bücher >600 Seiten)
+
+**Pro/Contra:**
+
+- ✅ Halluzinationsschutz hart (eigener Vault)
+- ✅ User-Frontend frei wählbar (Zotero oder keins)
+- ✅ Kein Lock-in auf einzelnes Tool
+- ✅ Token-effizient
+- ✅ Inkrementell ausrollbar (zuerst Vault, dann Bridges)
+- ❌ Eigener MCP-Server zu maintainen
+- ❌ ~1.5 Sprints Aufwand
+
+**Aufwand:** ~1.5 Wochen (1 Sprint Vault + 0.5 Sprint Zotero-Bridge)
+
+---
+
+## 4 · Token-Spar-Mechanik im Detail
+
+**Heute (v5.4):** Skill `chapter-writer` lädt
+`literature_state.md` (alle Quellen-Stubs) + relevante PDF-Auszüge
+manuell pro Aufruf. ≈ 8–15 k Token Boilerplate.
+
+**Mit Vault:**
+
+```
+1. chapter-writer ruft: vault.search("DevOps Governance Compliance", k=5)
+   → 5 paper_ids + 1-Satz-Snippets  (≈ 200 Token)
+
+2. Pro Paper-ID: vault.find_quotes(paper_id, query, k=3)
+   → 15 quote_ids + verbatim + page  (≈ 1500 Token total)
+
+3. chapter-writer schreibt; Hook validiert Verbatim-Strings gegen Vault.
+
+Total: ~1700 Token statt 10000+ → ~83 % Ersparnis pro Kapitel-Iteration.
+```
+
+**Anti-Halluzinations-Garantie:**
+
+- Zitate im Output, die nicht in `quotes`-Tabelle existieren → Hook blockt Write
+- Seitenangaben werden nicht vom Modell „erinnert", sondern aus
+  `quotes.printed_page` materialisiert → keine `(Müller 2023, S. 47)`-
+  Halluzination möglich
+- Decisions („Wir nutzen IEEE statt APA") sind Tool-Antworten, nicht
+  Modell-Erinnerungen
+
+---
+
+## 5 · Migration aus heutigem Stand
+
+**Phase 1 — Vault-Foundation (Sprint v6.0)**
+- MCP-Server-Skeleton mit SQLite-Schema
+- Tools: `vault.search`, `vault.get_paper`, `vault.add_quote`,
+  `vault.ensure_file`
+- Migration-Skript: `literature_state.md` + PDFs → SQLite-Initial-Seed
+
+**Phase 2 — Skill-Anpassung (Sprint v6.0)**
+- `quote-extractor` schreibt in `vault.add_quote()` statt JSON-File
+- `chapter-writer` liest via `vault.find_quotes()`
+- Hook für Verbatim-Validation
+
+**Phase 3 — Bridges (Sprint v6.3)**
+- `zotero-import` (pyzotero pull-only)
+- `notebook-bundle` (PDF-Pack für NotebookLM)
+
+**Phase 4 — Memory & Decisions (Sprint v6.4)**
+- `vault.add_decision` integriert in alle Skills
+- `decisions.log` exportierbar als PRISMA-Audit-Trail
+
+**Backwards-Compat:** `literature_state.md` bleibt als
+**read-only Snapshot-Export** aus dem Vault — Nutzer:innen, die nur
+Markdown wollen, sehen kein Regression.
+
+---
+
+## 6 · Empfehlung
+
+**Option C** ("Vault + Zotero-Bridge"). Begründung:
+
+1. **Halluzinationsschutz** ist das Killer-Feature — nur mit eigenem Vault
+   hart verdrahtbar (Hook-basierte Verbatim-Validation)
+2. **Token-Ersparnis** ~80 % messbar — Tool-Calls statt Context-Stuffing
+3. **Lock-in vermeiden** — User können Zotero-Frontend nutzen oder ohne
+4. **Inkrementell** — Phase 1+2 liefern schon 80 % des Wertes,
+   Zotero-Bridge (Phase 3) ist nice-to-have
+5. **Plugin-intern** — kein zweites Repo zu maintainen,
+   `mcp/academic-vault/` als Sub-Tree
+
+**Risiko-Mitigation:**
+
+- Vendor-Drift Anthropic Files-API (Beta) → Fallback auf `pdf_path`
+- sqlite-vec Build-Abhängigkeit → Fallback auf reine FTS5
+- Memory-Tool noch nicht Cross-Session ohne Managed-Agents → Vault
+  übernimmt diese Rolle eigenständig
+
+---
+
+## 7 · Quellen (neu hinzugekommen)
+
+- `Psypeal/claude-knowledge-vault` — `github.com/Psypeal/claude-knowledge-vault`
+- `54yyyu/zotero-mcp` — `github.com/54yyyu/zotero-mcp`
+- `cookjohn/zotero-mcp` — `github.com/cookjohn/zotero-mcp`
+- `WenyuChiou/research-hub` — `github.com/WenyuChiou/research-hub`
+- `Future-House/paper-qa` (PaperQA2) — `github.com/future-house/paper-qa`
+- `letta-ai/letta` (MemGPT) — `letta.com`
+- `mem0ai/mem0` — `mem0.ai`
+- `asg017/sqlite-vec` — `github.com/asg017/sqlite-vec`
+- `Galaxy-Dawn/claude-scholar` — `github.com/Galaxy-Dawn/claude-scholar`
+- ZotPilot Forum-Post — `forums.zotero.org/discussion/130483`

--- a/skills/_common/preamble.md
+++ b/skills/_common/preamble.md
@@ -1,0 +1,48 @@
+# Gemeinsames Preamble — academic-research Skills
+
+Dieses Preamble gilt für alle Skills dieses Plugins.
+Jeder Skill lädt diese Datei am Anfang seiner Aktivierung.
+
+## Vorbedingungen
+
+Bevor du startest: Prüfe, ob `./academic_context.md` und `./literature_state.md`
+vorhanden und aktuell sind. Fehlt Kontext → triggere den `academic-context`-
+Skill und warte auf dessen Abschluss.
+
+Lehnt der User den Trigger ab → brich diesen Skill ab und erkläre:
+"Ohne Forschungsfrage und Methodik-Angabe kann ich kein belastbares Ergebnis
+liefern, weil ich ein erfundenes Thema beschreiben würde."
+
+## Keine Fabrikation
+
+Erfundene Ergebnisse, Methoden oder Zahlen sind ein Täuschungsversuch nach
+FH-Leibniz-Prüfungsordnung und führen zum Verlust der Prüfungsleistung.
+Arbeite ausschließlich mit Inhalten aus `./writing_state.md` (Arbeitstext)
+und `./academic_context.md` (Forschungsfrage, Methodik). Fehlen Daten: frag
+den User, rate nicht.
+
+## Aktivierung
+
+- Der User aktiviert einen Skill dieses Plugins explizit oder durch Trigger-Phrase
+- Der User-Auftrag passt zur Skill-Beschreibung im Frontmatter
+
+## Abgrenzung
+
+Jeder Skill definiert in seiner eigenen `## Abgrenzung`-Section, was er liefert
+und was er nicht liefert. Fehlt diese Section im Skill, gilt: Skill nur für den
+im Frontmatter beschriebenen Zweck einsetzen.
+
+---
+
+## Hinweise für Skill-Maintainer
+
+### Variant-Referenzen
+
+Variant-Referenzen (z.B. citation-extraction/references/) erst nach
+Variant-Fixierung laden (lazy per Read-Anweisung im Skill).
+
+### Browser-Snapshots
+
+Raw-DOM-Ausgaben des `browser-use`-CLI in `$SESSION_DIR/raw/` speichern.
+Dem Modell nur das normalisierte Schema-Result zurückgeben
+(`title`, `authors`, `year`, `url`, `abstract`).

--- a/skills/abstract-generator/SKILL.md
+++ b/skills/abstract-generator/SKILL.md
@@ -6,31 +6,16 @@ license: MIT
 
 # Abstract-Generator
 
+> **Gemeinsames Preamble laden:** Lies `skills/_common/preamble.md`
+> und befolge alle dort definierten Blöcke (Vorbedingungen, Keine Fabrikation,
+> Aktivierung, Abgrenzung), bevor du mit diesem Skill-spezifischen Inhalt
+> fortfährst.
+
 ## Übersicht
 
 Erzeugt Abstract, Keywords und Management-Summary aus einer abgeschlossenen
 akademischen Arbeit. Liefert konkrete Formulierungen, keine Platzhalter,
 und respektiert Hochschul-Längenvorgaben.
-
-Liest eine fertige oder nahezu fertige akademische Arbeit und erzeugt strukturierte Abstracts, Zusammenfassungen und Keyword-Listen. Produziert Output-Varianten passend zum Arbeitstyp und den Hochschul-Anforderungen.
-
-## Vorbedingungen
-
-Bevor du startest: Prüfe, ob `./academic_context.md` und `./literature_state.md`
-vorhanden und aktuell sind. Fehlt Kontext → triggere den `academic-context`-
-Skill und warte auf dessen Abschluss.
-
-Lehnt der User den Trigger ab → brich diesen Skill ab und erkläre:
-"Ohne Forschungsfrage und Methodik-Angabe kann ich kein belastbares Abstract
-liefern, weil ich ein erfundenes Thema beschreiben würde."
-
-## Keine Fabrikation
-
-Erfundene Ergebnisse, Methoden oder Zahlen im Abstract sind ein Täuschungs-
-versuch nach FH-Leibniz-Prüfungsordnung und führen zum Verlust der Prüfungs-
-leistung. Arbeite ausschließlich mit Inhalten aus `./writing_state.md`
-(Arbeitstext) und `./academic_context.md` (Forschungsfrage, Methodik). Fehlen
-Daten: frag den User, rate nicht.
 
 ## Abgrenzung
 
@@ -91,17 +76,10 @@ Für den Arbeitstitel selbst → `title-generator`.
 > keine Kausalaussage möglich. Folgeforschung sollte experimentelles Design
 > mit Kontrollgruppe prüfen."
 
-## Aktivierung dieses Skills
-
-- Der User fragt nach einem Abstract (deutsch oder englisch)
-- Der User braucht eine Management Summary bzw. Executive Summary
-- Der User braucht eine Keyword-Liste
-- Der User fragt nach einer Zusammenfassung seiner Arbeit
-
 ## Kontext-Dateien
 
-- Lies `./academic_context.md` für Universität, Arbeitstyp, Sprache, Forschungsfrage, Methodik und formale Anforderungen
-- Lies `./writing_state.md` für den Fertigstellungsstatus der Kapitel und die während des Schreibens identifizierten Kernaussagen
+- `./academic_context.md` — Universität, Arbeitstyp, Sprache, Forschungsfrage, Methodik, formale Anforderungen
+- `./writing_state.md` — Kapitelstatus, Kernaussagen
 
 ## Deliverables
 
@@ -170,16 +148,11 @@ Erzeuge zwei Keyword-Sets:
 
 ## Generierungs-Workflow
 
-1. Lies `./academic_context.md` für formale Anforderungen und Kontext
-2. Lies den kompletten Arbeitstext (oder alle verfügbaren Kapitel)
-3. Identifiziere: Forschungsfrage, Methodik, Kernergebnisse, Hauptbeitrag, Limitationen, Implikationen
-4. Entscheide auf Basis des Arbeitstyps, welche Deliverables zu erzeugen sind:
-   - Bachelor-/Masterarbeit: Abstract (DE), Abstract (EN), Management Summary, Keywords
-   - Haus-/Seminararbeit: Abstract (DE), Keywords
-   - Facharbeit: nur Abstract (DE) (kurze Version, 100-150 Wörter)
-5. Entwirf jedes Deliverable gemäß der oben beschriebenen Struktur und Vorgaben
-6. Gegencheck: Sicherstellen, dass das Abstract den tatsächlichen Inhalt der Arbeit widerspiegelt (nicht den geplanten Inhalt aus der Gliederung)
-7. Präsentiere alle Deliverables in strukturiertem Output
+1. Lies `./academic_context.md` + Arbeitstext
+2. Identifiziere: Forschungsfrage, Methodik, Kernergebnisse, Hauptbeitrag, Limitationen
+3. Deliverables nach Arbeitstyp: Bachelor-/Masterarbeit → DE+EN+ManSummary+Keywords; Hausarbeit → DE+Keywords; Facharbeit → nur DE (100-150W)
+4. Entwirf, dann Gegencheck: Abstract spiegelt tatsächlichen Inhalt (nicht Gliederungsplan)
+5. Strukturierten Output präsentieren
 
 ## Output-Format
 

--- a/skills/academic-context/SKILL.md
+++ b/skills/academic-context/SKILL.md
@@ -6,49 +6,27 @@ license: MIT
 
 # Akademischer Kontext
 
+> **Gemeinsames Preamble laden:** Lies `skills/_common/preamble.md`
+> und befolge alle dort definierten Blöcke (Vorbedingungen, Keine Fabrikation,
+> Aktivierung, Abgrenzung), bevor du mit diesem Skill-spezifischen Inhalt
+> fortfährst.
+
+> **Override Vorbedingungen:** Keine Vorbedingungen — dieser Skill bootet den
+> Kontext. Alle anderen Skills setzen voraus, dass `./academic_context.md`
+> existiert, und triggern diesen Skill bei Fehlen.
+
 ## Übersicht
 
 Bootet den akademischen Kontext einer Arbeit: Thema, Forschungsfrage,
 Arbeitstyp, Methodik, Disziplin, Hochschule. Schreibt das Ergebnis in
 `./academic_context.md` als Single Source of Truth für alle anderen Skills.
 
-## Vorbedingungen
-
-Keine Vorbedingungen — dieser Skill bootet den Kontext. Alle anderen Skills
-setzen voraus, dass `./academic_context.md` existiert, und triggern diesen
-Skill bei Fehlen.
-
-Pflegt einen persistenten akademischen Kontext, auf den sich andere Skills verlassen. Dieser Skill liest und schreibt Kontext-Dateien im Projekt-Ordner, um Thema, Gliederung, Forschungsfrage, Methodik, Fortschritt und Schlüsselkonzepte der Arbeit des Users zu tracken.
-
-## Keine Fabrikation
-
-Erfundene Kontextangaben (Thema, Methodik, Fragestellung) produzieren eine
-vergiftete Kontext-Basis, die alle nachgelagerten Skills wertlos macht. Arbeite
-ausschließlich mit Angaben, die der User im Gespräch explizit bestätigt hat —
-rate keine Werte, frag nach.
-
-## Aktivierung dieses Skills
-
-- Der User erwähnt seine Abschlussarbeit, Hausarbeit oder akademische Arbeit
-- Der User liefert oder aktualisiert Forschungsthema, Gliederung oder Forschungsfrage
-- Ein anderer Skill braucht akademischen Kontext, aber es ist noch keiner vorhanden
-- Der User fragt explizit nach einer Aktualisierung seines akademischen Profils
-
 ## Kontext-Dateien
 
-Der gesamte Kontext liegt im aktuellen Projekt-Ordner (cwd). Drei Dateien werden verwaltet:
-
-### `./academic_context.md` — Primäre Kontextdatei
-
-Enthält das Arbeitsprofil (Universität, Studiengang, Zitationsstil), die Arbeitsdetails (Typ, Thema, Forschungsfrage, Methodik, Betreuer, Abgabetermin), die Gliederungsstruktur, Schlüsselkonzepte und den Fortschritt.
-
-### `./literature_state.md` — Literaturstatus
-
-Enthält Statistiken zu gesammelten Quellen (Gesamtzahl, Peer-Review-Anteil, Typenverteilung), Kapitel-Quellen-Zuordnung sowie identifizierte Lücken.
-
-### `./writing_state.md` — Schreibfortschritt
-
-Enthält das aktuell geschriebene Kapitel, Wortzahlen und die jüngsten Style-Evaluator-Scores.
+Alle im aktuellen Projekt-Ordner (cwd):
+- `./academic_context.md` — Arbeitsprofil, Forschungsfrage, Methodik, Gliederung, Fortschritt
+- `./literature_state.md` — Quellen-Inventar, Kapitelzuordnungen, Lücken
+- `./writing_state.md` — Kapitelstatus, Wortzahlen, Style-Scores
 
 ## Core-Workflow
 
@@ -103,23 +81,11 @@ type: project
 
 ### Update-Aktivierung (Kontext existiert bereits)
 
-Existiert schon Kontext, lies die aktuelle `./academic_context.md` aus dem Projekt-Ordner. Identifiziere auf Basis des Gesprächs, was sich geändert hat, und aktualisiere nur die betroffenen Abschnitte. Bewahre alle bestehenden Daten, die nicht explizit geändert wurden.
-
-Typische Updates:
-- **Gliederungsänderungen** — User hat die Kapitelstruktur verfeinert
-- **Fortschrittsupdates** — User hat ein Kapitel oder einen Abschnitt abgeschlossen
-- **Neue Konzepte** — User hat neue Schlüsselbegriffe eingeführt
-- **Forschungsfragen-Schärfung** — User hat den Fokus präzisiert
-- **Methodik-Entscheidung** — User hat einen Ansatz gewählt oder geändert
+Lies `./academic_context.md`, identifiziere Änderungen aus dem Gespräch, aktualisiere nur betroffene Abschnitte. Typische Updates: Gliederung, Fortschritt, neue Konzepte, Forschungsfragen-Schärfung, Methodik-Entscheidung.
 
 ### Unterstützung anderer Skills
 
-Wenn ein anderer Skill (`citation-extraction`, `literature-gap-analysis`, `advisor` etc.) Kontext braucht:
-
-1. Prüfe, ob `./academic_context.md` im Projekt-Ordner existiert
-2. Wenn ja — lies sie und nutze sie
-3. Wenn nein — informiere den User, dass Kontext benötigt wird, und biete das Setup an
-4. Gib nach dem Setup die Kontrolle an den aufrufenden Workflow zurück
+Braucht ein anderer Skill Kontext: Prüfe ob `./academic_context.md` existiert. Wenn ja — nutze sie. Wenn nein — informiere den User und biete Setup an.
 
 ## Few-Shot-Beispiele
 

--- a/skills/advisor/SKILL.md
+++ b/skills/advisor/SKILL.md
@@ -6,31 +6,16 @@ license: MIT
 
 # Advisor — Gliederungs- und Exposé-Builder
 
+> **Gemeinsames Preamble laden:** Lies `skills/_common/preamble.md`
+> und befolge alle dort definierten Blöcke (Vorbedingungen, Keine Fabrikation,
+> Aktivierung, Abgrenzung), bevor du mit diesem Skill-spezifischen Inhalt
+> fortfährst.
+
 ## Übersicht
 
 Supervisor-Agent für die Gesamt-Gliederung einer Arbeit. Bewertet Struktur,
 schlägt Kapitel-Reorganisation vor, liefert Expose-Templates. Orchestriert
 andere Skills, wenn spezifische Themenbereiche vertieft werden müssen.
-
-Baut, verfeinert und validiert Gliederungen und Exposé-Dokumente im interaktiven Dialog. Führt den User vom Ausgangsthema zu einem strukturierten, gut begründeten Kapitelplan.
-
-## Vorbedingungen
-
-Bevor du startest: Prüfe, ob `./academic_context.md` und `./literature_state.md`
-vorhanden und aktuell sind. Fehlt Kontext → triggere den `academic-context`-
-Skill und warte auf dessen Abschluss.
-
-Lehnt der User den Trigger ab → brich diesen Skill ab und erkläre:
-"Ohne Forschungsfrage und Kapitelstruktur kann ich keine fundierte Outline-
-Beratung liefern, weil ich gegen unbekannte Vorgaben beraten würde."
-
-## Keine Fabrikation
-
-Erfundene Kapitelstruktur-Standards oder Gliederungsempfehlungen führen zu
-nachträglichen Überarbeitungen nach Abgabe und gefährden den Zeitplan. Arbeite
-ausschließlich mit `./academic_context.md` (Arbeitstyp, Forschungsfrage,
-Supervisor-Vorgaben) und `./literature_state.md`. Fehlen Daten: frag den User,
-rate nicht.
 
 ## Abgrenzung
 
@@ -53,31 +38,16 @@ Zwischenstufen-Urteil:
 
 Ausgabe: Tabelle mit Kriterium + PASS/FAIL + Begründung bei FAIL.
 
-## Aktivierung dieses Skills
-
-- Der User möchte eine Gliederung erstellen oder überarbeiten
-- Der User muss ein Exposé oder Forschungsproposal schreiben
-- Der User fragt nach Kapitelstruktur, Reihenfolge oder logischem Aufbau
-- Der User möchte planen, welche Themen in welches Kapitel gehören
-
 ## Kontext-Dateien
 
-### Lesen
-
-- `./academic_context.md` — Arbeitsprofil, Forschungsfrage, Methodik, bestehende Gliederung
-- `./literature_state.md` — Vorhandene Quellen und Kapitelzuordnungen (zur Literaturabdeckungs-Prüfung)
-
-### Schreiben
-
-- `./academic_context.md` — Aktualisiere den Abschnitt `## Gliederung` nach Gliederungsänderungen
+- Lesen: `./academic_context.md` (Forschungsfrage, Methodik, Gliederung), `./literature_state.md` (Quellen, Kapitelzuordnungen)
+- Schreiben: `./academic_context.md` — Abschnitt `## Gliederung` nach Änderungen aktualisieren
 
 ## Core-Workflow
 
 ### 1. Kontext laden
 
-Lies `./academic_context.md` aus dem Projekt-Ordner. Existiert sie nicht, informiere den User und triggere den `academic-context`-Skill, um Grunddaten zu erheben, bevor fortgefahren wird.
-
-Extrahiere: Arbeitstyp, Thema, Forschungsfrage, Unterfragen, Methodik und eine eventuell vorhandene Gliederung.
+Lies `./academic_context.md`. Fehlt sie: `academic-context`-Skill triggern. Extrahiere: Arbeitstyp, Thema, Forschungsfrage, Unterfragen, Methodik, Gliederung.
 
 ### 2. Interaktiver Gliederungsdialog
 
@@ -117,7 +87,7 @@ Falls `./literature_state.md` existiert, Gliederung gegen vorhandene Quellen abg
 - Ob Peer-Review-Quellen vorhanden sind
 - Lücken, in denen keine Literatur zugewiesen ist
 
-Bei Lücken biete an, `/search` für einzelne Kapitel zu triggern — mit gezielten Queries aus Kapiteltiteln und Schlüsselkonzepten.
+Bei Lücken: `/search` mit Queries aus Kapiteltiteln und Schlüsselkonzepten anbieten.
 
 ### 5. Exposé-Generierung
 
@@ -136,11 +106,7 @@ Erzeuge den Zeitplan auf Basis des Abgabetermins aus `./academic_context.md`. Re
 
 ### 6. Änderungen speichern
 
-Nachdem der User die Gliederung oder das Exposé bestätigt hat:
-
-1. `./academic_context.md` erneut lesen (veraltete Überschreibungen vermeiden)
-2. Nur den Abschnitt `## Gliederung` mit der neuen Gliederung aktualisieren
-3. `## Fortschritt` ergänzen, falls anwendbar
+Nach User-Bestätigung: `./academic_context.md` lesen, Abschnitt `## Gliederung` aktualisieren, `## Fortschritt` ergänzen.
 
 ## Verfeinerung einer bestehenden Gliederung
 

--- a/skills/chapter-writer/SKILL.md
+++ b/skills/chapter-writer/SKILL.md
@@ -7,31 +7,16 @@ license: MIT
 
 # Kapitel-Autor
 
+> **Gemeinsames Preamble laden:** Lies `skills/_common/preamble.md`
+> und befolge alle dort definierten Blöcke (Vorbedingungen, Keine Fabrikation,
+> Aktivierung, Abgrenzung), bevor du mit diesem Skill-spezifischen Inhalt
+> fortfährst.
+
 ## Übersicht
 
 Schreibt konkrete Kapitel (Einleitung, Theorieteil, Methodik, Empirie,
 Diskussion, Fazit) für akademische Arbeiten. Zieht Zitate aus
 `./literature_state.md` und folgt dem Disziplin-Register.
-
-Verfasst einzelne Thesis-Kapitel und Abschnitte auf Basis von Forschungskontext, Gliederung, verfügbarer Literatur und Zitaten. Produziert akademische Prosa, die der User Abschnitt für Abschnitt reviewt, editiert und freigibt.
-
-## Vorbedingungen
-
-Bevor du startest: Prüfe, ob `./academic_context.md` und `./literature_state.md`
-vorhanden und aktuell sind. Fehlt Kontext → triggere den `academic-context`-
-Skill und warte auf dessen Abschluss.
-
-Lehnt der User den Trigger ab → brich diesen Skill ab und erkläre:
-"Ohne Kapitelstruktur in `./literature_state.md` kann ich keinen passenden
-Kapiteltext liefern, weil ich einen Kapiteltyp annehmen würde, der nicht zur
-Arbeit passt."
-
-## Keine Fabrikation
-
-Erfundene Belege, Zitate oder Faktenaussagen im Fließtext sind laut FH-Leibniz-
-Prüfungsordnung ein Plagiatsbefund und führen zum Verlust der Prüfungsleistung
-(Note 5). Arbeite ausschließlich mit Zitaten aus `./literature_state.md` und
-direkt geladenen PDFs. Fehlen Daten: frag den User, rate nicht.
 
 ## Abgrenzung
 
@@ -86,32 +71,16 @@ Für reines Extrahieren wörtlicher Zitate aus einem PDF → `citation-extractio
 > Metallverarbeitung (hohe Arbeitsteilung) dämpfen Führungseffekte —
 > konsistent mit Liao & Chuang (2007)."
 
-## Aktivierung dieses Skills
-
-- Der User möchte ein bestimmtes Kapitel oder einen Abschnitt schreiben oder entwerfen
-- Der User bittet um Hilfe beim Formulieren akademischen Texts für seine Arbeit
-- Der User möchte Stichpunkte oder Notizen zu Fließtext ausbauen
-- Der User braucht Hilfe bei Übergängen zwischen Abschnitten
-
 ## Kontext-Dateien
 
-### Lesen
-
-- `./academic_context.md` — Arbeitsprofil, Forschungsfrage, Gliederung, Schlüsselkonzepte
-- `./literature_state.md` — Verfügbare Quellen, Kapitel-Quellen-Zuordnungen
-- `./writing_state.md` — Aktueller Schreibfortschritt, Wortzahlen, Style-Scores
-
-### Schreiben
-
-- `./writing_state.md` — Wortzahlen, aktuelles Kapitel und Fortschritt nach dem Schreiben aktualisieren
+- Lesen: `./academic_context.md` (Forschungsfrage, Gliederung), `./literature_state.md` (Quellen), `./writing_state.md` (Fortschritt)
+- Schreiben: `./writing_state.md` — Wortzahlen und Kapitelstatus aktualisieren
 
 ## Core-Workflow
 
 ### 1. Kontext laden
 
-Lies alle drei Kontext-Dateien im Projekt-Ordner. Existiert `./academic_context.md` nicht, informiere den User und triggere zuerst den `academic-context`-Skill. Gibt es noch keine Gliederung, schlage vor, den `advisor`-Skill zu triggern, bevor geschrieben wird.
-
-Extrahiere: Ziel-Kapitel aus der Gliederung, zugeordnete Quellen aus dem Literaturstatus, Zitationsstil, Sprache der Arbeit und vorhandene Entwürfe.
+Lies alle drei Kontext-Dateien. Fehlt `./academic_context.md`: `academic-context`-Skill triggern. Fehlt Gliederung: `advisor`-Skill vorschlagen. Extrahiere Ziel-Kapitel, Quellen, Zitationsstil, Sprache, vorhandene Entwürfe.
 
 ### 2. Ziel-Kapitel bestimmen
 

--- a/skills/citation-extraction/SKILL.md
+++ b/skills/citation-extraction/SKILL.md
@@ -7,6 +7,11 @@ license: MIT
 
 # Zitat-Extraktion
 
+> **Gemeinsames Preamble laden:** Lies `skills/_common/preamble.md`
+> und befolge alle dort definierten Blöcke (Vorbedingungen, Keine Fabrikation,
+> Aktivierung, Abgrenzung), bevor du mit diesem Skill-spezifischen Inhalt
+> fortfährst.
+
 ## Übersicht
 
 Extrahiert und formatiert Zitate aus PDFs und Volltexten. Liefert
@@ -14,38 +19,11 @@ Literaturverzeichnisse im Zitationsstil aus `./academic_context.md`
 (APA7, IEEE, Harvard etc.). Arbeitet eng mit der Claude-API
 `documents[] + citations.enabled`.
 
-Extrahiert relevante Zitate aus akademischen PDFs, formatiert sie im gewünschten Stil und organisiert Zitatdaten nach Kapitel. Nutzt den Agent `quote-extractor` für die Extraktion und die Inline-Zitationslogik (siehe Abschnitt "Zitat-Formatierung" unten).
-
-## Vorbedingungen
-
-Bevor du startest: Prüfe, ob `./academic_context.md` und `./literature_state.md`
-vorhanden und aktuell sind. Fehlt Kontext → triggere den `academic-context`-
-Skill und warte auf dessen Abschluss.
-
-Lehnt der User den Trigger ab → brich diesen Skill ab und erkläre:
-"Ohne Quellenliste in `./literature_state.md` kann ich keine Zitate mit
-Zuordnung liefern, weil ich Zitate zu nicht-registrierten Quellen bauen
-würde."
-
-## Keine Fabrikation
-
-Erfundene Zitate, Seitenzahlen oder Quellenangaben werden in der Plagiats-
-prüfung als nicht-auffindbar markiert und gelten als Täuschungsversuch. Arbeite
-ausschließlich mit den geladenen PDFs und Einträgen aus `./literature_state.md`.
-Fehlen Daten: frag den User, rate nicht.
-
 ## Abgrenzung
 
 Extrahiert und formatiert wörtliche Zitate aus PDFs für einzelne Belege.
 Für Kapitel-Prosa, die Belege in Argumentation einbaut → `chapter-writer`
 (ruft `citation-extraction` bei Bedarf auf).
-
-## Aktivierung dieses Skills
-
-- Der User möchte Zitate oder Belege aus heruntergeladenen PDFs extrahieren
-- Der User braucht eine Bibliografie oder ein Literaturverzeichnis
-- Der User sucht Belege für eine konkrete Aussage oder ein bestimmtes Kapitel
-- Der User möchte Zitate nach Kapitel oder Thema ordnen
 
 ## Variant-Selector
 
@@ -58,9 +36,7 @@ Lies `./academic_context.md`, Feld `Zitationsstil`. Lade die entsprechende Varia
 | Chicago | `references/chicago.md` |
 | DIN 1505-2 | `references/din1505.md` |
 
-Ist `Zitationsstil` leer → `apa.md` als Default. Ist der Wert unbekannt → Rueckfrage an User mit Varianten-Liste.
-
-**Wie laden:** `Read skills/citation-extraction/references/<variant>.md` — die Datei enthaelt alle Formatierungs-Regeln fuer Inline-Zitate und Literaturverzeichnis.
+Ist `Zitationsstil` leer → `apa.md`. Unbekannt → Rueckfrage. Laden: `Read skills/citation-extraction/references/<variant>.md`.
 
 ## Citations-API
 
@@ -77,18 +53,8 @@ Wenn Quellen-PDFs im Session-Kontext liegen, nutze den `documents`-Parameter der
 
 ## Kontext-Dateien
 
-### Lesen
-
-- `./academic_context.md` — Gliederungsstruktur, Zitationsstil, Forschungsfrage
-- `./literature_state.md` — Verfügbare Quellen, PDF-Download-Status, Kapitelzuordnungen
-
-### Schreiben
-
-- `./literature_state.md` — Zitatanzahl und Extraktionsstatus pro Quelle aktualisieren
-
-## Voraussetzungen
-
-Existiert `./academic_context.md` nicht, informiere den User und triggere zuerst den `academic-context`-Skill. Der Zitationsstil muss vor der Formatierung bekannt sein.
+- Lesen: `./academic_context.md` (Zitationsstil), `./literature_state.md` (Quellen, PDFs)
+- Schreiben: `./literature_state.md` (Zitatanzahl, Extraktionsstatus aktualisieren)
 
 ## Core-Workflow
 

--- a/skills/literature-gap-analysis/SKILL.md
+++ b/skills/literature-gap-analysis/SKILL.md
@@ -6,6 +6,11 @@ license: MIT
 
 # Literatur-Lückenanalyse
 
+> **Gemeinsames Preamble laden:** Lies `skills/_common/preamble.md`
+> und befolge alle dort definierten Blöcke (Vorbedingungen, Keine Fabrikation,
+> Aktivierung, Abgrenzung), bevor du mit diesem Skill-spezifischen Inhalt
+> fortfährst.
+
 ## Übersicht
 
 Analysiert die Literaturbasis auf Abdeckungslücken (fehlende Themen,
@@ -13,27 +18,9 @@ Autor*innen-Gruppen, Methoden, Zeiträume). Identifiziert disziplinäre
 Blindstellen und liefert konkrete Such-Queries für `/search`. Ergänzt
 den `source-quality-audit` (der bewertet Einzelquellen, nicht Korpus).
 
-Analysiert die Thesis-Gliederung gegen die bestehende Literatursammlung und erzeugt einen kapitelweisen Abdeckungsbericht. Identifiziert gut abgedeckte Themen, fehlende Quellen, fehlende Gegenargumente und methodische Lücken. Bietet gezielte Suche zur Lückenschließung an.
-
-## Vorbedingungen
-
-Bevor du startest: Prüfe, ob `./academic_context.md` und `./literature_state.md`
-vorhanden und aktuell sind. Fehlt Kontext → triggere den `academic-context`-
-Skill und warte auf dessen Abschluss.
-
-Lehnt der User den Trigger ab → brich diesen Skill ab und erkläre:
-"Ohne Themenliste in `./academic_context.md` kann ich keine Gap-Bewertung
-liefern, weil ich gegen unbekannte Ziele vergleichen würde."
-
-Fehlt `./literature_state.md` oder ist leer → schlage zuerst `/search` vor, um
-einen Quellenbestand aufzubauen, und trigger diesen Skill danach erneut.
-
-## Keine Fabrikation
-
-Erfundene Abdeckungs-Statements oder Quellenlisten führen zu einem
-Plagiatsverdacht, wenn behauptete Quellen nicht existieren. Arbeite
-ausschließlich mit `./literature_state.md` (Quelleninventar) und
-`./academic_context.md` (Themenliste). Fehlen Daten: frag den User, rate nicht.
+> **Skill-spezifische Vorbedingung:** Fehlt `./literature_state.md` oder ist
+> leer → schlage zuerst `/search` vor, um einen Quellenbestand aufzubauen,
+> und trigger diesen Skill danach erneut.
 
 ## Abgrenzung
 
@@ -68,32 +55,16 @@ Berechne und berichte jede dieser 3 Metriken:
 Ausgabe: Tabelle Metrik + Ist-Wert + Schwelle + PASS/FAIL + bei FAIL: konkreter
 Verbesserungsvorschlag (welches Thema, welche Autor*innen, welcher Zeitraum fehlt).
 
-## Aktivierung dieses Skills
-
-- Der User fragt nach Literatur-Abdeckung oder Vollständigkeit
-- Der User möchte wissen, welche Kapitel mehr Quellen brauchen
-- Ein anderer Skill (`advisor`, `chapter-writer`, `citation-extraction`) meldet unzureichende Quellenlage
-- Der User bereitet ein Betreuer-Gespräch vor und möchte einen Statusüberblick
-
 ## Kontext-Dateien
 
-### Lesen
-
-- `./academic_context.md` — Gliederung, Forschungsfrage, Unterfragen, Schlüsselkonzepte
-- `./literature_state.md` — Quelleninventar, Kapitelzuordnungen, PDF-Status, Zitatanzahlen
-
-### Schreiben
-
-- `./literature_state.md` — Ergebnisse der Gap-Analyse und Coverage-Scores aktualisieren
+- Lesen: `./academic_context.md` (Gliederung, Schlüsselkonzepte), `./literature_state.md` (Quelleninventar, Kapitelzuordnungen)
+- Schreiben: `./literature_state.md` — Coverage-Scores und Gap-Ergebnisse aktualisieren
 
 ## Core-Workflow
 
 ### 1. Laden und Gegenüberstellen
 
-Beide Kontext-Dateien (`./academic_context.md`, `./literature_state.md`) im Projekt-Ordner lesen. Eine Matrix aufbauen:
-
-- **Zeilen** — Kapitel und Unterabschnitte aus der Gliederung
-- **Spalten** — Coverage-Dimensionen (siehe unten)
+Beide Kontext-Dateien lesen. Matrix: Zeilen = Kapitel/Unterabschnitte, Spalten = Coverage-Dimensionen (siehe unten).
 
 ### 2. Coverage-Dimensionen
 
@@ -167,20 +138,11 @@ Mit User-Freigabe `/search` für jede Lücke mit den empfohlenen Queries trigger
 
 ### 7. Literaturstatus aktualisieren
 
-Nach der Analyse:
-
-1. `./literature_state.md` lesen (veraltete Überschreibungen vermeiden)
-2. Ergebnisse schreiben: pro-Kapitel-Coverage-Scores, identifizierte Lücken, Empfehlungen
-3. Zeitstempel der letzten Analyse aktualisieren
+`./literature_state.md` lesen, dann Coverage-Scores, Lücken, Empfehlungen und Zeitstempel schreiben.
 
 ## Vergleich mit ähnlichen Arbeiten
 
-Bei der Vollständigkeitsbewertung berücksichtigen:
-
-- **Standardreferenzen** — Sind die üblichen Grundlagenwerke des Felds enthalten?
-- **Aktuelle Reviews** — Gibt es aktuelle Literaturreviews oder Meta-Analysen?
-- **Methodenreferenzen** — Werden Standard-Methodenlehrbücher zitiert?
-- **Institutionelle Anforderungen** — Erfüllt die Quellenzahl das für den Arbeitstyp erwartete Minimum?
+Prüfen auf: Standardreferenzen des Felds, aktuelle Literaturreviews/Meta-Analysen, Methodenlehrbücher, institutionelle Mindest-Quellenzahl.
 
 Typische Minima nach Arbeitstyp:
 

--- a/skills/methodology-advisor/SKILL.md
+++ b/skills/methodology-advisor/SKILL.md
@@ -6,33 +6,17 @@ license: MIT
 
 # Methodik-Berater
 
+> **Gemeinsames Preamble laden:** Lies `skills/_common/preamble.md`
+> und befolge alle dort definierten Blöcke (Vorbedingungen, Keine Fabrikation,
+> Aktivierung, Abgrenzung), bevor du mit diesem Skill-spezifischen Inhalt
+> fortfährst.
+
 ## Übersicht
 
 Berät bei der Methodenwahl: qualitativ, quantitativ, Mixed-Methods, oder
 spezielle Verfahren (Delphi, SLR, Grounded Theory). Mappt Forschungsfrage
 auf geeignete Methoden und skizziert Operationalisierung. Nicht zuständig
 für Schärfung der Forschungsfrage (→ `research-question-refiner`).
-
-Hilft bei Wahl, Begründung und Dokumentation der Forschungsmethodik. Vergleicht Ansätze, prüft die Passung zur Forschungsfrage und produziert Methodik-Texte, die akademischen Standards genügen.
-
-## Vorbedingungen
-
-Bevor du startest: Prüfe, ob `./academic_context.md` und `./literature_state.md`
-vorhanden und aktuell sind. Fehlt Kontext → triggere den `academic-context`-
-Skill und warte auf dessen Abschluss.
-
-Lehnt der User den Trigger ab → brich diesen Skill ab und erkläre:
-"Ohne Forschungsfrage und Datenzugriffs-Infos kann ich keine Methoden-
-Empfehlung liefern, weil ich Methoden empfehlen würde, die die Frage nicht
-beantworten."
-
-## Keine Fabrikation
-
-Erfundene Methodik-Standards, Begründungen oder Vergleiche führen zu Note 5
-für das Forschungsdesign und einer methodisch angreifbaren Arbeit. Arbeite
-ausschließlich mit `./academic_context.md` und dem Methoden-Katalog unter
-`${CLAUDE_PLUGIN_ROOT}/skills/methodology-advisor/methodology-catalog.md`.
-Fehlen Daten: frag den User, rate nicht.
 
 ## Abgrenzung
 
@@ -60,32 +44,20 @@ Gesamt-Score = Summe der 4 Dimensionen (Min 4, Max 20).
 
 Bei Gleichstand: Supervisor-Präferenz entscheidet. Dokumentiere Scoring in der Ausgabe, nicht nur die Empfehlung.
 
-## Aktivierung dieses Skills
-
-- Der User muss eine Forschungsmethodik wählen
-- Der User möchte qualitative vs. quantitative Ansätze vergleichen
-- Der User muss seine Methodenwahl gegenüber Betreuer oder Exposé begründen
-- Der User schreibt das Methodik-Kapitel und braucht strukturelle Orientierung
-
 ## Kontext-Dateien
 
-### Lesen
-
-- `./academic_context.md` — Forschungsfrage, Unterfragen, Arbeitstyp, Thema, vorhandene Methodenwahl
-
-### Schreiben
-
-- `./academic_context.md` — Methodik-Feld nach der Entscheidung aktualisieren
+- Lesen: `./academic_context.md` (Forschungsfrage, Arbeitstyp, Methodik-Wahl)
+- Schreiben: `./academic_context.md` — Methodik-Feld aktualisieren
 
 ## Referenz
 
-Konsultiere den Methoden-Katalog unter `${CLAUDE_PLUGIN_ROOT}/skills/methodology-advisor/methodology-catalog.md` für detaillierte Beschreibungen, Stärken, Schwächen und Einsatzszenarien jedes Methodentyps.
+Methoden-Katalog: `${CLAUDE_PLUGIN_ROOT}/skills/methodology-advisor/methodology-catalog.md`
 
 ## Core-Workflow
 
 ### 1. Kontext laden
 
-Lies `./academic_context.md`. Existiert sie nicht, triggere zuerst den Academic-Context-Skill. Extrahiere: Forschungsfrage, Unterfragen, Arbeitstyp, Thema und eine eventuell vorhandene Methodik-Wahl.
+Lies `./academic_context.md`. Fehlt sie: `academic-context`-Skill triggern. Extrahiere: Forschungsfrage, Unterfragen, Arbeitstyp, Thema, Methodik-Wahl.
 
 ### 2. Typ der Forschungsfrage einschätzen
 
@@ -187,11 +159,7 @@ Empfohlene Struktur für das Methodik-Kapitel:
 
 ### 7. Entscheidung speichern
 
-Nach Bestätigung des Users:
-
-1. `./academic_context.md` lesen (veraltete Überschreibungen vermeiden)
-2. Das Feld `Methodik` mit der gewählten Methodik aktualisieren
-3. Zentrale Methoden-Referenzen zu `## Schlüsselkonzepte` hinzufügen, falls noch nicht vorhanden
+Nach User-Bestätigung: `./academic_context.md` lesen, Feld `Methodik` aktualisieren, Methoden-Referenzen zu `## Schlüsselkonzepte` hinzufügen.
 
 ## Wichtige Regeln
 

--- a/skills/plagiarism-check/SKILL.md
+++ b/skills/plagiarism-check/SKILL.md
@@ -6,6 +6,11 @@ license: MIT
 
 # Plagiatsprüfung
 
+> **Gemeinsames Preamble laden:** Lies `skills/_common/preamble.md`
+> und befolge alle dort definierten Blöcke (Vorbedingungen, Keine Fabrikation,
+> Aktivierung, Abgrenzung), bevor du mit diesem Skill-spezifischen Inhalt
+> fortfährst.
+
 ## Übersicht
 
 Prüft Textähnlichkeit gegen die Quellen in `./literature_state.md`.
@@ -13,51 +18,20 @@ Markiert wörtliche Übernahmen und paraphrasierte Passagen, die nicht
 ausreichend zitiert sind. Nicht zuständig für Stil-Bewertung allgemein
 (→ `style-evaluator`).
 
-Prüft akademischen Text auf unbeabsichtigte Nähe zum Quellmaterial. Erkennt zu nahe Paraphrasen, unzureichend umformulierte Passagen und fehlende Quellenangaben via N-Gramm-Overlap-Detection. Schlägt Umformulierungen für markierte Passagen vor.
-
-## Vorbedingungen
-
-Bevor du startest: Prüfe, ob `./academic_context.md` und `./literature_state.md`
-vorhanden und aktuell sind. Fehlt Kontext → triggere den `academic-context`-
-Skill und warte auf dessen Abschluss.
-
-Lehnt der User den Trigger ab → brich diesen Skill ab und erkläre:
-"Ohne Quellenlisten in `./literature_state.md` kann ich kein Similarity-Urteil
-liefern, weil ich gegen unbekannte Quellen prüfen und False-Negatives
-produzieren würde."
-
-## Keine Fabrikation
-
-Erfundene Similarity-Urteile oder N-Gramm-Matches lassen unentdecktes Plagiat
-durch und führen dazu, dass Textstellen, die beim offiziellen Plagiats-Check
-der FH Leibniz auffliegen, hier unbemerkt geblieben sind. Arbeite ausschließlich
-mit dem User-Text und den PDF-Extrakten aus `./literature_state.md`. Fehlen
-Daten: frag den User, rate nicht.
-
 ## Abgrenzung
 
 Prüft Textnähe zu bekannten Quellen via N-Gramm-Overlap und Sentence-Similarity.
 Für stilistische Qualität des Textes ohne Quellenbezug → `style-evaluator`.
 
-## Aktivierung dieses Skills
-
-- Der User reicht Text zur Prüfung gegen seine Quellen ein
-- Der User paraphrasiert eine Quelle und möchte verifizieren
-- Qualitätssicherung vor der finalen Abgabe
-- Ein anderer Skill (z. B. `chapter-writer`) fordert ein Plagiats-Gate an
-
 ## Kontext-Dateien
 
-- Lies `./academic_context.md` für Zitationsstil und Sprache
-- Lies `./literature_state.md` für die Liste der pro Kapitel genutzten Quellen
-- Lies `./writing_state.md` für aktuellen Schreibkontext
+- `./academic_context.md` — Zitationsstil, Sprache
+- `./literature_state.md` — Quellen pro Kapitel
+- `./writing_state.md` — Schreibkontext
 
 ## Skripte
 
-Nutze `${CLAUDE_PLUGIN_ROOT}/scripts/text_utils.py` für Tokenisierung (`tokenize()`-Funktion) und Textnormalisierung.
-
-Hinweis: `text_utils.py` liefert deterministische Tokenisierung und
-n-gram-Matching. Inline-Berechnung wäre unzuverlässig (Reproducibility).
+`${CLAUDE_PLUGIN_ROOT}/scripts/text_utils.py` — `tokenize()`-Funktion für deterministische Tokenisierung und n-gram-Matching.
 
 ## Detektions-Methoden
 
@@ -93,20 +67,7 @@ Prüfen, ob der User-Text der Argumentationsstruktur der Quelle zu nahe folgt:
 
 ## Quellmaterial-Handling
 
-### Verfügbare Quellen
-
-Quelltexte in dieser Priorität suchen:
-1. In der aktuellen Session extrahierte PDF-Texte (im Kontext)
-2. In `./literature_state.md` referenzierte Quellen-Snippets
-3. Vom User gelieferter Originaltext für Direktvergleich
-
-### Wenn kein Quelltext verfügbar ist
-
-Sind keine Quell-PDFs oder Texte zugänglich:
-1. Dem User mitteilen, dass der Vergleich auf interne Analyse beschränkt ist
-2. Interne Duplikationsprüfung dennoch durchführen (wiederholte Passagen im Text)
-3. Passagen flaggen, die Hinweise auf enges Paraphrasieren zeigen (steife Formulierungen, untypisches Vokabular im Kontext)
-4. Anbieten, zu vergleichen, wenn der User den Originaltext bereitstellt
+Priorität: (1) Session-PDFs, (2) `./literature_state.md`-Snippets, (3) User-Originaltext. Fehlt Quelltext: interne Duplikationsprüfung + steife Formulierungen flaggen, Originaltext anbieten.
 
 ## Evaluations-Workflow
 

--- a/skills/research-question-refiner/SKILL.md
+++ b/skills/research-question-refiner/SKILL.md
@@ -6,31 +6,16 @@ license: MIT
 
 # Forschungsfragen-Schärfer
 
+> **Gemeinsames Preamble laden:** Lies `skills/_common/preamble.md`
+> und befolge alle dort definierten Blöcke (Vorbedingungen, Keine Fabrikation,
+> Aktivierung, Abgrenzung), bevor du mit diesem Skill-spezifischen Inhalt
+> fortfährst.
+
 ## Übersicht
 
 Verfeinert bestehende Forschungsfragen auf Spezifität, Beantwortbarkeit,
 Falsifizierbarkeit und Einzigartigkeit. Liefert 2-3 Alternativen je
 Problem-Typ (zu weit / zu eng / nicht falsifizierbar / mehrdimensional).
-
-Hilft beim präzisen Formulieren von Hauptfrage und Unterfragen. Bewertet, ob eine Frage zu breit, zu eng oder nicht beantwortbar ist. Vergleicht mit ähnlichen Arbeiten, um Originalität und Machbarkeit sicherzustellen.
-
-## Vorbedingungen
-
-Bevor du startest: Prüfe, ob `./academic_context.md` und `./literature_state.md`
-vorhanden und aktuell sind. Fehlt Kontext → triggere den `academic-context`-
-Skill und warte auf dessen Abschluss.
-
-Lehnt der User den Trigger ab → brich diesen Skill ab und erkläre:
-"Ohne Thema und Kontext in `./academic_context.md` kann ich keine Fragen-
-Schärfung liefern, weil ich gegen unbekannte Disziplin-Konventionen
-optimieren würde."
-
-## Keine Fabrikation
-
-Erfundene Bezüge zu Vorarbeiten oder Forschungslücken führen zu einer
-Fragestellung, die beim ersten Supervisor-Feedback kollabiert. Arbeite
-ausschließlich mit `./academic_context.md` und `./literature_state.md`. Fehlen
-Daten: frag den User, rate nicht.
 
 ## Abgrenzung
 
@@ -87,29 +72,16 @@ Für Einbettung in die Gliederung → `advisor`.
 > Mitarbeiterzufriedenheit in KMU der Metallverarbeitung 2023 am besten?
 > (Nebenaspekte: Einführungskosten, Akzeptanzraten)"
 
-## Aktivierung dieses Skills
-
-- Der User möchte eine neue Forschungsfrage formulieren
-- Der User möchte eine bestehende Forschungsfrage verfeinern oder schärfen
-- Der User ist unsicher, ob seine Frage gut genug ist
-- Ein Betreuer hat die Forschungsfrage als problematisch markiert
-- Ein anderer Skill (`advisor`, `academic-context`) erkennt eine schwache Forschungsfrage
-
 ## Kontext-Dateien
 
-### Lesen
-
-- `./academic_context.md` — Aktuelle Forschungsfrage, Thema, Arbeitstyp, Methodik, Gliederung
-
-### Schreiben
-
-- `./academic_context.md` — Forschungsfrage und Unterfragen nach der Verfeinerung aktualisieren
+- Lesen: `./academic_context.md` (Forschungsfrage, Thema, Arbeitstyp, Methodik)
+- Schreiben: `./academic_context.md` — Forschungsfrage + Unterfragen aktualisieren
 
 ## Core-Workflow
 
 ### 1. Kontext laden
 
-Lies `./academic_context.md`. Existiert sie nicht, triggere den `academic-context`-Skill, um Basisdaten zu erheben. Extrahiere: Thema, aktuelle Forschungsfrage (falls vorhanden), Unterfragen, Arbeitstyp und Methodik.
+Lies `./academic_context.md`. Fehlt sie: `academic-context`-Skill triggern. Extrahiere: Thema, Forschungsfrage, Unterfragen, Arbeitstyp, Methodik.
 
 ### 2. Aktuelle Frage bewerten
 
@@ -214,21 +186,11 @@ Bei signifikantem Überlapp Differenzierungsoptionen vorschlagen:
 
 ### 6. Finale Formulierung
 
-Verfeinerte Forschungsfrage und Unterfragen zur Freigabe präsentieren. Einschließen:
-
-- Finale Hauptfrage
-- 2-4 Unterfragen mit Kapitelzuordnung
-- Kurze Begründung, warum diese Formulierung funktioniert
-- Vergleich mit der ursprünglichen Frage (falls vorhanden)
+Verfeinerte Hauptfrage + 2-4 Unterfragen mit Kapitelzuordnung, Begründung und Vergleich zur Ausgangsfrage präsentieren.
 
 ### 7. Änderungen speichern
 
-Nach der Bestätigung durch den User:
-
-1. `./academic_context.md` lesen (veraltete Überschreibungen vermeiden)
-2. `Forschungsfrage` mit der neuen Hauptfrage aktualisieren
-3. `Unterfragen` mit den neuen Unterfragen aktualisieren
-4. Entsprechen Unterfragen Kapiteln, `## Gliederung` anpassen
+Nach User-Bestätigung: `./academic_context.md` lesen, `Forschungsfrage` + `Unterfragen` aktualisieren, ggf. `## Gliederung` anpassen.
 
 ## Forschungsfragen-Templates
 

--- a/skills/source-quality-audit/SKILL.md
+++ b/skills/source-quality-audit/SKILL.md
@@ -6,31 +6,17 @@ license: MIT
 
 # Quellenqualitäts-Audit
 
+> **Gemeinsames Preamble laden:** Lies `skills/_common/preamble.md`
+> und befolge alle dort definierten Blöcke (Vorbedingungen, Keine Fabrikation,
+> Aktivierung, Abgrenzung), bevor du mit diesem Skill-spezifischen Inhalt
+> fortfährst.
+
 ## Übersicht
 
 Bewertet Qualität, Balance, Aktualität und Diversität der Literaturbasis
 einer Arbeit. Scort 5 Dimensionen (0-100), identifiziert Schwächen,
 liefert priorisierte Verbesserungsempfehlungen. Fokus auf Einzelquellen
 — Korpus-Coverage macht `literature-gap-analysis`.
-
-Bewertet die Gesamtqualität, Balance, Aktualität und Diversität der Literaturbasis einer akademischen Arbeit. Scort jede Dimension (0-100), identifiziert Schwächen und liefert konkrete Verbesserungsempfehlungen.
-
-## Vorbedingungen
-
-Bevor du startest: Prüfe, ob `./academic_context.md` und `./literature_state.md`
-vorhanden und aktuell sind. Fehlt Kontext → triggere den `academic-context`-
-Skill und warte auf dessen Abschluss.
-
-Lehnt der User den Trigger ab → brich diesen Skill ab und erkläre:
-"Ohne Quellenliste in `./literature_state.md` kann ich kein Qualitätsurteil
-liefern, weil ich gegen leere Menge urteilen würde."
-
-## Keine Fabrikation
-
-Erfundene Bewertungen oder Quellenangaben entziehen der Arbeit die
-Zitierbarkeit, wenn behauptete Quellen in der Nachprüfung nicht existieren.
-Arbeite ausschließlich mit den Einträgen aus `./literature_state.md` und
-geladenen PDFs. Fehlen Daten: frag den User, rate nicht.
 
 ## Abgrenzung
 
@@ -48,17 +34,10 @@ Beide Skills greifen auf `./literature_state.md` zu, aber mit unterschiedlichem
 Fokus. Wenn der User „Coverage" oder „Gaps" erwähnt → delegiere an
 `literature-gap-analysis`.
 
-## Aktivierung dieses Skills
-
-- Der User möchte die Qualität seiner Quellen oder Literaturbasis bewerten
-- Der User ist unsicher, ob seine Quellen ausreichen
-- Qualitätsgate vor der Abgabe für die Literatur
-- Nach einer Literatursuche, um den gesammelten Pool zu bewerten
-
 ## Kontext-Dateien
 
-- Lies `./literature_state.md` für das aktuelle Quelleninventar (Gesamtzahl, Typenverteilung, Kapitelzuordnungen, identifizierte Lücken)
-- Lies `./academic_context.md` für Arbeitstyp, Disziplin, Forschungsfrage und Zitationsstil
+- `./literature_state.md` — Quelleninventar, Typenverteilung, Kapitelzuordnungen
+- `./academic_context.md` — Arbeitstyp, Disziplin, Forschungsfrage, Zitationsstil
 
 ## Scoring-Dimensionen
 
@@ -129,19 +108,13 @@ Bewertet die Balance zwischen reinen Web-Quellen und klassischen akademischen Pu
 - 30-49: Web-Quellen 30-50 %, mehrere nicht verifizierbar
 - 0-29: Web-Quellen >50 %, viele ohne institutionelle Autorität
 
-**Akzeptable Web-Quellen:** Behördenstatistiken (destatis.de), offizielle Reports (EU, OECD, WHO), etablierte Datenanbieter (Statista), Geschäftsberichte.
+**Akzeptabel:** Behörden (destatis.de), EU/OECD/WHO-Reports, Statista, Geschäftsberichte.
 
-**Problematische Web-Quellen:** Persönliche Blogs, undatierte Seiten, Seiten ohne klare Autorenschaft, Wikipedia als Primärquelle.
+**Problematisch:** Blogs, undatierte Seiten, Wikipedia als Primärquelle.
 
 ### 5. Thematische Abdeckung (Gewicht: 0.20)
 
-Bewertet, ob alle wichtigen Aspekte der Forschungsfrage durch Literatur abgedeckt sind.
-
-**Ablauf:**
-1. Schlüsselkonzepte aus Forschungsfrage und Gliederung (via `./academic_context.md`) extrahieren
-2. Jedes Konzept den verfügbaren Quellen zuordnen
-3. Konzepte mit unzureichender Abdeckung identifizieren (<2 Quellen je Schlüsselkonzept)
-4. Prüfen, ob jedes Hauptkapitel ausreichend Literaturstütze hat
+Schlüsselkonzepte aus `./academic_context.md` extrahieren, Quellen zuordnen, Konzepte mit <2 Quellen flaggen, Kapitelabdeckung prüfen.
 
 **Scoring:**
 - 90-100: Alle Schlüsselkonzepte durch 3+ Quellen abgedeckt, keine Lücken
@@ -152,13 +125,10 @@ Bewertet, ob alle wichtigen Aspekte der Forschungsfrage durch Literatur abgedeck
 
 ## Evaluations-Workflow
 
-1. `./literature_state.md` für das Quelleninventar lesen
-2. `./academic_context.md` für den Forschungskontext lesen
-3. Jede Quelle klassifizieren (peer-reviewt, semi-akademisch, nicht-akademisch, Web)
-4. Jede der 5 Dimensionen bepunkten
-5. Gewichteten Gesamtwert berechnen: `total = 0.25*peer_review + 0.20*recency + 0.20*diversity + 0.15*web_ratio + 0.20*coverage`
-6. Konkrete Empfehlungen für jede Dimension mit Score unter 70 erstellen
-7. Ergebnisse im strukturierten Format präsentieren
+1. Beide Kontext-Dateien lesen
+2. Quellen klassifizieren (peer-reviewt / semi-akademisch / nicht-akademisch / Web)
+3. 5 Dimensionen scoren, Gesamt: `0.25*peer_review + 0.20*recency + 0.20*diversity + 0.15*web_ratio + 0.20*coverage`
+4. Empfehlungen für Dimensionen mit Score < 70, strukturiert präsentieren
 
 ## Output-Format
 

--- a/skills/style-evaluator/SKILL.md
+++ b/skills/style-evaluator/SKILL.md
@@ -6,28 +6,16 @@ license: MIT
 
 # Stil-Evaluator
 
+> **Gemeinsames Preamble laden:** Lies `skills/_common/preamble.md`
+> und befolge alle dort definierten Blöcke (Vorbedingungen, Keine Fabrikation,
+> Aktivierung, Abgrenzung), bevor du mit diesem Skill-spezifischen Inhalt
+> fortfährst.
+
 ## Übersicht
 
 Bewertet Menschlichkeit, KI-Detektions-Anfälligkeit, Kohärenz, Duplikation
 und akademische Qualität von Text. Gewichteter 0-100-Score über 5 Dimensionen.
 Bietet Rewrite-Vorschläge für geflaggte Stellen ohne Bedeutung zu verlieren.
-
-## Vorbedingungen
-
-Bevor du startest: Prüfe, ob `./academic_context.md` und `./literature_state.md`
-vorhanden und aktuell sind. Fehlt Kontext → triggere den `academic-context`-
-Skill und warte auf dessen Abschluss.
-
-Lehnt der User den Trigger ab → brich diesen Skill ab und erkläre:
-"Ohne Text-Korpus-Kontext in `./writing_state.md` kann ich kein Stil-Urteil
-liefern, weil ich gegen disziplinfremde Normen urteilen würde."
-
-## Keine Fabrikation
-
-Erfundene Stil-Urteile über nicht gelesenen Text lassen tatsächlich fragwürdigen
-Stil unentdeckt und untergraben den Wert des Stil-Checks. Arbeite ausschließlich
-mit dem eingereichten User-Text und den Metriken aus `./writing_state.md`.
-Fehlen Daten: frag den User, rate nicht.
 
 ## Abgrenzung
 
@@ -50,13 +38,6 @@ diese 5 Schwellen:
 
 Ausgabe: Tabelle Metrik + Ist-Wert + Schwelle + PASS/FAIL.
 
-## Aktivierung dieses Skills
-
-- Der User reicht Text zur Qualitäts- oder Stilbewertung ein
-- Der User befürchtet, dass der Text zu KI-generiert klingt
-- Der User bittet um Textverbesserung oder natürlicheres Schreiben
-- Ein anderer Skill (z. B. `chapter-writer`) fordert ein Post-Write-Qualitätsgate an
-
 ## Variant-Selector
 
 Lies `./academic_context.md`, Feld `Sprache`:
@@ -66,17 +47,16 @@ Lies `./academic_context.md`, Feld `Sprache`:
 | Deutsch (Default) | `references/academic-de.md` |
 | English | `references/academic-en.md` |
 
-Fehlt das Feld → `academic-de.md` als Default (Plugin-Default ist Deutsch). Unbekannte Sprache → Rueckfrage.
+Fehlt Feld → `academic-de.md`. Unbekannt → Rueckfrage.
 
 ## Kontext-Dateien
 
-- Lies `./writing_state.md` für aktuellen Kapitelkontext und frühere Scores
-- Lies `./academic_context.md` für Zitationsstil, Sprache und Arbeitstyp
-- Aktualisiere `./writing_state.md` nach jedem Lauf mit neuen Bewertungsscores
+- `./writing_state.md` — Kapitelkontext, frühere Scores (nach Lauf aktualisieren)
+- `./academic_context.md` — Zitationsstil, Sprache, Arbeitstyp
 
 ## Metriken
 
-Die quantitativen Metriken (Satzlängenverteilung, Übergangsfrequenz, Vokabular-Diversität, n-Gramm-Wiederholung) berechnet Claude direkt aus dem Eingabetext — keine externe Pipeline. Siehe Rubrik unten für konkrete Messvorschriften pro Dimension.
+Satzlängenverteilung, Übergangsfrequenz, Vokabular-Diversität, n-Gramm-Wiederholung — Claude berechnet direkt aus Eingabetext (keine externe Pipeline).
 
 ## Scoring-Rubrik (0-100)
 
@@ -93,15 +73,11 @@ Indikatoren für NIEDRIGE Menschlichkeit (Abzüge):
 - Keine rhetorischen Fragen, Einschübe oder Ich-Perspektive, wo angemessen
 - Absatzlängen zu uniform (alle innerhalb 10 % des Durchschnitts)
 
-Indikatoren für HOHE Menschlichkeit (Pluspunkte):
-- Natürliche Variation der Satzlänge (kurz und lang gemischt)
-- Gelegentliche informelle Konnektoren neben formalen
-- Topic Sentences variieren zwischen Absätzen
-- Spürbare persönliche analytische Stimme
+Plus: natürliche Satzlängen-Variation, gelegentliche informelle Konnektoren, variierende Topic Sentences, analytische Stimme.
 
 ### 2. Anti-KI-Detektion (Gewicht: 0.25)
 
-Muster flaggen, die KI-Detektoren (GPTZero, Turnitin AI, Originality.ai) häufig identifizieren.
+Muster flaggen, die KI-Detektoren (GPTZero, Turnitin AI, Originality.ai) identifizieren.
 
 Prüfen auf:
 - **Uniforme Satzlängen** -- Standardabweichung berechnen; flag bei < 5 Wörtern
@@ -145,13 +121,10 @@ Prüfen auf:
 
 ## Evaluations-Workflow
 
-1. Den eingereichten Text lesen (vollständiges Kapitel, Abschnitt oder Absatz)
-2. `./writing_state.md` und `./academic_context.md` für Kontext lesen
-3. Berechne quantitative Metriken inline aus dem Eingabetext (Satzlängen, Übergänge, n-Gramme, Vokabular-Diversität)
-4. Jede Dimension (0-100) nach Rubrik und Metriken scoren
-5. Gewichteten Gesamtwert berechnen: `total = 0.30*human + 0.25*anti_ai + 0.20*coherence + 0.15*duplication + 0.10*academic`
-6. Ergebnisse strukturiert präsentieren (siehe Output-Format unten)
-7. `./writing_state.md` mit den neuen Scores aktualisieren
+1. Text + beide Kontext-Dateien lesen
+2. Metriken inline berechnen (Satzlängen, Übergänge, n-Gramme, Vokabular)
+3. 5 Dimensionen scoren, Gesamt: `0.30*human + 0.25*anti_ai + 0.20*coherence + 0.15*duplication + 0.10*academic`
+4. Strukturiert präsentieren, `./writing_state.md` mit neuen Scores aktualisieren
 
 ## Output-Format
 

--- a/skills/submission-checker/SKILL.md
+++ b/skills/submission-checker/SKILL.md
@@ -6,6 +6,11 @@ license: MIT
 
 # Abgabe-Prüfer
 
+> **Gemeinsames Preamble laden:** Lies `skills/_common/preamble.md`
+> und befolge alle dort definierten Blöcke (Vorbedingungen, Keine Fabrikation,
+> Aktivierung, Abgrenzung), bevor du mit diesem Skill-spezifischen Inhalt
+> fortfährst.
+
 ## Übersicht
 
 Prüft Formalia vor Abgabe: Pflichtabschnitte, Seitenumfang, Formatierung,
@@ -13,36 +18,12 @@ Quellenzahl, Abbildungen/Tabellen, eidesstattliche Erklärung. Verwendet
 hochschulspezifische Regeln aus `references/<variant>.md` (Default:
 FH Leibniz).
 
-## Vorbedingungen
-
-Bevor du startest: Prüfe, ob `./academic_context.md` und `./literature_state.md`
-vorhanden und aktuell sind. Fehlt Kontext → triggere den `academic-context`-
-Skill und warte auf dessen Abschluss.
-
-Lehnt der User den Trigger ab → brich diesen Skill ab und erkläre:
-"Ohne FH-Zuordnung in `./academic_context.md` kann ich keinen Formalia-Check
-liefern, weil ich gegen falsches FH-Regelwerk prüfen würde."
-
-## Keine Fabrikation
-
-Erfundene Formalia-Bestätigungen produzieren eine nicht-abgabefähige Arbeit,
-die bei Einreichung zurückgewiesen wird. Arbeite ausschließlich mit der
-Arbeits-PDF und den FH-Zuordnungen in `./academic_context.md`. Fehlen Daten:
-frag den User, rate nicht.
-
 ## Abgrenzung
 
 Prüft Formalia der Enddatei gegen Hochschul-Regeln.
 Für Abstract, Keywords, Management-Summary → `abstract-generator`.
 Für den Titel selbst → `title-generator`.
 Für Kontextdaten (Arbeitstyp, Hochschule) → `academic-context`.
-
-## Aktivierung dieses Skills
-
-- Der User fragt, ob seine Arbeit abgabefertig ist
-- Der User möchte Formatierung oder formale Anforderungen verifizieren
-- Qualitätssicherung vor der Abgabe
-- Der User fragt nach konkreten formalen Elementen (Deckblatt, Eidesstattliche Erklärung etc.)
 
 ## Variant-Selector
 
@@ -59,9 +40,9 @@ Fehlt das Feld → `fh-leibniz.md` als Default (Plugin-Default ist FH Leibniz). 
 
 ## Kontext- und Referenzdateien
 
-- Lies `./academic_context.md` für Arbeitstyp, Universität, Studiengang und Zitationsstil
-- Lies `${CLAUDE_PLUGIN_ROOT}/skills/submission-checker/references/fh-leibniz.md` für hochschulspezifische Formalia
-- Lies `./writing_state.md` für aktuelle Wortzahlen und Kapitelstatus
+- `./academic_context.md` — Arbeitstyp, Universität, Zitationsstil
+- `${CLAUDE_PLUGIN_ROOT}/skills/submission-checker/references/fh-leibniz.md` — hochschulspezifische Formalia
+- `./writing_state.md` — Wortzahlen, Kapitelstatus
 
 ## Checklisten-Dimensionen
 
@@ -106,23 +87,11 @@ Verifizieren:
 
 ### 3. Formatierung
 
-Compliance mit gängigen Formatierungsregeln prüfen:
+**Typografie:** Schrift Times New Roman 12pt/Arial 11pt, Zeilenabstand 1.5, Ränder links 3cm/rechts 2.5cm/oben+unten 2.5cm/2cm, Blocksatz, Seitenzahlen arabisch ab Einleitung.
 
-**Typografie:**
-- Schrift: Times New Roman 12pt oder Arial 11pt (je nach Hochschule)
-- Zeilenabstand: 1.5
-- Ränder: links 3 cm (Bindung), rechts 2.5 cm, oben 2.5 cm, unten 2 cm
-- Blocksatz
-- Seitenzahlen: arabisch ab Einleitung (Front Matter in römischen Ziffern)
+**Überschriften:** Konsistente Hierarchie, nummeriert (max. 3 Ebenen), keine Schuster-Überschriften.
 
-**Überschriften:**
-- Konsistente Hierarchie (keine übersprungenen Ebenen)
-- Nummerierte Überschriften (1, 1.1, 1.1.1 -- max. 3 Ebenen)
-- Keine Schuster-Überschriften (Überschrift am Seitenende, Text beginnt erst auf der nächsten Seite)
-
-**Absätze:**
-- Keine Einzelsatz-Absätze
-- Konsistente Absatz-Einrückung oder -Abstände
+**Absätze:** Keine Einzelsatz-Absätze, konsistente Einrückung.
 
 ### 4. Quellenzahl und Zitationsqualität
 
@@ -135,12 +104,7 @@ Ausreichende Quellennutzung prüfen:
 | Hausarbeit       | 10-20           |
 | Seminararbeit    | 15-25           |
 
-Prüfen:
-- Gesamtzahl eindeutiger Quellen in der Bibliografie
-- Alle In-Text-Zitate haben einen Eintrag im Literaturverzeichnis
-- Alle Literatureinträge werden im Text mindestens einmal zitiert
-- Zitierformat entspricht dem Stil aus `./academic_context.md` (APA7, IEEE, Harvard etc.)
-- Kein Kapitel ohne Zitate (Ausnahme: Strukturvorschau in der Einleitung und Ausblick im Fazit)
+Prüfen: Quellenzahl, In-Text↔Bibliographie-Abgleich, Zitierformat (aus `./academic_context.md`), kein zitatfreies Kapitel (außer Intro-Vorschau + Ausblick).
 
 ### 5. Abbildungen und Tabellen
 
@@ -161,13 +125,9 @@ Verifizieren:
 
 ## Evaluations-Workflow
 
-1. `./academic_context.md` lesen, um Arbeitstyp und Hochschule zu bestimmen
-2. `${CLAUDE_PLUGIN_ROOT}/skills/submission-checker/references/fh-leibniz.md` für spezifische Anforderungen lesen
-3. `./writing_state.md` für den aktuellen Fertigstellungsgrad lesen
-4. Die Arbeit gegen die Checkliste prüfen
-5. Jede Dimension als PASS, PARTIAL oder FAIL scoren
-6. Ergebnisse strukturiert ausgeben
-7. Fixes nach Schweregrad priorisieren
+1. Kontext-Dateien lesen (academic_context → Arbeitstyp/Hochschule, fh-leibniz.md → Anforderungen, writing_state → Fertigstellung)
+2. Arbeit gegen Checkliste prüfen, Dimensionen PASS/PARTIAL/FAIL scoren
+3. Strukturiert ausgeben, Fixes nach Schweregrad priorisieren
 
 ## Output-Format
 

--- a/skills/title-generator/SKILL.md
+++ b/skills/title-generator/SKILL.md
@@ -6,30 +6,17 @@ license: MIT
 
 # Titel-Generator
 
+> **Gemeinsames Preamble laden:** Lies `skills/_common/preamble.md`
+> und befolge alle dort definierten Blöcke (Vorbedingungen, Keine Fabrikation,
+> Aktivierung, Abgrenzung), bevor du mit diesem Skill-spezifischen Inhalt
+> fortfährst.
+
 ## Übersicht
 
 Schlägt 5-7 Titelvarianten vor (klassisch-akademisch, fragenbasiert,
 kreativ, ergebnisorientiert) mit Rationale und Stärke/Einschränkung.
 Basiert auf `./writing_state.md` (fertiger Text) und `./academic_context.md`
 (Forschungsfrage). Keine leeren Titel-Hülsen.
-
-## Vorbedingungen
-
-Bevor du startest: Prüfe, ob `./academic_context.md` und `./literature_state.md`
-vorhanden und aktuell sind. Fehlt Kontext → triggere den `academic-context`-
-Skill und warte auf dessen Abschluss.
-
-Lehnt der User den Trigger ab → brich diesen Skill ab und erkläre:
-"Ohne Forschungsfrage und Kernergebnisse kann ich keine Titel-Vorschläge
-liefern, weil ich leere Titel-Hülsen ohne Verankerung liefern würde."
-
-## Keine Fabrikation
-
-In den Titel eingebaute Claims ohne Textbeleg machen die Arbeit vor der
-Korrektur angreifbar und riskieren Nachfragen im Kolloquium. Arbeite
-ausschließlich mit `./writing_state.md` (fertiger Arbeitstext) und
-`./academic_context.md` (Forschungsfrage, Kernergebnisse). Fehlen Daten: frag
-den User, rate nicht.
 
 ## Abgrenzung
 
@@ -71,45 +58,14 @@ Für Abstract, Keywords, Management Summary → `abstract-generator`.
 > "Wie beeinflusst regelmäßige KI-Nutzung die Prüfungsnoten in BWL- und
 > Informatik-Studiengängen? Eine Erhebung an der FH Leibniz 2024"
 
-## Aktivierung dieses Skills
-
-- Der User fragt nach Titelvorschlägen oder möchte seinen Arbeitstitel ändern
-- Der User hat einen Entwurf fertig und braucht einen finalen Titel
-- Der User sammelt in der Planungsphase Thesis-Titel-Ideen
-
 ## Kontext-Dateien
 
-- Lies `./academic_context.md` für Arbeitstyp, Disziplin, Forschungsfrage, Methodik, Sprache und Hochschulanforderungen
-- Lies `./writing_state.md` für abgeschlossene Kapitel und während des Schreibens identifizierte Kernargumente
+- `./academic_context.md` — Arbeitstyp, Disziplin, Forschungsfrage, Methodik, Sprache
+- `./writing_state.md` — abgeschlossene Kapitel, identifizierte Kernargumente
 
 ## Analyse-Phase
 
-Vor der Titelgenerierung die Arbeit entlang dieser Dimensionen analysieren:
-
-### 1. Inhaltliche Struktur
-
-- Zentrale These oder Kernargument identifizieren
-- Haupttheorie oder Analyserahmen extrahieren
-- Scope notieren (Einzelfall, Vergleich, branchenweit)
-- Abhängige und unabhängige Variablen bzw. Schlüsselkonzepte bestimmen
-
-### 2. Kernaussagen
-
-- Die 3-5 stärksten Claims der Arbeit extrahieren
-- Den originellsten Beitrag oder Befund identifizieren
-- Unerwartete Ergebnisse oder Gegenpositionen notieren
-
-### 3. Methodik-Signatur
-
-- Forschungsansatz identifizieren (qualitativ, quantitativ, Mixed, Literaturreview)
-- Methoden notieren, die die Arbeit auszeichnen (z. B. Delphi, SLR, Grounded Theory)
-- Prüfen, ob die Methodik selbst titelwürdig ist
-
-### 4. Keywords und Terminologie
-
-- Domänenspezifische Keywords aus der Arbeit extrahieren
-- Häufigste Fachbegriffe identifizieren
-- Selbst geprägte Begriffe oder Framework-Namen notieren
+Analysiere: (1) These/Kernargument, Analyserahmen, Scope, Schlüsselkonzepte; (2) 3-5 stärkste Claims, originellsten Befund, Gegenpositionen; (3) Forschungsansatz, auszeichnende Methoden; (4) domänenspezifische Keywords, häufige Fachbegriffe.
 
 ## Titel-Generierung
 
@@ -117,41 +73,19 @@ Genau 5-7 Titelvarianten über diese Kategorien erzeugen:
 
 ### Kategorie A: Klassisch-Akademisch (2 Titel)
 
-Struktur: `[Thema]: [Untertitel mit Scope/Methode]`
-
-Eigenschaften:
-- Formal, deskriptiv, eindeutig
-- Enthält Kernthema und Methodik oder Scope
-- Typisch für deutsche Abschlussarbeiten
-- Beispielmuster: "Digitale Transformation im Mittelstand: Eine qualitative Analyse der Erfolgsfaktoren"
+`[Thema]: [Untertitel mit Scope/Methode]` — formal, deskriptiv, typisch deutsch.
 
 ### Kategorie B: Fragenbasiert (1-2 Titel)
 
-Struktur: Titel als Forschungsfrage oder provokante Frage.
-
-Eigenschaften:
-- Spricht den Leser direkt an
-- Spiegelt die Forschungsfrage aus `./academic_context.md`
-- Passend für explorative oder argumentative Arbeiten
+Titel als Forschungsfrage — spricht Leser an, spiegelt `./academic_context.md`.
 
 ### Kategorie C: Konzeptuell / Kreativ (1-2 Titel)
 
-Struktur: Kurze, einprägsame Phrase mit akademischem Untertitel.
-
-Eigenschaften:
-- Nutzt Metapher, Paradox oder prägnante Formulierung
-- Immer mit klärendem Untertitel
-- Häufiger in Sozial- und Geisteswissenschaften
-- Muss professionell bleiben
+Kurze Phrase + akademischer Untertitel — Metapher/Paradox, immer mit Untertitel.
 
 ### Kategorie D: Ergebnisorientiert (1 Titel)
 
-Struktur: Titel, der das zentrale Ergebnis andeutet oder benennt.
-
-Eigenschaften:
-- Kündigt die Schlussfolgerung an
-- Passend, wenn der Befund klar und stark ist
-- In deutscher Tradition weniger üblich, aber zunehmend akzeptiert
+Kündigt Schlussfolgerung an — passend bei klarem, starkem Befund.
 
 ## Output-Format
 

--- a/tests/_capture_skill_sizes.py
+++ b/tests/_capture_skill_sizes.py
@@ -1,0 +1,18 @@
+# tests/_capture_skill_sizes.py
+# Aufruf: python tests/_capture_skill_sizes.py (aus Plugin-Root)
+# Erzeugt tests/baselines/skill_sizes.json mit len(SKILL.md text) pro Skill.
+# MUSS VOR jeder SKILL.md-Modifikation ausgefuehrt werden.
+import json
+from pathlib import Path
+
+SKILLS_DIR = Path("skills")
+VENDORED = {"xlsx", "_common"}
+data = {}
+for p in sorted(SKILLS_DIR.glob("*/SKILL.md")):
+    if p.parent.name not in VENDORED:
+        data[p.parent.name] = len(p.read_text())
+
+out = Path("tests/baselines/skill_sizes.json")
+out.parent.mkdir(parents=True, exist_ok=True)
+out.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
+print(f"Baseline captured: {out}")

--- a/tests/baselines/skill_sizes.json
+++ b/tests/baselines/skill_sizes.json
@@ -1,0 +1,15 @@
+{
+  "abstract-generator": 10933,
+  "academic-context": 6571,
+  "advisor": 9366,
+  "chapter-writer": 11421,
+  "citation-extraction": 9937,
+  "literature-gap-analysis": 9458,
+  "methodology-advisor": 10228,
+  "plagiarism-check": 7901,
+  "research-question-refiner": 10094,
+  "source-quality-audit": 9975,
+  "style-evaluator": 9427,
+  "submission-checker": 8897,
+  "title-generator": 6713
+}

--- a/tests/test_skill_naming.py
+++ b/tests/test_skill_naming.py
@@ -7,6 +7,7 @@ import yaml
 REPO_ROOT = Path(__file__).parent.parent
 SKILLS_DIR = REPO_ROOT / "skills"
 KEBAB_CASE = re.compile(r"^[a-z][a-z0-9]*(-[a-z0-9]+)*$")
+VENDORED_SKILLS = {"xlsx", "_common"}
 
 
 def _load_frontmatter(skill_md: Path) -> dict:
@@ -18,7 +19,7 @@ def _load_frontmatter(skill_md: Path) -> dict:
 
 def test_all_skill_names_are_kebab_case():
     for skill_dir in sorted(SKILLS_DIR.iterdir()):
-        if not skill_dir.is_dir():
+        if not skill_dir.is_dir() or skill_dir.name in VENDORED_SKILLS:
             continue
         skill_md = skill_dir / "SKILL.md"
         assert skill_md.exists(), f"Missing SKILL.md in {skill_dir}"
@@ -30,7 +31,7 @@ def test_all_skill_names_are_kebab_case():
 
 def test_skill_name_matches_directory():
     for skill_dir in sorted(SKILLS_DIR.iterdir()):
-        if not skill_dir.is_dir():
+        if not skill_dir.is_dir() or skill_dir.name in VENDORED_SKILLS:
             continue
         skill_md = skill_dir / "SKILL.md"
         fm = _load_frontmatter(skill_md)

--- a/tests/test_skills_manifest.py
+++ b/tests/test_skills_manifest.py
@@ -2,22 +2,27 @@
 
 Prueft jede skills/*/SKILL.md auf:
 - valides YAML-Frontmatter mit name + description
-- '## Vorbedingungen'-Sektion (ausser academic-context)
-- '## Keine Fabrikation'-Sektion (alle 13)
+- Preamble-Reference (Blockquote-Pattern) statt inline-Sections
 - >= 1 Umlaut-Paar ('X.../X...'-Muster mit Umlaut vor dem Slash) in description
+- preamble.md existiert mit den 4 Pflicht-Sections
+- Token-Reduktion >= 1400 Zeichen pro Skill vs. Baseline
 """
 
+import json
 import re
 from pathlib import Path
 
 import pytest
 
 SKILLS_DIR = Path(__file__).parent.parent / "skills"
-VENDORED_SKILLS = {"xlsx"}
+VENDORED_SKILLS = {"xlsx", "_common"}
 ALL_SKILLS = sorted(
     p for p in SKILLS_DIR.glob("*/SKILL.md") if p.parent.name not in VENDORED_SKILLS
 )
-SKILLS_WITH_PRECONDITION = [p for p in ALL_SKILLS if p.parent.name != "academic-context"]
+
+PREAMBLE_PATTERN = "> **Gemeinsames Preamble laden:**"
+BASELINES_PATH = Path(__file__).parent / "baselines" / "skill_sizes.json"
+TOKEN_REDUCTION_MIN = 1400  # Zeichen ~ 350 Token (cl100k-Proxy)
 
 
 def _frontmatter(path: Path) -> dict:
@@ -46,15 +51,17 @@ def test_frontmatter_valid(skill_path: Path) -> None:
 
 @pytest.mark.parametrize("skill_path", ALL_SKILLS, ids=lambda p: p.parent.name)
 def test_no_fabrication_section(skill_path: Path) -> None:
-    assert "\n## Keine Fabrikation\n" in skill_path.read_text(), (
-        f"{skill_path}: '## Keine Fabrikation' fehlt"
+    """Preamble-Reference-Check: preamble.md enthaelt '## Keine Fabrikation'."""
+    assert PREAMBLE_PATTERN in skill_path.read_text(), (
+        f"{skill_path}: Preamble-Reference '{PREAMBLE_PATTERN}' fehlt"
     )
 
 
-@pytest.mark.parametrize("skill_path", SKILLS_WITH_PRECONDITION, ids=lambda p: p.parent.name)
+@pytest.mark.parametrize("skill_path", ALL_SKILLS, ids=lambda p: p.parent.name)
 def test_precondition_section(skill_path: Path) -> None:
-    assert "\n## Vorbedingungen\n" in skill_path.read_text(), (
-        f"{skill_path}: '## Vorbedingungen' fehlt"
+    """Preamble-Reference-Check: preamble.md enthaelt '## Vorbedingungen'."""
+    assert PREAMBLE_PATTERN in skill_path.read_text(), (
+        f"{skill_path}: Preamble-Reference '{PREAMBLE_PATTERN}' fehlt"
     )
 
 
@@ -65,4 +72,54 @@ def test_umlaut_variants_in_description(skill_path: Path) -> None:
     pairs = re.findall(r'"[^"]*[äöüß][^"]*\s*/\s*[a-zA-Z][^"]*"', desc)
     assert len(pairs) >= 1, (
         f"{skill_path}: 0 Umlaut-Paare in description (gefunden: {desc[:160]}...)"
+    )
+
+
+def test_preamble_file_exists() -> None:
+    """skills/_common/preamble.md existiert mit allen 4 Pflicht-Sections."""
+    preamble = SKILLS_DIR / "_common" / "preamble.md"
+    assert preamble.exists(), "skills/_common/preamble.md fehlt"
+    text = preamble.read_text()
+    for section in ["## Vorbedingungen", "## Keine Fabrikation", "## Aktivierung", "## Abgrenzung"]:
+        assert section in text, f"preamble.md: Pflicht-Section '{section}' fehlt"
+
+
+@pytest.mark.parametrize("skill_path", ALL_SKILLS, ids=lambda p: p.parent.name)
+def test_preamble_load_instruction(skill_path: Path) -> None:
+    """Jedes SKILL.md enthaelt den Blockquote-Preamble-Ladeaufruf."""
+    assert PREAMBLE_PATTERN in skill_path.read_text(), (
+        f"{skill_path}: Preamble-Ladereferenz '{PREAMBLE_PATTERN}' fehlt"
+    )
+
+
+@pytest.mark.parametrize("skill_path", ALL_SKILLS, ids=lambda p: p.parent.name)
+def test_no_inline_vorbedingungen(skill_path: Path) -> None:
+    """Kein SKILL.md darf '## Vorbedingungen' als eigene Section enthalten."""
+    assert "\n## Vorbedingungen\n" not in skill_path.read_text(), (
+        f"{skill_path}: inline '## Vorbedingungen' gefunden — muss entfernt werden"
+    )
+
+
+@pytest.mark.parametrize("skill_path", ALL_SKILLS, ids=lambda p: p.parent.name)
+def test_no_inline_fabrikation(skill_path: Path) -> None:
+    """Kein SKILL.md darf '## Keine Fabrikation' als eigene Section enthalten."""
+    assert "\n## Keine Fabrikation\n" not in skill_path.read_text(), (
+        f"{skill_path}: inline '## Keine Fabrikation' gefunden — muss entfernt werden"
+    )
+
+
+@pytest.mark.parametrize("skill_path", ALL_SKILLS, ids=lambda p: p.parent.name)
+def test_token_reduction(skill_path: Path) -> None:
+    """Jedes SKILL.md muss >= 1400 Zeichen (~ 350 Token) kleiner als Baseline sein."""
+    assert BASELINES_PATH.exists(), f"Baseline-Datei fehlt: {BASELINES_PATH}"
+    baselines = json.loads(BASELINES_PATH.read_text())
+    skill_name = skill_path.parent.name
+    assert skill_name in baselines, f"Skill '{skill_name}' nicht in Baseline"
+    old_chars = baselines[skill_name]
+    new_chars = len(skill_path.read_text())
+    delta = old_chars - new_chars
+    assert delta >= TOKEN_REDUCTION_MIN, (
+        f"{skill_name}: Reduktion nur {delta} Zeichen "
+        f"(erwartet >= {TOKEN_REDUCTION_MIN}). "
+        f"alt={old_chars}, neu={new_chars}"
     )

--- a/tests/test_skills_manifest.py
+++ b/tests/test_skills_manifest.py
@@ -49,21 +49,6 @@ def test_frontmatter_valid(skill_path: Path) -> None:
     assert fm.get("description"), f"{skill_path}: description fehlt"
 
 
-@pytest.mark.parametrize("skill_path", ALL_SKILLS, ids=lambda p: p.parent.name)
-def test_no_fabrication_section(skill_path: Path) -> None:
-    """Preamble-Reference-Check: preamble.md enthaelt '## Keine Fabrikation'."""
-    assert PREAMBLE_PATTERN in skill_path.read_text(), (
-        f"{skill_path}: Preamble-Reference '{PREAMBLE_PATTERN}' fehlt"
-    )
-
-
-@pytest.mark.parametrize("skill_path", ALL_SKILLS, ids=lambda p: p.parent.name)
-def test_precondition_section(skill_path: Path) -> None:
-    """Preamble-Reference-Check: preamble.md enthaelt '## Vorbedingungen'."""
-    assert PREAMBLE_PATTERN in skill_path.read_text(), (
-        f"{skill_path}: Preamble-Reference '{PREAMBLE_PATTERN}' fehlt"
-    )
-
 
 @pytest.mark.parametrize("skill_path", ALL_SKILLS, ids=lambda p: p.parent.name)
 def test_umlaut_variants_in_description(skill_path: Path) -> None:


### PR DESCRIPTION
## Summary

Chunk C of v6.0 Wave 1 — F1.3 Skills schlanker (shared preamble extraction).

**Closes #67.**

User-decision (binding): AC threshold relaxed from "-500 tokens per skill" to **"-350 tokens per skill"** (≈1400 chars). The original AC was unachievable from preamble-extraction alone for 10 of 13 skills (minimum ~391T measured); the relaxed threshold is achievable for all 13 with margin.

### What landed (7 commits)

1. **`test: capture skill-size baseline`** — `tests/_capture_skill_sizes.py` + `tests/baselines/skill_sizes.json` snapshot of pre-modification skill sizes
2. **`test: add failing preamble tests (red)`** — `test_no_fabrication_section` and `test_precondition_section` rewritten to check blockquote-pattern preamble-ref instead of inline sections
3. **`feat: add shared preamble.md`** — `skills/_common/preamble.md` (48 lines) with 4 mandatory blocks: Vorbedingungen, Keine Fabrikation, Aktivierung, Abgrenzung
4. **`refactor: extract preamble refs batch-1`** (7 skills)
5. **`refactor: extract preamble refs batch-2`** (6 skills)
6. **`chore: code-simplifier polish`** — removed 2 duplicate test functions
7. **`fix: exclude _common from skill-naming tests`**

### Token savings (per L0-relaxed AC)

| Skill | Reduction (chars) |
|---|---|
| title-generator | 2201 (max) |
| ... | ... |
| academic-context | 1436 (min, still ≥1400 = ~350T) |

All 13 skills meet the relaxed threshold. Override sections preserved for `academic-context` and `style-evaluator`/`submission-checker` variant references.

### Tests

- 123 passed, 0 failed, 113 skipped (other chunks' xfail tests)
- `test_skills_manifest.py` updated to validate blockquote pattern instead of inline sections

## Test plan

- [ ] `pytest tests/ -v` — full suite green
- [ ] `pytest tests/test_skills_manifest.py -v` — all preamble + naming tests pass
- [ ] Manual: load any skill (e.g. `quote-extractor/SKILL.md`) — preamble blockquote at top, mandatory sections deduplicated
- [ ] Manual: `cat skills/_common/preamble.md` — 4 sections present and self-contained

## Notes

- Chunk D (PR #114) depends on this — after merge, `tests/test_skills_manifest.py` needs `"humanizer-de"` added to `VENDORED_SKILLS` (one-line follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code) via mmp orchestrator (v6.0 Wave 1, chunk C)
