### PR TITLE
v6.0/W2-C: humanizer-de Integration in chapter-writer + quality-reviewer (#68)

### DIFF
--- a/agents/quality-reviewer.md
+++ b/agents/quality-reviewer.md
@@ -56,7 +56,8 @@ Du bist ein strenger, aber fairer akademischer Reviewer. Du prüfst generierten 
   "context": {
     "component": "chapter-writer",
     "chapter": "3 Grundlagen",
-    "iteration": 0
+    "iteration": 0,
+    "humanizer_de_pass": false
   }
 }
 ```
@@ -88,6 +89,11 @@ BLOCKIERT_VON: <none | iteration-limit>
 3. **REVISE nur wenn mindestens 1 Kriterium FAIL.** Bei PASS alle Kriterien einzeln bestätigen.
 4. **EMPFEHLUNGEN sind handlungsbezogen.** „Passiv reduzieren" ist vage; „Satz 3 Abschnitt 2: 'wird durchgeführt' → 'führt durch' ersetzen" ist konkret.
 5. **Iteration 2+ triggert PASS-with-warnings.** Der Aufrufer hat dann eine Begründungs-Liste, um die Probleme dem User transparent zu machen.
+6. **humanizer-de-Pass beachten.** Wenn `context.humanizer_de_pass: true`, wurde
+   der Entwurf bereits durch einen Anti-KI-Audit-Pass (`humanizer-de`, Modus `formal`)
+   geführt. KI-typische Schreibmuster wurden bereits bereinigt — kein eigener
+   Anti-KI-Audit-Pass durch den Reviewer. Beurteilung nur nach den gelieferten
+   `criteria` (Satzlänge, Passiv, Nominalstil, Quellen-Dichte).
 
 ---
 

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -20,6 +20,13 @@ Das Skript übernimmt in sechs Schritten:
 2. Erstellt die Python-venv und installiert `httpx`, `PyPDF2`, `pyyaml`, `openpyxl` (aus `scripts/requirements.txt`).
 3. Prüft, ob `browser-use` CLI vorhanden ist. Falls nicht: installiert automatisch via `uv tool install` oder `pipx install`, sofern eines der beiden Tools vorhanden ist. Führt anschließend `browser-use doctor` aus.
 4. Prüft, ob der globale `browser-use` Claude-Skill unter `~/.claude/skills/browser-use/` liegt.
+4a. Prüft, ob der `humanizer-de`-Skill unter `~/.codex/skills/humanizer-de/`
+    global installiert ist. Dieser Skill ist im Plugin bereits vendoriert
+    (`skills/humanizer-de/`) und damit immer verfügbar. Der globale Check
+    gilt für eigenständige Nutzung außerhalb des Plugins.
+    - Gefunden: `✅ humanizer-de Skill (global): vorhanden`
+    - Nicht gefunden: `⚠️ humanizer-de Skill (global): nicht gefunden — für eigenständige Nutzung installieren: https://github.com/marmbiz/humanizer-de`
+    (kein Hard-Fail — der vendorierte Skill im Plugin bleibt funktionsfähig)
 5. Schreibt die Claude-Code-Permissions über `scripts/configure_permissions.py`.
 6. **Projekt-Bootstrap (Auto-Detect).** Wenn das aktuelle Verzeichnis ein leerer Ordner ist, fragt `/setup` `"Hier einen Facharbeit-Arbeitsordner initialisieren?"`. Bei `y` werden `academic_context.md` (Stub), `CLAUDE.md`, `.gitignore`, sowie `kapitel/`, `literatur/`, `pdfs/` angelegt. In einem bestehenden Facharbeit-Ordner (mit `academic_context.md`) werden nur fehlende Artefakte nachgezogen — idempotent, keine Rückfrage. In Code-Repos (erkannt an `package.json`, `pyproject.toml`, …) oder nicht-leeren fremden Verzeichnissen: keine Aktion. Findet der Bootstrap zusätzlich bestehenden Kontext in Claude-Memory, bietet er an, ihn einmalig ins Projekt zu kopieren; die Memory-Dateien bleiben als Backup liegen.
 
@@ -30,6 +37,8 @@ Das Skript übernimmt in sechs Schritten:
 | ✅ Python environment: ready | venv + requirements.txt erfolgreich installiert |
 | ✅ browser-use CLI: ready | CLI vorhanden und `browser-use doctor` meldet keinen Fehler |
 | ✅ browser-use Claude-Skill: vorhanden | Skill unter `~/.claude/skills/browser-use/` |
+| ✅ humanizer-de Skill (global): vorhanden | Skill global unter `~/.codex/skills/humanizer-de/` installiert |
+| ⚠️ humanizer-de Skill (global): nicht gefunden | Nur vendorierter Plugin-Skill verfügbar (ausreichend für Plugin-Nutzung) |
 | ⚠️ … | siehe Hinweistext direkt unter dem Marker |
 | ✅ Facharbeit-Arbeitsordner initialisiert | Projekt-Struktur wurde im aktuellen Verzeichnis angelegt |
 

--- a/evals/humanizer-de-pipeline/README.md
+++ b/evals/humanizer-de-pipeline/README.md
@@ -1,0 +1,96 @@
+# Eval-Set: humanizer-de-Pipeline
+
+**Ticket:** #68 — F4 humanizer-de Integration in chapter-writer + quality-reviewer  
+**Status:** Eval-Skeleton (manueller Run erforderlich)
+
+---
+
+## Zweck
+
+Dieser Eval-Set prüft, ob der `humanizer-de(audit)`-Zwischenschritt in
+`chapter-writer` KI-typische Schreibmuster effektiv reduziert — messbar
+als Abfall des GPTZero AI-Scores vor vs. nach dem Humanizer-Pass.
+
+---
+
+## Eval-Kriterien
+
+| Kriterium | Ziel |
+|-----------|------|
+| GPTZero AI-Score vor Humanizer | Baseline (erwartet: hoch, > 70 %) |
+| GPTZero AI-Score nach Humanizer | Soll sinken (Ziel: < 50 %) |
+| Inhaltlicher Verlust | Keine Fakten/Zitate verloren |
+| Lesbarkeit | Akademischer Register bleibt erhalten |
+
+---
+
+## Draft-Samples
+
+| Draft | Kontext | KI-Tells |
+|-------|---------|----------|
+| `drafts/draft-01-theorie.md` | Bachelorarbeit, Theoriekapitel | Aufzählungs-Einstieg, Nominalstil-Übermaß |
+| `drafts/draft-02-methodik.md` | Masterarbeit, Methodikkapitel | Passiv-Übermaß, stereotype Formulierungen |
+| `drafts/draft-03-diskussion.md` | Dissertation, Diskussionskapitel | Hedging-Übermaß, redundante Einleitung |
+
+---
+
+## Manueller Run-Ablauf
+
+### Voraussetzungen
+
+- `ANTHROPIC_API_KEY` in der Shell gesetzt
+- Zugang zu GPTZero (https://gptzero.me) oder OriginalityAI
+- Claude Code mit dem `academic-research`-Plugin geladen
+
+### Schritte
+
+1. **Draft einlesen und GPTZero-Score messen (Vor-Wert)**
+
+   Für jeden Draft: Inhalt in GPTZero einfügen, Score notieren.
+   Eintrag in `template-comparison.md` Spalte „Score vor".
+
+2. **Humanizer-Pass ausführen**
+
+   ```
+   /academic-research:humanize evals/humanizer-de-pipeline/drafts/draft-01-theorie.md
+   /academic-research:humanize evals/humanizer-de-pipeline/drafts/draft-02-methodik.md
+   /academic-research:humanize evals/humanizer-de-pipeline/drafts/draft-03-diskussion.md
+   ```
+
+   Ausgabe: `drafts/draft-0N-*.humanized.md` + `drafts/draft-0N-*.diff.md`
+
+3. **GPTZero-Score nach Humanizer messen (Nach-Wert)**
+
+   Inhalt der `.humanized.md`-Dateien in GPTZero einfügen, Score notieren.
+   Eintrag in `template-comparison.md` Spalte „Score nach".
+
+4. **Ergebnisse eintragen**
+
+   `template-comparison.md` ausfüllen. Ziel: Score-Reduktion ≥ 20 Prozentpunkte
+   pro Draft.
+
+5. **Qualitäts-Spot-Check**
+
+   Humanisierten Text mit Original vergleichen:
+   - Kein Fakten-/Zitat-Verlust
+   - Akademisches Register erhalten
+   - Keine stilistischen Brüche
+
+---
+
+## Erfolgskriterien
+
+- [ ] Alle 3 Drafts: GPTZero-Score sinkt nach Humanizer-Pass
+- [ ] Mindestens 2 von 3: Score-Reduktion ≥ 20 Prozentpunkte
+- [ ] Kein Draft verliert Zitate oder Kernaussagen
+- [ ] Lesbarkeit nach Spot-Check akzeptabel
+
+---
+
+## Hinweise
+
+- Der `humanizer-de`-Skill ist im Plugin vendoriert (`skills/humanizer-de/`).
+  Kein separates Setup nötig.
+- GPTZero-Scores schwanken — bei Grenzfällen zwei Messungen, Durchschnitt bilden.
+- Dieser Eval ist bewusst **kein automatisierter CI-Run** (erfordert externen
+  GPTZero-API-Key und manuelle Qualitätsbewertung).

--- a/evals/humanizer-de-pipeline/drafts/draft-01-theorie.md
+++ b/evals/humanizer-de-pipeline/drafts/draft-01-theorie.md
@@ -1,0 +1,30 @@
+# Draft 01 — Theoriekapitel (Bachelorarbeit)
+
+**Kontext:** Bachelorarbeit BWL, Kapitel 2 „Theoretischer Rahmen: Transformationale Führung"  
+**Eval-Zweck:** KI-typische Tells — Aufzählungs-Einstieg, Nominalstil-Übermaß, fehlende Evidenz  
+**Status:** Rohdraft vor humanizer-de-Pass (Baseline für GPTZero-Vergleich)
+
+---
+
+Transformationale Führung ist ein wichtiges Konzept in der modernen Managementliteratur.
+Es gibt verschiedene Aspekte, die dabei eine Rolle spielen. Erstens ist die Visionsvermittlung
+von entscheidender Bedeutung. Zweitens spielt die individuelle Förderung der Mitarbeiterinnen
+und Mitarbeiter eine wesentliche Rolle. Drittens ist die intellektuelle Stimulierung ein
+zentrales Element des transformationalen Führungsansatzes.
+
+Die Transformationalität von Führungskräften manifestiert sich in der Ausübung von
+Einflussnahme auf die Motivationsstruktur der Geführten. Die Ausprägung dieser
+Führungsqualität korreliert positiv mit der Leistungsbereitschaft und der
+Arbeitszufriedenheit der Belegschaft. In der wissenschaftlichen Literatur findet sich
+eine Vielzahl von Untersuchungen, die diese Zusammenhänge empirisch belegen.
+
+Es ist wichtig zu betonen, dass transformationale Führung sich von transaktionaler
+Führung unterscheidet. Während transaktionale Führung auf einem Austauschverhältnis
+basiert, zielt transformationale Führung auf eine tiefergehende Veränderung ab.
+Die Forschung zeigt, dass transformationale Führung effektiver ist. Dies hat
+bedeutende Implikationen für die Praxis der Unternehmensführung und die Gestaltung
+von Führungsentwicklungsprogrammen in modernen Organisationen.
+
+Zusammenfassend lässt sich sagen, dass transformationale Führung ein vielschichtiges
+Konzept darstellt, das verschiedene Dimensionen umfasst. Die Berücksichtigung dieser
+Dimensionen ist für eine erfolgreiche Führungspraxis von großer Wichtigkeit.

--- a/evals/humanizer-de-pipeline/drafts/draft-02-methodik.md
+++ b/evals/humanizer-de-pipeline/drafts/draft-02-methodik.md
@@ -1,0 +1,28 @@
+# Draft 02 — Methodikkapitel (Masterarbeit)
+
+**Kontext:** Masterarbeit Wirtschaftspsychologie, Kapitel 3 „Methodik"  
+**Eval-Zweck:** KI-typische Tells — Passiv-Übermaß, stereotype Formulierungen, fehlende Limitations  
+**Status:** Rohdraft vor humanizer-de-Pass (Baseline für GPTZero-Vergleich)
+
+---
+
+Im Rahmen dieser Masterarbeit wurde ein quantitatives Forschungsdesign gewählt.
+Es wurden Daten von insgesamt 150 Teilnehmerinnen und Teilnehmern erhoben.
+Die Datenerhebung wurde mittels eines standardisierten Online-Fragebogens durchgeführt.
+Der Fragebogen wurde sorgfältig entwickelt und vor der Haupterhebung einem Pretest
+unterzogen. Die Ergebnisse des Pretests wurden zur Verbesserung des Fragebogens genutzt.
+
+Die Stichprobe wurde nach dem Zufallsprinzip ausgewählt. Es wurde sichergestellt,
+dass die Stichprobe repräsentativ für die Grundgesamtheit ist. Die Daten wurden
+mit Hilfe von SPSS ausgewertet. Es wurden verschiedene statistische Verfahren
+angewendet. Dazu gehörten deskriptive Statistiken, Korrelationsanalysen und
+multiple Regressionsanalysen. Die Ergebnisse wurden sorgfältig interpretiert.
+
+Es ist anzumerken, dass die vorliegende Studie einige Einschränkungen aufweist.
+Diese Einschränkungen sollten bei der Interpretation der Ergebnisse berücksichtigt
+werden. Zukünftige Forschung sollte diese Einschränkungen adressieren und weitere
+Untersuchungen durchführen, um ein umfassenderes Bild zu erhalten.
+
+Insgesamt bietet die gewählte Methodik eine solide Grundlage für die Beantwortung
+der Forschungsfrage. Die Ergebnisse sind als aussagekräftig zu bewerten, auch wenn
+die genannten Einschränkungen zu beachten sind.

--- a/evals/humanizer-de-pipeline/drafts/draft-03-diskussion.md
+++ b/evals/humanizer-de-pipeline/drafts/draft-03-diskussion.md
@@ -1,0 +1,30 @@
+# Draft 03 — Diskussionskapitel (Dissertation)
+
+**Kontext:** Dissertation Sozialwissenschaften, Kapitel 5 „Diskussion der Ergebnisse"  
+**Eval-Zweck:** KI-typische Tells — Hedging-Übermaß, redundante Einleitung, fehlende Literatureinbettung  
+**Status:** Rohdraft vor humanizer-de-Pass (Baseline für GPTZero-Vergleich)
+
+---
+
+In diesem Kapitel werden die Ergebnisse der vorliegenden Untersuchung diskutiert.
+Die Befunde werden im Kontext des theoretischen Rahmens und der bestehenden
+Forschungsliteratur eingeordnet. Es ist wichtig zu betonen, dass die folgende
+Diskussion einen Beitrag zum wissenschaftlichen Diskurs leisten möchte.
+
+Die Ergebnisse deuten möglicherweise darauf hin, dass ein Zusammenhang zwischen
+den untersuchten Variablen bestehen könnte. Es scheint so zu sein, dass dieser
+Zusammenhang unter bestimmten Bedingungen besonders ausgeprägt sein könnte.
+Allerdings ist zu beachten, dass diese Interpretation mit Vorsicht zu genießen ist.
+Es könnte sein, dass weitere Faktoren eine Rolle spielen könnten, die in der
+vorliegenden Studie möglicherweise nicht ausreichend berücksichtigt wurden.
+
+Es lässt sich festhalten, dass die vorliegenden Ergebnisse in gewissem Maße
+konsistent mit früheren Forschungsergebnissen zu sein scheinen. Gleichzeitig
+gibt es jedoch auch Aspekte, die von bisherigen Erkenntnissen abzuweichen
+scheinen. Diese Abweichungen könnten möglicherweise auf verschiedene Faktoren
+zurückzuführen sein, die im Rahmen zukünftiger Forschung untersucht werden sollten.
+
+Zusammenfassend kann gesagt werden, dass die vorliegende Diskussion zeigt,
+dass das Thema komplex ist und weitere Forschung erforderlich sein könnte,
+um ein vollständigeres Verständnis zu erlangen. Die Bedeutung dieser Befunde
+für die wissenschaftliche Gemeinschaft sollte nicht unterschätzt werden.

--- a/evals/humanizer-de-pipeline/template-comparison.md
+++ b/evals/humanizer-de-pipeline/template-comparison.md
@@ -1,0 +1,63 @@
+# Vergleichs-Template: GPTZero-Scores vor/nach humanizer-de
+
+**Eval-Set:** humanizer-de-Pipeline (#68)  
+**Run-Datum:** ___ (ausfüllen)  
+**Ausgeführt von:** ___
+
+---
+
+## Score-Tabelle
+
+| Draft | Kapiteltyp | Arbeitstyp | GPTZero Score VOR | GPTZero Score NACH | Reduktion | Ziel (≥ 20 PP) |
+|-------|-----------|------------|-------------------|-------------------|-----------|----------------|
+| draft-01-theorie.md | Theorie | Bachelor | ___ % | ___ % | ___ PP | ☐ |
+| draft-02-methodik.md | Methodik | Master | ___ % | ___ % | ___ PP | ☐ |
+| draft-03-diskussion.md | Diskussion | Dissertation | ___ % | ___ % | ___ PP | ☐ |
+
+**Legende:** PP = Prozentpunkte. Score-Quelle: GPTZero (https://gptzero.me) oder OriginalityAI.
+
+---
+
+## Qualitäts-Spot-Check
+
+Für jeden Draft nach dem Humanizer-Pass:
+
+### Draft 01 — Theorie (Bachelor)
+
+- [ ] Kein Fakten- oder Zitat-Verlust
+- [ ] Akademisches Register erhalten
+- [ ] Keine stilistischen Brüche
+- **Anmerkungen:** ___
+
+### Draft 02 — Methodik (Master)
+
+- [ ] Kein Fakten- oder Zitat-Verlust
+- [ ] Akademisches Register erhalten
+- [ ] Keine stilistischen Brüche
+- **Anmerkungen:** ___
+
+### Draft 03 — Diskussion (Dissertation)
+
+- [ ] Kein Fakten- oder Zitat-Verlust
+- [ ] Akademisches Register erhalten
+- [ ] Keine stilistischen Brüche
+- **Anmerkungen:** ___
+
+---
+
+## Humanizer-Diff-Zusammenfassung
+
+| Draft | Critical | High | Medium | Low | Gesamt-Änderungen |
+|-------|----------|------|--------|-----|-------------------|
+| draft-01 | ___ | ___ | ___ | ___ | ___ |
+| draft-02 | ___ | ___ | ___ | ___ | ___ |
+| draft-03 | ___ | ___ | ___ | ___ | ___ |
+
+---
+
+## Gesamturteil
+
+- [ ] **PASS** — ≥ 2/3 Drafts erreichen Score-Reduktion ≥ 20 PP, kein Qualitätsverlust
+- [ ] **FAIL** — Ziel nicht erreicht oder Qualitätsverlust festgestellt
+
+**Fazit:** ___

--- a/scripts/bootstrap/academic_context.stub.md
+++ b/scripts/bootstrap/academic_context.stub.md
@@ -11,7 +11,8 @@ type: project
 - Sprache: TODO (Default: Deutsch)
 
 ## Arbeit
-- Typ: TODO (Bachelorarbeit/Masterarbeit/Hausarbeit/Facharbeit)
+- Typ: TODO (Bachelorarbeit/Masterarbeit/Diplom/Dissertation/Hausarbeit/Facharbeit)
+- humanizer_de: on   # Anti-KI-Audit-Pass: on (Default bei Hochschularbeiten) | off (überspringen)
 - Thema: TODO
 - Forschungsfrage: TODO
 - Methodik: TODO

--- a/skills/chapter-writer/SKILL.md
+++ b/skills/chapter-writer/SKILL.md
@@ -216,22 +216,67 @@ Beim Einweben von Zitaten in Kapitel-Prosa: Quellen-PDFs im `documents`-Paramete
 nutze den Vault-Zitat-Text (`verbatim`) direkt als Prompt-basiertes Zitat
 ohne Citations-API-Erzwingung.
 
+## Humanizer-Audit-Pass (nur Hochschul-Kontext)
+
+Bevor `quality-reviewer` aufgerufen wird, prüfe ob ein Anti-KI-Audit-Pass
+erforderlich ist:
+
+### Trigger-Bedingung
+
+1. Lies `./academic_context.md` (bereits in Schritt 1 geladen).
+2. Extrahiere das Feld `Typ:` (Freitext, z. B. `Bachelorarbeit`).
+3. Prüfe Substring-Match (case-insensitiv) gegen:
+   `["bachelor", "master", "diplom", "dissertation"]`
+4. Prüfe ob `humanizer_de: off` in `./academic_context.md` gesetzt ist.
+
+**Humanizer überspringen wenn:**
+- `./academic_context.md` fehlt, oder `Typ:` nicht gesetzt, oder kein Hochschul-Marker gefunden, **oder**
+- `humanizer_de: off` in `./academic_context.md` gesetzt ist.
+
+**Humanizer ausführen wenn:** Hochschul-Marker gefunden UND kein Bypass-Flag.
+
+### Ausführung
+
+```
+Skill(humanizer-de):
+  mode: formal
+  input: <aktueller Kapitel-Entwurf>
+  voice_samples_dir: <aus academic_context.md project_slug oder null>
+```
+
+Der Skill gibt zurück:
+- `humanized_text` — überarbeiteter Entwurf (ersetzt den rohen Draft)
+- `changes` — Liste der Änderungen mit `severity` und `pattern_id`
+
+**Nach dem Audit-Pass:** Verwende `humanized_text` als Input für den
+nachfolgenden `quality-reviewer`-Aufruf.
+
+**Anzahl Critical/High-Änderungen** kurz dem User melden (z. B.:
+`Humanizer-Audit: 3 Critical, 7 High, 12 Medium Muster korrigiert.`),
+ohne den vollständigen Diff auszugeben — User kann `/humanize` für
+den vollständigen Diff aufrufen.
+
 ## Qualitaets-Review vor finalem Output
 
-Nach der Generierung des Kapitel-Entwurfs triggere den `quality-reviewer`-Agent:
+Nach der Generierung des Kapitel-Entwurfs (ggf. nach Humanizer-Audit-Pass)
+triggere den `quality-reviewer`-Agent:
 
 ```
 Agent(
   subagent_type="quality-reviewer",
   prompt={
-    "content": "<Entwurfs-Text>",
+    "content": "<Entwurfs-Text oder humanized_text>",
     "criteria": [
       {"name": "Satzlaenge Median", "threshold": "15-25 Woerter", "metric": "median"},
       {"name": "Passiv-Quote", "threshold": "< 30%", "metric": "percentage"},
       {"name": "Nominalstil", "threshold": "< 40%", "metric": "percentage"},
       {"name": "Quellen pro 1000 Woerter", "threshold": ">= 5", "metric": "count_per_1000"}
     ],
-    "context": {"component": "chapter-writer", "iteration": <N>}
+    "context": {
+      "component": "chapter-writer",
+      "iteration": <N>,
+      "humanizer_de_pass": <true wenn Audit-Pass gelaufen, sonst false>
+    }
   }
 )
 ```

--- a/specs/v6.0/W2-C-plan.md
+++ b/specs/v6.0/W2-C-plan.md
@@ -1,0 +1,425 @@
+# humanizer-de Pipeline Integration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `humanizer-de(audit)`-Schritt als Pflicht-Zwischenschritt in `chapter-writer` einbauen — nur bei Hochschul-Kontexten, opt-out-fähig via `humanizer_de: off`.
+
+**Architecture:** Markdown-driven Plugin-Repo ohne Build-System. Alle Änderungen sind Edits an bestehenden `.md`-Dateien plus neue Eval-Skeleton-Dateien. Kein Code-Compile-Step. "Tests" sind grep-basierte Smoke-Checks gegen die geänderten Dateien.
+
+**Tech Stack:** Markdown, YAML-Frontmatter-Konventionen, Bash-Smoke-Checks.
+
+---
+
+## File-Map
+
+| Datei | Aktion |
+|-------|--------|
+| `skills/chapter-writer/SKILL.md` | Edit — humanizer-de-Block nach Schritt 4 (Draften), vor quality-reviewer |
+| `agents/quality-reviewer.md` | Edit — Hinweis auf humanizer-de(audit)-Pass im Input-Format |
+| `commands/setup.md` | Edit — Skill-Existenz-Check für `~/.codex/skills/humanizer-de/` |
+| `scripts/bootstrap/academic_context.stub.md` | Edit — `humanizer_de:` Bypass-Flag ergänzen |
+| `evals/humanizer-de-pipeline/README.md` | Neu |
+| `evals/humanizer-de-pipeline/drafts/draft-01-theorie.md` | Neu |
+| `evals/humanizer-de-pipeline/drafts/draft-02-methodik.md` | Neu |
+| `evals/humanizer-de-pipeline/drafts/draft-03-diskussion.md` | Neu |
+| `evals/humanizer-de-pipeline/template-comparison.md` | Neu |
+
+---
+
+## Task 1: Smoke-Test-Baseline (RED)
+
+Da das Repo keine Unit-Tests hat, sind Smoke-Tests grep-basiert. Wir definieren
+zuerst die Assertions, die nach der Implementierung grün sein müssen.
+
+**Files:** (keine Produktion, nur Baseline-Prüfung)
+
+- [ ] **Step 1: Prüfe aktuellen Zustand — alle müssen FAIL (fehlen noch)**
+
+```bash
+# Diese greps sollten jetzt NOCH NICHT matchen (RED-Phase):
+
+grep -q "humanizer-de" /Users/j65674/Repos/academic-research-W2-C/skills/chapter-writer/SKILL.md \
+  && echo "FOUND (schon drin)" || echo "NOT FOUND (erwartet: RED)"
+
+grep -q "humanizer_de_pass" /Users/j65674/Repos/academic-research-W2-C/agents/quality-reviewer.md \
+  && echo "FOUND (schon drin)" || echo "NOT FOUND (erwartet: RED)"
+
+grep -q "codex/skills/humanizer-de" /Users/j65674/Repos/academic-research-W2-C/commands/setup.md \
+  && echo "FOUND (schon drin)" || echo "NOT FOUND (erwartet: RED)"
+
+grep -q "humanizer_de:" /Users/j65674/Repos/academic-research-W2-C/scripts/bootstrap/academic_context.stub.md \
+  && echo "FOUND (schon drin)" || echo "NOT FOUND (erwartet: RED)"
+
+ls /Users/j65674/Repos/academic-research-W2-C/evals/humanizer-de-pipeline/README.md 2>/dev/null \
+  && echo "FOUND (schon drin)" || echo "NOT FOUND (erwartet: RED)"
+```
+
+Erwartete Ausgabe: alle 5 Zeilen = `NOT FOUND (erwartet: RED)`.
+
+Abweichungen notieren — falls ein Item bereits grün ist, Step überspringen.
+
+---
+
+## Task 2: chapter-writer — humanizer-de-Schritt einbauen
+
+**Files:** Modify `skills/chapter-writer/SKILL.md`
+
+- [ ] **Step 1: Aktuellen Abschnitt „Qualitaets-Review vor finalem Output" lokalisieren**
+
+Öffne `skills/chapter-writer/SKILL.md`, finde Zeile mit:
+```
+## Qualitaets-Review vor finalem Output
+```
+Dieser Abschnitt ruft aktuell direkt `quality-reviewer` auf.
+
+- [ ] **Step 2: Neuen Abschnitt „Humanizer-Audit-Pass" VOR dem Quality-Review einfügen**
+
+Füge **oberhalb** von `## Qualitaets-Review vor finalem Output` folgenden Block ein:
+
+```markdown
+## Humanizer-Audit-Pass (nur Hochschul-Kontext)
+
+Bevor `quality-reviewer` aufgerufen wird, prüfe ob ein Anti-KI-Audit-Pass
+erforderlich ist:
+
+### Trigger-Bedingung
+
+1. Lies `./academic_context.md` (bereits in Schritt 1 geladen).
+2. Extrahiere das Feld `Typ:` (Freitext, z. B. `Bachelorarbeit`).
+3. Prüfe Substring-Match (case-insensitiv) gegen:
+   `["bachelor", "master", "diplom", "dissertation"]`
+4. Prüfe ob `humanizer_de: off` in `./academic_context.md` gesetzt ist.
+
+**Humanizer überspringen wenn:**
+- `Typ:` nicht gesetzt oder kein Hochschul-Marker gefunden, **oder**
+- `humanizer_de: off` in `./academic_context.md` gesetzt ist.
+
+**Humanizer ausführen wenn:** Hochschul-Marker gefunden UND kein Bypass-Flag.
+
+### Ausführung
+
+```
+Skill(humanizer-de):
+  mode: formal
+  input: <aktueller Kapitel-Entwurf>
+  voice_samples_dir: <aus academic_context.md project_slug oder null>
+```
+
+Der Skill gibt zurück:
+- `humanized_text` — überarbeiteter Entwurf (ersetzt den rohen Draft)
+- `changes` — Liste der Änderungen mit `severity` und `pattern_id`
+
+**Nach dem Audit-Pass:** Verwende `humanized_text` als Input für den
+nachfolgenden `quality-reviewer`-Aufruf.
+
+**Anzahl Critical/High-Änderungen** kurz dem User melden (z. B.:
+`Humanizer-Audit: 3 Critical, 7 High, 12 Medium Muster korrigiert.`),
+ohne den vollständigen Diff auszugeben — User kann `/humanize` für
+den vollständigen Diff aufrufen.
+```
+
+- [ ] **Step 3: Im quality-reviewer-Aufruf das neue Kontext-Feld ergänzen**
+
+Finde im selben File den bestehenden `quality-reviewer`-Aufruf-Block:
+```
+    "context": {"component": "chapter-writer", "iteration": <N>}
+```
+
+Ersetze durch:
+```
+    "context": {
+      "component": "chapter-writer",
+      "iteration": <N>,
+      "humanizer_de_pass": <true wenn Audit-Pass gelaufen, sonst false>
+    }
+```
+
+- [ ] **Step 4: Smoke-Test — vault.search + humanizer-de beide vorhanden**
+
+```bash
+grep -q "vault.search" /Users/j65674/Repos/academic-research-W2-C/skills/chapter-writer/SKILL.md \
+  && echo "PASS: vault.search vorhanden" || echo "FAIL: vault.search fehlt"
+
+grep -q "humanizer-de" /Users/j65674/Repos/academic-research-W2-C/skills/chapter-writer/SKILL.md \
+  && echo "PASS: humanizer-de vorhanden" || echo "FAIL: humanizer-de fehlt"
+
+grep -q "vault.find_quotes" /Users/j65674/Repos/academic-research-W2-C/skills/chapter-writer/SKILL.md \
+  && echo "PASS: vault.find_quotes vorhanden" || echo "FAIL: vault.find_quotes fehlt (W2-A-Regression!)"
+
+grep -q "humanizer_de_pass" /Users/j65674/Repos/academic-research-W2-C/skills/chapter-writer/SKILL.md \
+  && echo "PASS: humanizer_de_pass Feld vorhanden" || echo "FAIL: Feld fehlt"
+```
+
+Alle 4 = PASS. Bei `vault.find_quotes`-FAIL: Sofort stoppen, W2-A-Regression prüfen.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/j65674/Repos/academic-research-W2-C && git add skills/chapter-writer/SKILL.md && git commit -m "feat(v6.0/W2-C): chapter-writer — humanizer-de(audit) vor quality-reviewer"
+```
+
+---
+
+## Task 3: quality-reviewer — Hinweis auf Audit-Pass
+
+**Files:** Modify `agents/quality-reviewer.md`
+
+- [ ] **Step 1: Input-Format-Abschnitt finden**
+
+Öffne `agents/quality-reviewer.md`, finde Abschnitt `## Input-Format`.
+Das `context`-Objekt enthält aktuell `component`, `chapter`, `iteration`.
+
+- [ ] **Step 2: `humanizer_de_pass`-Feld im Input-Format ergänzen**
+
+Ergänze das JSON-Beispiel im `## Input-Format`-Abschnitt:
+
+```json
+{
+  "content": "<der generierte Text>",
+  "criteria": [...],
+  "context": {
+    "component": "chapter-writer",
+    "chapter": "3 Grundlagen",
+    "iteration": 0,
+    "humanizer_de_pass": false
+  }
+}
+```
+
+(Feld auf `false` im Beispiel — `chapter-writer` setzt es auf `true` nach gelaufenem Pass.)
+
+- [ ] **Step 3: Strategie-Abschnitt — Hinweis einfügen**
+
+Finde `## Strategie`. Ergänze als neuen Punkt 6 (nach den bestehenden 5 Punkten):
+
+```markdown
+6. **humanizer-de-Pass beachten.** Wenn `context.humanizer_de_pass: true`, wurde
+   der Entwurf bereits durch einen Anti-KI-Audit-Pass (`humanizer-de`, Modus `formal`)
+   geführt. KI-typische Schreibmuster wurden bereits bereinigt — kein eigener
+   Anti-KI-Audit-Pass durch den Reviewer. Beurteilung nur nach den gelieferten
+   `criteria` (Satzlänge, Passiv, Nominalstil, Quellen-Dichte).
+```
+
+- [ ] **Step 4: Smoke-Test**
+
+```bash
+grep -q "humanizer_de_pass" /Users/j65674/Repos/academic-research-W2-C/agents/quality-reviewer.md \
+  && echo "PASS" || echo "FAIL"
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/j65674/Repos/academic-research-W2-C && git add agents/quality-reviewer.md && git commit -m "feat(v6.0/W2-C): quality-reviewer — Hinweis auf humanizer-de(audit)-Pass"
+```
+
+---
+
+## Task 4: setup.md — Skill-Existenz-Check
+
+**Files:** Modify `commands/setup.md`
+
+- [ ] **Step 1: Bestehenden Struktur-Abschnitt lokalisieren**
+
+Öffne `commands/setup.md`. Finde Schritt 4 (browser-use Claude-Skill-Check):
+```
+4. Prüft, ob der globale `browser-use` Claude-Skill unter `~/.claude/skills/browser-use/` liegt.
+```
+
+- [ ] **Step 2: Neuen Check für humanizer-de ergänzen**
+
+Ergänze **nach** Schritt 4, als neuen Schritt 4a (vor Schritt 5):
+
+```markdown
+4a. Prüft, ob der `humanizer-de`-Skill unter `~/.codex/skills/humanizer-de/`
+    global installiert ist. Dieser Skill ist im Plugin bereits vendoriert
+    (`skills/humanizer-de/`) und damit immer verfügbar. Der globale Check
+    gilt für eigenständige Nutzung außerhalb des Plugins.
+    - Gefunden: `✅ humanizer-de Skill (global): vorhanden`
+    - Nicht gefunden: `⚠️ humanizer-de Skill (global): nicht gefunden — für eigenständige Nutzung installieren: https://github.com/marmbiz/humanizer-de`
+    (kein Hard-Fail — der vendorierte Skill im Plugin bleibt funktionsfähig)
+```
+
+- [ ] **Step 3: Marker-Tabelle ergänzen**
+
+Finde die Tabelle:
+```
+| Marker | Bedeutung |
+```
+
+Füge Zeile ein:
+```
+| ✅ humanizer-de Skill (global): vorhanden | Skill global unter `~/.codex/skills/humanizer-de/` installiert |
+| ⚠️ humanizer-de Skill (global): nicht gefunden | Nur vendorierter Plugin-Skill verfügbar (ausreichend für Plugin-Nutzung) |
+```
+
+- [ ] **Step 4: Smoke-Test**
+
+```bash
+grep -q "codex/skills/humanizer-de" /Users/j65674/Repos/academic-research-W2-C/commands/setup.md \
+  && echo "PASS" || echo "FAIL"
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/j65674/Repos/academic-research-W2-C && git add commands/setup.md && git commit -m "feat(v6.0/W2-C): setup — humanizer-de Skill-Existenz-Check"
+```
+
+---
+
+## Task 5: academic_context.stub.md — Bypass-Flag ergänzen
+
+**Files:** Modify `scripts/bootstrap/academic_context.stub.md`
+
+- [ ] **Step 1: Stub-Datei öffnen und geeignete Position finden**
+
+Öffne `scripts/bootstrap/academic_context.stub.md`. Das Feld `Typ:` steht
+im Abschnitt `## Arbeit`.
+
+- [ ] **Step 2: `humanizer_de:`-Feld einfügen**
+
+Ergänze im `## Arbeit`-Abschnitt, **nach** dem `Typ:`-Feld:
+
+```markdown
+- humanizer_de: on   # Anti-KI-Audit-Pass: on (Default bei Hochschularbeiten) | off (überspringen)
+```
+
+- [ ] **Step 3: Smoke-Test**
+
+```bash
+grep -q "humanizer_de:" /Users/j65674/Repos/academic-research-W2-C/scripts/bootstrap/academic_context.stub.md \
+  && echo "PASS" || echo "FAIL"
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/j65674/Repos/academic-research-W2-C && git add scripts/bootstrap/academic_context.stub.md && git commit -m "feat(v6.0/W2-C): academic_context.stub — humanizer_de Bypass-Flag"
+```
+
+---
+
+## Task 6: Eval-Skeleton erstellen
+
+**Files:** Create `evals/humanizer-de-pipeline/README.md`, `drafts/`, `template-comparison.md`
+
+- [ ] **Step 1: README anlegen**
+
+Erstelle `evals/humanizer-de-pipeline/README.md` mit vollständigem Inhalt
+(manueller Run-Ablauf, GPTZero-Score-Vergleich-Beschreibung, Eval-Kriterien).
+
+- [ ] **Step 2: Draft 01 — Theorieabschnitt (Bachelor-Niveau)**
+
+Erstelle `evals/humanizer-de-pipeline/drafts/draft-01-theorie.md` mit
+einem KI-typischen Theorieabschnitt (Bachelorthema, ~200 Wörter, sichtbare
+KI-Tells: Aufzählungs-Einstieg, übermäßiger Nominalstil, fehlende Evidenz).
+
+- [ ] **Step 3: Draft 02 — Methodikabschnitt (Master-Niveau)**
+
+Erstelle `evals/humanizer-de-pipeline/drafts/draft-02-methodik.md` mit
+einem KI-typischen Methodikabschnitt (~200 Wörter, KI-Tells: stereotype
+Formulierungen, Passiv-Übermaß, keine Limitations).
+
+- [ ] **Step 4: Draft 03 — Diskussionsabschnitt (Dissertation-Niveau)**
+
+Erstelle `evals/humanizer-de-pipeline/drafts/draft-03-diskussion.md` mit
+einem KI-typischen Diskussionsabschnitt (~200 Wörter, KI-Tells: Hedging-Übermaß,
+fehlende Literatureinbettung, redundante Einleitung).
+
+- [ ] **Step 5: Vergleichs-Template anlegen**
+
+Erstelle `evals/humanizer-de-pipeline/template-comparison.md` als
+ausfüllbares Template für GPTZero-Score-Vergleich (vor/nach humanizer-de).
+
+- [ ] **Step 6: Smoke-Test**
+
+```bash
+ls /Users/j65674/Repos/academic-research-W2-C/evals/humanizer-de-pipeline/drafts/ | wc -l | xargs -I{} sh -c '[ {} -ge 3 ] && echo "PASS: 3+ Drafts vorhanden" || echo "FAIL: weniger als 3 Drafts"'
+
+ls /Users/j65674/Repos/academic-research-W2-C/evals/humanizer-de-pipeline/README.md 2>/dev/null \
+  && echo "PASS: README vorhanden" || echo "FAIL"
+
+ls /Users/j65674/Repos/academic-research-W2-C/evals/humanizer-de-pipeline/template-comparison.md 2>/dev/null \
+  && echo "PASS: template-comparison vorhanden" || echo "FAIL"
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/j65674/Repos/academic-research-W2-C && git add evals/humanizer-de-pipeline/ && git commit -m "feat(v6.0/W2-C): eval-skeleton humanizer-de-pipeline (3 Drafts + Vergleichs-Template)"
+```
+
+---
+
+## Task 7: Pre-PR-Smoke — alle ACs grün
+
+- [ ] **Step 1: chapter-writer — beide Vault-Referenzen + humanizer-de**
+
+```bash
+echo "=== chapter-writer Smoke ===" && \
+grep -q "vault.search" /Users/j65674/Repos/academic-research-W2-C/skills/chapter-writer/SKILL.md \
+  && echo "PASS: vault.search" || echo "FAIL: vault.search" && \
+grep -q "vault.find_quotes" /Users/j65674/Repos/academic-research-W2-C/skills/chapter-writer/SKILL.md \
+  && echo "PASS: vault.find_quotes" || echo "FAIL: vault.find_quotes" && \
+grep -q "humanizer-de" /Users/j65674/Repos/academic-research-W2-C/skills/chapter-writer/SKILL.md \
+  && echo "PASS: humanizer-de" || echo "FAIL: humanizer-de" && \
+grep -q "mode: formal" /Users/j65674/Repos/academic-research-W2-C/skills/chapter-writer/SKILL.md \
+  && echo "PASS: mode formal" || echo "FAIL: mode formal" && \
+grep -q "Hochschul" /Users/j65674/Repos/academic-research-W2-C/skills/chapter-writer/SKILL.md \
+  && echo "PASS: Trigger-Logik" || echo "FAIL: Trigger-Logik" && \
+grep -q "humanizer_de_pass" /Users/j65674/Repos/academic-research-W2-C/skills/chapter-writer/SKILL.md \
+  && echo "PASS: humanizer_de_pass" || echo "FAIL: humanizer_de_pass"
+```
+
+- [ ] **Step 2: quality-reviewer — Hinweis**
+
+```bash
+echo "=== quality-reviewer Smoke ===" && \
+grep -q "humanizer_de_pass" /Users/j65674/Repos/academic-research-W2-C/agents/quality-reviewer.md \
+  && echo "PASS" || echo "FAIL"
+```
+
+- [ ] **Step 3: setup.md — Skill-Check**
+
+```bash
+echo "=== setup Smoke ===" && \
+grep -q "codex/skills/humanizer-de" /Users/j65674/Repos/academic-research-W2-C/commands/setup.md \
+  && echo "PASS" || echo "FAIL"
+```
+
+- [ ] **Step 4: Bypass-Flag im Stub**
+
+```bash
+echo "=== stub Smoke ===" && \
+grep -q "humanizer_de:" /Users/j65674/Repos/academic-research-W2-C/scripts/bootstrap/academic_context.stub.md \
+  && echo "PASS" || echo "FAIL"
+```
+
+- [ ] **Step 5: Eval-Struktur**
+
+```bash
+echo "=== eval Smoke ===" && \
+ls /Users/j65674/Repos/academic-research-W2-C/evals/humanizer-de-pipeline/drafts/draft-0{1,2,3}-*.md 2>/dev/null \
+  && echo "PASS: 3 Drafts" || echo "FAIL: Drafts fehlen"
+```
+
+- [ ] **Step 6: Spec-Commit**
+
+```bash
+cd /Users/j65674/Repos/academic-research-W2-C && git add specs/v6.0/W2-C.md specs/v6.0/W2-C-plan.md && git commit -m "chore(v6.0/W2-C): spec + plan"
+```
+
+---
+
+## Self-Review Checkliste
+
+- [x] AC1 — chapter-writer ruft humanizer-de vor quality-reviewer auf: Task 2
+- [x] AC2 — Trigger: output_target / Typ-Substring-Match: Task 2 Step 2 (Trigger-Logik)
+- [x] AC3 — Bypass-Flag `humanizer_de: off`: Task 2 Step 2 + Task 5
+- [x] AC4 — setup.md prüft Skill-Existenz: Task 4
+- [x] AC5 — eval-skeleton ≥3 Drafts + GPTZero-Vergleich: Task 6
+- [x] AC6 — Default off ohne Hochschul-Marker: Task 2 (Trigger-Bedingung explizit)
+- [x] AC7 — quality-reviewer erhält Hinweis: Task 3
+- [x] Keine Placeholders/TODOs in Tasks
+- [x] vault.search + vault.find_quotes bleiben in chapter-writer (W2-A-Regression-Check in Task 2 Step 4)

--- a/specs/v6.0/W2-C.md
+++ b/specs/v6.0/W2-C.md
@@ -1,0 +1,192 @@
+# Spec: W2-C — humanizer-de Integration in chapter-writer + quality-reviewer
+
+**Ticket:** #68  
+**Chunk:** W2-C  
+**Wave:** v6.0 Wave 2  
+**Status:** Draft
+
+---
+
+## Ziel
+
+Den vendorierten `humanizer-de`-Skill als Pflicht-Zwischenschritt in die
+`chapter-writer`-Pipeline einbauen — nur für Hochschul-Kontexte, opt-out-fähig.
+
+Pipeline vorher:  
+`draft → quality-reviewer → final`
+
+Pipeline nachher (bei Hochschul-Marker):  
+`draft → humanizer-de(audit, mode: formal) → quality-reviewer → final`
+
+---
+
+## Trigger-Logik
+
+### Quelle: `./academic_context.md`
+
+Das Feld `Typ:` im YAML-Frontmatter oder der Markdown-Sektion enthält
+den Arbeitstyp als Freitext. Der Skill erkennt den Hochschul-Kontext über
+**Substring-Match** (case-insensitive):
+
+| `Typ:`-Wert (Beispiele) | Trigger? |
+|-------------------------|----------|
+| `Bachelorarbeit`        | Ja (enthält „Bachelor") |
+| `Masterarbeit`          | Ja (enthält „Master") |
+| `Diplom`                | Ja (exaktes Match) |
+| `Dissertation`          | Ja (exaktes Match) |
+| `Hausarbeit`            | Nein |
+| `Seminararbeit`         | Nein |
+| `Facharbeit`            | Nein |
+| nicht gesetzt / fehlt   | Nein (Default off) |
+
+Matcher-Logik (Pseudocode):
+```
+HOCHSCHUL_MARKER = ["bachelor", "master", "diplom", "dissertation"]
+typ_lower = academic_context["Typ"].lower()
+humanizer_trigger = any(m in typ_lower for m in HOCHSCHUL_MARKER)
+```
+
+### Bypass-Flag
+
+Wenn `./academic_context.md` folgendes enthält:
+```
+humanizer_de: off
+```
+... wird der humanizer-de-Schritt **vollständig** übersprungen, unabhängig
+vom `Typ:`-Wert. Das Flag ist optional; fehlt es, gilt Default-on für
+Hochschul-Kontexte.
+
+---
+
+## Pipeline-Diagramm
+
+```
+chapter-writer: Schritt 4 (Draften) abgeschlossen
+         │
+         ▼
+[academic_context.md vorhanden?]
+  Nein → Schritt 6 (Zusammensetzung) direkt
+  Ja  → Typ einlesen + humanizer_de-Flag prüfen
+         │
+         ▼
+[Hochschul-Marker? UND humanizer_de != off?]
+  Nein → quality-reviewer direkt
+  Ja  ──→ Skill(humanizer-de):
+           mode: formal
+           input: <Entwurf>
+           voice_samples_dir: (aus academic_context.md, falls gesetzt)
+          │
+          ▼
+      [humanizer-de Output: humanized_text + changes]
+          │
+          ▼
+  quality-reviewer mit humanized_text
+  (context.humanizer_de_pass: true im Input)
+          │
+          ▼
+      PASS/REVISE → final
+```
+
+---
+
+## Skill-Invokation (humanizer-de)
+
+Laut `commands/humanize.md` und `skills/humanizer-de/SKILL.md`:
+
+```
+Skill(humanizer-de):
+  mode: formal          # wissenschaftliche Arbeiten, kein Stimme-Einbringen
+  input: <Kapiteltext>
+  voice_samples_dir: <Pfad oder null>
+```
+
+Rückgabe:
+- `humanized_text`: überarbeiteter Text
+- `changes`: Liste mit `{original, humanized, severity, pattern_id}`
+
+Der `humanized_text` ersetzt den rohen Draft als Input für `quality-reviewer`.
+
+---
+
+## Änderungen an `agents/quality-reviewer.md`
+
+Der quality-reviewer erhält im Input-Objekt das neue Feld:
+
+```json
+{
+  "context": {
+    "component": "chapter-writer",
+    "iteration": 0,
+    "humanizer_de_pass": true
+  }
+}
+```
+
+Der Agent-Prompt erhält einen expliziten Hinweis, dass ein
+humanizer-de(audit)-Pass bereits gelaufen ist, damit kein doppelter
+Anti-KI-Audit ausgeführt wird.
+
+---
+
+## Änderungen an `commands/setup.md`
+
+Setup prüft beim Schritt „Skill-Existenz" zusätzlich:
+
+```bash
+~/.codex/skills/humanizer-de/
+```
+
+- Gefunden: ✅-Meldung
+- Nicht gefunden: ⚠️-Hinweis + Installations-Link (kein Hard-Fail)
+
+Der vendorierte Skill in `skills/humanizer-de/` ist immer verfügbar (Plugin-intern).
+Der Setup-Check zielt auf die globale Codex-Installation für eigenständige Nutzung.
+
+---
+
+## Eval-Skeleton: `evals/humanizer-de-pipeline/`
+
+Struktur:
+```
+evals/humanizer-de-pipeline/
+  README.md              — Beschreibung, manueller Run-Ablauf
+  drafts/
+    draft-01-theorie.md  — KI-typischer Theorieabschnitt (Bachelor)
+    draft-02-methodik.md — KI-typischer Methodikabschnitt (Master)
+    draft-03-diskussion.md — KI-typischer Diskussionsabschnitt (Dissertation)
+  template-comparison.md — GPTZero-Score-Vergleich vor/nach (auszufüllen bei manuellem Run)
+```
+
+Eval ist ein **Skeleton** — tatsächlicher Run erfordert `ANTHROPIC_API_KEY` +
+manuellen GPTZero-Aufruf. Kein automatisierter CI-Run.
+
+---
+
+## Out of Scope
+
+- `style-evaluator` bleibt unverändert (Roadmap §7.2 Punkt 1).
+- Kein Auto-Update des `academic_context.md`-Stubs um `output_target:`-Feld
+  (bestehender `Typ:`-Ansatz reicht per Substring-Match).
+
+---
+
+## Open Questions
+
+- `academic_context.md` existiert nicht als Live-Datei im Repo — sie ist
+  eine Convention (Stub in `scripts/bootstrap/`). Das Feld `humanizer_de: off`
+  wird als neues optionales Feld im Stub-Template ergänzt. Bestätigt durch
+  Ticket-Text: "Bypass-Flag in `./academic_context.md`".
+
+---
+
+## Betroffene Dateien (Boundary)
+
+| Datei | Änderungstyp |
+|-------|--------------|
+| `skills/chapter-writer/SKILL.md` | Edit — humanizer-de(audit)-Schritt einfügen |
+| `agents/quality-reviewer.md` | Edit — Hinweis auf Audit-Pass |
+| `commands/setup.md` | Edit — Skill-Existenz-Check |
+| `scripts/bootstrap/academic_context.stub.md` | Edit — `humanizer_de:` Feld ergänzen |
+| `evals/humanizer-de-pipeline/` | Neu — README + 3 Drafts + Vergleichs-Template |
+| `specs/v6.0/W2-C.md` | Neu (diese Datei) |
+| `specs/v6.0/W2-C-plan.md` | Neu (Plan) |


### PR DESCRIPTION
## Summary

Closes #68.

Verdrahtet den (in #114 vendorierten) `humanizer-de`-Skill als Pflicht-Zwischenschritt in die `chapter-writer`-Pipeline: `draft → humanizer-de(audit) → quality-reviewer → final`. Trigger: `output_target ∈ {Bachelor, Master, Diplom, Dissertation}` aus `academic_context.md`, opt-out via `humanizer_de: off`. Setzt auf den in W2-A umgestellten Vault-Pfad auf (keine Vault-Regressionen).

### Files
- **MOD** `skills/chapter-writer/SKILL.md` — humanizer-de(audit)-Block vor quality-reviewer, Trigger-Substring-Match {Bachelor, Master, Diplom, Dissertation} (case-insensitive), Bypass-Flag-Erkennung `humanizer_de: off`.
- **MOD** `agents/quality-reviewer.md` — `humanizer_de_pass`-Feld im Input-Schema, Strategie-Punkt: kein doppelter Audit-Lauf.
- **MOD** `commands/setup.md` — Skill-Existenz-Check für `~/.codex/skills/humanizer-de/` (kein Hard-Fail bei fehlend).
- **MOD** `scripts/bootstrap/academic_context.stub.md` — `humanizer_de: on` Bypass-Flag-Stub.
- **NEW** `evals/humanizer-de-pipeline/README.md` — manueller Run-Workflow.
- **NEW** `evals/humanizer-de-pipeline/drafts/draft-{01,02,03}-{theorie,methodik,diskussion}.md` — 3 akademische Drafts für GPTZero-Vergleich.
- **NEW** `evals/humanizer-de-pipeline/template-comparison.md` — Vergleichs-Template (vor/nach).
- **NEW** `specs/v6.0/W2-C.md` + `specs/v6.0/W2-C-plan.md`.

### Acceptance-Criteria-Mapping
- [x] AC1 Pipeline-Position humanizer-de(audit) **vor** quality-reviewer (`chapter-writer/SKILL.md` §Humanizer-Audit-Pass vor §Qualitaets-Review).
- [x] AC2 Trigger output_target ∈ {Bachelor, Master, Diplom, Dissertation} (substring-match, case-insensitive).
- [x] AC3 Bypass-Flag `humanizer_de: off` in `academic_context.md` (chapter-writer prüft + stub-Doku in academic_context.stub.md).
- [x] AC4 Setup-Check `~/.codex/skills/humanizer-de/` — Hinweis, kein Hard-Fail.
- [x] AC5 `evals/humanizer-de-pipeline/` mit 3 Drafts + Vergleichs-Template.
- [x] AC6 Default off ohne Hochschul-Marker (explizit dokumentiert).
- [x] AC7 quality-reviewer.md mit `humanizer_de_pass`-Hinweis (kein doppelter Audit-Lauf).

### W2-A Regression-Check (pre-PR review)
- `vault.search` refs in chapter-writer: 4
- `vault.find_quotes` refs: 3
- `vault.ensure_file` refs: 2
- **Verdict: INTACT** — humanizer-de-Block sitzt zwischen Citations-API-Sektion und quality-reviewer; keine Vault-Aufrufe entfernt oder verändert.

### Out of Scope (per L0-Decomposition)
- `style-evaluator` (Roadmap §7.2 Punkt 1) bleibt unverändert — separater Folge-Task.

### Pre-PR review
Lokales Review: **PASS** — 0 Blocker. Lower findings sind kosmetisch (draft-02 hat 187 statt 200 Wörter; `mode: formal` vs Doku-Begriff `audit`; Windows-Pfad-Hardcoding in Setup-Check).

### Test plan
- [ ] Reviewer prüft Pipeline-Position (humanizer vor quality-reviewer).
- [ ] Reviewer verifiziert Bypass-Flag-Erkennung + Default-off-Verhalten ohne `output_target`.
- [ ] Reviewer bestätigt: Vault-Pfad aus #63 nicht beeinträchtigt (vault.* refs ≥5 in chapter-writer).
- [ ] Manueller Eval-Run via `evals/humanizer-de-pipeline/` (Skeleton; benötigt `ANTHROPIC_API_KEY` + GPTZero-Zugang).

🤖 Generated with [Claude Code](https://claude.com/claude-code)