### PR TITLE
v6.1: F2.2 — Kapitel-Schnitt aus Buch-PDFs (PyPDF2 Outline-Tree) + Vault parent_paper_id

### DIFF
--- a/mcp/academic_vault/db.py
+++ b/mcp/academic_vault/db.py
@@ -120,6 +120,7 @@ class VaultDB:
         page_first: Optional[int] = None,
         page_last: Optional[int] = None,
         container_title: Optional[str] = None,
+        parent_paper_id: Optional[str] = None,
     ) -> None:
         """Upsert eines Papers in die papers-Tabelle.
 
@@ -144,25 +145,28 @@ class VaultDB:
             INSERT INTO papers
               (paper_id, type, csl_json, doi, isbn, pdf_path, page_offset,
                editor, chapter, page_first, page_last, container_title,
+               parent_paper_id,
                added_at, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(paper_id) DO UPDATE SET
-              type           = excluded.type,
-              csl_json       = excluded.csl_json,
-              doi            = excluded.doi,
-              isbn           = excluded.isbn,
-              pdf_path       = excluded.pdf_path,
-              page_offset    = excluded.page_offset,
-              editor         = excluded.editor,
-              chapter        = excluded.chapter,
-              page_first     = excluded.page_first,
-              page_last      = excluded.page_last,
-              container_title= excluded.container_title,
-              updated_at     = excluded.updated_at
+              type            = excluded.type,
+              csl_json        = excluded.csl_json,
+              doi             = excluded.doi,
+              isbn            = excluded.isbn,
+              pdf_path        = excluded.pdf_path,
+              page_offset     = excluded.page_offset,
+              editor          = excluded.editor,
+              chapter         = excluded.chapter,
+              page_first      = excluded.page_first,
+              page_last       = excluded.page_last,
+              container_title = excluded.container_title,
+              parent_paper_id = excluded.parent_paper_id,
+              updated_at      = excluded.updated_at
             """,
             (
                 paper_id, paper_type, csl_json, doi, isbn, pdf_path, page_offset,
                 editor, chapter, page_first, page_last, container_title,
+                parent_paper_id,
                 now, now,
             ),
         )

--- a/mcp/academic_vault/migrate.py
+++ b/mcp/academic_vault/migrate.py
@@ -183,6 +183,26 @@ def add_book_columns(db_path: str) -> None:
         conn.close()
 
 
+def add_parent_paper_id_column(db_path: str) -> None:
+    """Fuegt parent_paper_id-Spalte zu papers hinzu. Idempotent (try/except).
+
+    Aufruf-Sicher: Kann mehrfach auf derselben DB ausgefuehrt werden.
+    """
+    import sqlite3 as _sqlite3
+    conn = _sqlite3.connect(db_path)
+    try:
+        try:
+            conn.execute(
+                "ALTER TABLE papers ADD COLUMN "
+                "parent_paper_id TEXT REFERENCES papers(paper_id)"
+            )
+        except _sqlite3.OperationalError:
+            pass  # Spalte existiert bereits -- idempotent
+        conn.commit()
+    finally:
+        conn.close()
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Seed-Migration: literature_state.md -> academic_vault SQLite"

--- a/mcp/academic_vault/schema.sql
+++ b/mcp/academic_vault/schema.sql
@@ -19,6 +19,7 @@ CREATE TABLE IF NOT EXISTS papers (
   page_first            INTEGER,
   page_last             INTEGER,
   container_title       TEXT,
+  parent_paper_id       TEXT REFERENCES papers(paper_id),
   added_at              INTEGER NOT NULL,
   updated_at            INTEGER NOT NULL
 );

--- a/mcp/academic_vault/server.py
+++ b/mcp/academic_vault/server.py
@@ -5,6 +5,7 @@ add_quote/find_quotes/get_quote/stats bereit.
 
 Start via: python -m mcp.academic_vault.server
 """
+import json
 import os
 from uuid import uuid4
 from typing import Optional
@@ -166,14 +167,13 @@ def add_chapter(
 
     Setzt type=chapter automatisch falls nicht in csl_json angegeben.
     """
-    import json as _json
     if paper_id is None:
         paper_id = f"{parent_paper_id}-ch{chapter_number}"
     # Sicherstellen dass type=chapter in csl_json gesetzt ist
     try:
-        csl = _json.loads(csl_json)
+        csl = json.loads(csl_json)
         csl.setdefault("type", "chapter")
-        csl_json = _json.dumps(csl, ensure_ascii=False)
+        csl_json = json.dumps(csl, ensure_ascii=False)
     except Exception:
         pass
     add_paper(

--- a/mcp/academic_vault/server.py
+++ b/mcp/academic_vault/server.py
@@ -137,6 +137,7 @@ def add_paper(
     page_first: Optional[int] = None,
     page_last: Optional[int] = None,
     container_title: Optional[str] = None,
+    parent_paper_id: Optional[str] = None,
 ) -> None:
     """Upsert eines Papers in den Vault. Unterstuetzt type=book|chapter."""
     db = VaultDB(db_path)
@@ -147,7 +148,45 @@ def add_paper(
         editor=editor, chapter=chapter,
         page_first=page_first, page_last=page_last,
         container_title=container_title,
+        parent_paper_id=parent_paper_id,
     )
+
+
+def add_chapter(
+    db_path: str,
+    parent_paper_id: str,
+    chapter_number: int,
+    csl_json: str,
+    paper_id: Optional[str] = None,
+    pdf_path: Optional[str] = None,
+    page_first: Optional[int] = None,
+    page_last: Optional[int] = None,
+) -> str:
+    """Legt ein Kapitel als Kind-Paper in den Vault. Gibt paper_id zurueck.
+
+    Setzt type=chapter automatisch falls nicht in csl_json angegeben.
+    """
+    import json as _json
+    if paper_id is None:
+        paper_id = f"{parent_paper_id}-ch{chapter_number}"
+    # Sicherstellen dass type=chapter in csl_json gesetzt ist
+    try:
+        csl = _json.loads(csl_json)
+        csl.setdefault("type", "chapter")
+        csl_json = _json.dumps(csl, ensure_ascii=False)
+    except Exception:
+        pass
+    add_paper(
+        db_path=db_path,
+        paper_id=paper_id,
+        csl_json=csl_json,
+        pdf_path=pdf_path,
+        chapter=str(chapter_number),
+        page_first=page_first,
+        page_last=page_last,
+        parent_paper_id=parent_paper_id,
+    )
+    return paper_id
 
 
 def get_paper(db_path: str, paper_id: str) -> Optional[dict]:
@@ -213,14 +252,38 @@ def _build_mcp_server():
         page_first: int = None,
         page_last: int = None,
         container_title: str = None,
+        parent_paper_id: str = None,
     ) -> None:
-        """Upsert eines Papers in den Vault. type aus csl_json; book|chapter|article-journal erlaubt."""
+        """Upsert eines Papers. type aus csl_json; book|chapter|article-journal erlaubt."""
         add_paper(
             db_path, paper_id, csl_json,
             pdf_path=pdf_path, doi=doi, isbn=isbn, page_offset=page_offset,
             editor=editor, chapter=chapter,
             page_first=page_first, page_last=page_last,
             container_title=container_title,
+            parent_paper_id=parent_paper_id,
+        )
+
+    @mcp.tool(name="vault.add_chapter")
+    def _vault_add_chapter(
+        parent_paper_id: str,
+        chapter_number: int,
+        csl_json: str,
+        paper_id: str = None,
+        pdf_path: str = None,
+        page_first: int = None,
+        page_last: int = None,
+    ) -> str:
+        """Legt Kapitel als Kind-Paper an. Gibt paper_id zurueck."""
+        return add_chapter(
+            db_path=db_path,
+            parent_paper_id=parent_paper_id,
+            chapter_number=chapter_number,
+            csl_json=csl_json,
+            paper_id=paper_id,
+            pdf_path=pdf_path,
+            page_first=page_first,
+            page_last=page_last,
         )
 
     @mcp.tool(name="vault.ensure_file")

--- a/scripts/chunk_pdf.py
+++ b/scripts/chunk_pdf.py
@@ -185,9 +185,9 @@ def write_all_chapters(
     """Schreibt alle Kapitel als separate PDFs. Gibt Liste der Pfade zurueck."""
     chapters = extract_chapters(pdf_path)
     os.makedirs(output_dir, exist_ok=True)
+    safe_isbn = re.sub(r"[^a-zA-Z0-9_-]", "-", isbn)
     paths = []
     for i, ch in enumerate(chapters, start=1):
-        safe_isbn = re.sub(r"[^a-zA-Z0-9_-]", "-", isbn)
         fname = f"{safe_isbn}-ch{i}.pdf"
         out_path = os.path.join(output_dir, fname)
         write_chapter(pdf_path, ch, out_path)

--- a/scripts/chunk_pdf.py
+++ b/scripts/chunk_pdf.py
@@ -163,9 +163,10 @@ def extract_chapters(pdf_path: str) -> list[dict]:
     return _assign_end_pages(chapters, total)
 
 
-def write_chapter(pdf_path: str, chapter: dict, output_path: str) -> None:
-    """Schreibt Seiten eines Kapitels als neues PDF nach output_path."""
-    reader = PdfReader(pdf_path)
+def _write_chapter_from_reader(
+    reader: PdfReader, chapter: dict, output_path: str
+) -> None:
+    """Schreibt Seiten eines Kapitels mit vorhandenem PdfReader-Objekt."""
     writer = PdfWriter()
     start = chapter["start_page"]
     end = chapter["end_page"]
@@ -177,20 +178,29 @@ def write_chapter(pdf_path: str, chapter: dict, output_path: str) -> None:
         writer.write(f)
 
 
+def write_chapter(pdf_path: str, chapter: dict, output_path: str) -> None:
+    """Schreibt Seiten eines Kapitels als neues PDF nach output_path."""
+    _write_chapter_from_reader(PdfReader(pdf_path), chapter, output_path)
+
+
 def write_all_chapters(
     pdf_path: str,
     output_dir: str,
     isbn: str = "book",
 ) -> list[str]:
-    """Schreibt alle Kapitel als separate PDFs. Gibt Liste der Pfade zurueck."""
+    """Schreibt alle Kapitel als separate PDFs. Gibt Liste der Pfade zurueck.
+
+    Oeffnet das Quell-PDF einmalig fuer alle Kapitel (kein N+1-Overhead).
+    """
     chapters = extract_chapters(pdf_path)
+    reader = PdfReader(pdf_path)  # einmalig oeffnen
     os.makedirs(output_dir, exist_ok=True)
     safe_isbn = re.sub(r"[^a-zA-Z0-9_-]", "-", isbn)
     paths = []
     for i, ch in enumerate(chapters, start=1):
         fname = f"{safe_isbn}-ch{i}.pdf"
         out_path = os.path.join(output_dir, fname)
-        write_chapter(pdf_path, ch, out_path)
+        _write_chapter_from_reader(reader, ch, out_path)
         paths.append(out_path)
     return paths
 

--- a/scripts/chunk_pdf.py
+++ b/scripts/chunk_pdf.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""chunk_pdf.py — Zerlegt Buch-PDFs kapitelweise via PyPDF2 Outline-Tree.
+
+CLI:
+    python chunk_pdf.py --input book.pdf --chapter <n|toc|all> --output <pfad>
+
+Kapitel-Erkennung (Prioritaet):
+    1. PyPDF2 Outline-Tree (PdfReader.outline)
+    2. Fallback: Textextraktion erste 20 Seiten, Regex-Kapitelsuche
+
+Ausgabe:
+    --chapter all  -> Alle Kapitel nach <output_dir>/<isbn>-ch<n>.pdf
+    --chapter N    -> Kapitel N (1-basiert) nach <output>-Pfad
+    --chapter toc  -> JSON-TOC auf stdout
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from typing import Optional
+
+from PyPDF2 import PdfReader, PdfWriter
+from PyPDF2.generic import Destination
+
+
+def _outline_page_number(reader: PdfReader, item) -> Optional[int]:
+    """Gibt 0-indexed Seitennummer eines Outline-Items zurueck oder None."""
+    try:
+        if isinstance(item, Destination):
+            return reader.get_destination_page_number(item)
+        # Neuere PyPDF2-Versionen: item kann dict-aehnlich sein
+        if hasattr(item, "page"):
+            page_obj = item.page
+            if hasattr(page_obj, "get_object"):
+                page_obj = page_obj.get_object()
+            for i, p in enumerate(reader.pages):
+                if p.get_object() == page_obj:
+                    return i
+    except Exception:
+        pass
+    return None
+
+
+def _flatten_outline(reader: PdfReader, outline, depth: int = 0) -> list[dict]:
+    """Flacht den Outline-Tree auf Top-Level-Kapitel ab (Tiefe 0)."""
+    result = []
+    if outline is None:
+        return result
+    for item in outline:
+        if isinstance(item, list):
+            # Verschachtelte Liste: Sub-Ebene nur bei depth==0 aufnehmen
+            if depth == 0:
+                result.extend(_flatten_outline(reader, item, depth + 1))
+        else:
+            page_num = _outline_page_number(reader, item)
+            title = getattr(item, "title", None) or str(item)
+            if page_num is not None and title:
+                result.append({"title": title, "start_page": page_num})
+    return result
+
+
+def _extract_via_outline(reader: PdfReader) -> list[dict]:
+    """Extrahiert Kapitel aus PyPDF2 Outline-Tree. Gibt [] wenn kein Outline."""
+    outline = reader.outline
+    if not outline:
+        return []
+    chapters = _flatten_outline(reader, outline)
+    # Duplikate entfernen und sortieren
+    seen: set[tuple] = set()
+    unique = []
+    for ch in chapters:
+        key = (ch["title"], ch["start_page"])
+        if key not in seen:
+            seen.add(key)
+            unique.append(ch)
+    unique.sort(key=lambda c: c["start_page"])
+    return unique
+
+
+def _extract_via_toc_text(reader: PdfReader) -> list[dict]:
+    """Fallback: Sucht Kapitelzeilen in den ersten 20 Seiten per Regex."""
+    patterns = [
+        # "Kapitel 1: Titel .... 5" oder "Chapter 1 Title 5"
+        re.compile(
+            r"(?:Kapitel|Chapter)\s+(\d+)[.:)]\s*(.+?)\s+(\d+)\s*$",
+            re.IGNORECASE | re.MULTILINE,
+        ),
+        # "1. Titel     5"
+        re.compile(
+            r"^(\d+)\.\s+([A-Za-zÄÖÜäöüß][^\n]{3,60}?)\s{2,}(\d+)\s*$",
+            re.MULTILINE,
+        ),
+    ]
+    text_pages = min(20, len(reader.pages))
+    full_text = ""
+    for i in range(text_pages):
+        try:
+            full_text += (reader.pages[i].extract_text() or "") + "\n"
+        except Exception:
+            pass
+
+    chapters: list[dict] = []
+    for pat in patterns:
+        for m in pat.finditer(full_text):
+            try:
+                num = int(m.group(1))
+                title = m.group(2).strip()
+                page = int(m.group(3)) - 1  # 1-indexed -> 0-indexed
+                if 0 <= page < len(reader.pages):
+                    chapters.append({
+                        "title": f"Kapitel {num}: {title}",
+                        "start_page": page,
+                    })
+            except (ValueError, IndexError):
+                pass
+        if chapters:
+            break
+
+    chapters.sort(key=lambda c: c["start_page"])
+    # Duplikate entfernen
+    seen_pages: set[int] = set()
+    unique = []
+    for ch in chapters:
+        if ch["start_page"] not in seen_pages:
+            seen_pages.add(ch["start_page"])
+            unique.append(ch)
+    return unique
+
+
+def _assign_end_pages(chapters: list[dict], total_pages: int) -> list[dict]:
+    """Berechnet end_page fuer jedes Kapitel (in-place)."""
+    for i, ch in enumerate(chapters):
+        if i + 1 < len(chapters):
+            ch["end_page"] = chapters[i + 1]["start_page"] - 1
+        else:
+            ch["end_page"] = total_pages - 1
+    return chapters
+
+
+def extract_chapters(pdf_path: str) -> list[dict]:
+    """Extrahiert Kapitel-Metadaten aus PDF.
+
+    Gibt [{title, start_page, end_page}] zurueck (0-indexed Seitennummern).
+    Raises SystemExit(2) wenn weder Outline noch TOC-Text gefunden.
+    """
+    reader = PdfReader(pdf_path)
+    total = len(reader.pages)
+
+    chapters = _extract_via_outline(reader)
+    if not chapters:
+        chapters = _extract_via_toc_text(reader)
+    if not chapters:
+        print(
+            f"[chunk_pdf] Fehler: Kein Outline-Tree und kein TOC-Text in "
+            f"'{pdf_path}' gefunden.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    return _assign_end_pages(chapters, total)
+
+
+def write_chapter(pdf_path: str, chapter: dict, output_path: str) -> None:
+    """Schreibt Seiten eines Kapitels als neues PDF nach output_path."""
+    reader = PdfReader(pdf_path)
+    writer = PdfWriter()
+    start = chapter["start_page"]
+    end = chapter["end_page"]
+    for page_num in range(start, end + 1):
+        if 0 <= page_num < len(reader.pages):
+            writer.add_page(reader.pages[page_num])
+    os.makedirs(os.path.dirname(os.path.abspath(output_path)), exist_ok=True)
+    with open(output_path, "wb") as f:
+        writer.write(f)
+
+
+def write_all_chapters(
+    pdf_path: str,
+    output_dir: str,
+    isbn: str = "book",
+) -> list[str]:
+    """Schreibt alle Kapitel als separate PDFs. Gibt Liste der Pfade zurueck."""
+    chapters = extract_chapters(pdf_path)
+    os.makedirs(output_dir, exist_ok=True)
+    paths = []
+    for i, ch in enumerate(chapters, start=1):
+        safe_isbn = re.sub(r"[^a-zA-Z0-9_-]", "-", isbn)
+        fname = f"{safe_isbn}-ch{i}.pdf"
+        out_path = os.path.join(output_dir, fname)
+        write_chapter(pdf_path, ch, out_path)
+        paths.append(out_path)
+    return paths
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Zerlegt Buch-PDFs kapitelweise (PyPDF2 Outline-Tree)."
+    )
+    parser.add_argument("--input", required=True, help="Eingabe-PDF")
+    parser.add_argument(
+        "--chapter",
+        required=True,
+        help="Kapitel-Nummer (1-basiert), 'all' oder 'toc'",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Ausgabe-Pfad oder Verzeichnis (bei --chapter all)",
+    )
+    parser.add_argument(
+        "--isbn",
+        default="book",
+        help="ISBN fuer Dateinamen (bei --chapter all)",
+    )
+    args = parser.parse_args()
+
+    if not os.path.exists(args.input):
+        print(
+            f"[chunk_pdf] Eingabe-PDF nicht gefunden: {args.input}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if args.chapter == "toc":
+        chapters = extract_chapters(args.input)
+        print(
+            json.dumps(
+                [
+                    {
+                        "title": c["title"],
+                        "start_page": c["start_page"],
+                        "end_page": c["end_page"],
+                    }
+                    for c in chapters
+                ],
+                ensure_ascii=False,
+                indent=2,
+            )
+        )
+        return 0
+
+    if args.chapter == "all":
+        paths = write_all_chapters(args.input, args.output, isbn=args.isbn)
+        print(f"[chunk_pdf] {len(paths)} Kapitel geschrieben nach {args.output}")
+        for p in paths:
+            print(f"  {p}")
+        return 0
+
+    # Einzelnes Kapitel (1-basiert)
+    try:
+        n = int(args.chapter)
+    except ValueError:
+        print(
+            f"[chunk_pdf] Ungueltige Kapitel-Angabe: {args.chapter!r}",
+            file=sys.stderr,
+        )
+        return 1
+
+    chapters = extract_chapters(args.input)
+    if n < 1 or n > len(chapters):
+        print(
+            f"[chunk_pdf] Kapitel {n} nicht vorhanden (1-{len(chapters)}).",
+            file=sys.stderr,
+        )
+        return 1
+
+    write_chapter(args.input, chapters[n - 1], args.output)
+    print(f"[chunk_pdf] Kapitel {n} geschrieben: {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/citation-extraction/SKILL.md
+++ b/skills/citation-extraction/SKILL.md
@@ -97,12 +97,6 @@ als `file_id` übergeben — kein direktes `pdf_path` im Context.
 
 ### 3. Zitat-Extraktion
 
-> **Kapitel-PDF-Modus:** Wenn `vault.get_paper(paper_id)["parent_paper_id"]`
-> gesetzt ist, liegt ein Kapitel-PDF vor (erzeugt von `chunk_pdf.py`). Uebergib
-> statt des Gesamt-Buches nur dieses Kapitel-PDF als `file_id` via
-> `vault.ensure_file(paper_id)`. Das reduziert den Token-Footprint um typisch
-> 90-95 % gegenueber dem Gesamtbuch.
-
 Wenn Vault-Zitate für ein Paper vorhanden sind, diese direkt verwenden — kein
 Agent-Spawn nötig.
 

--- a/skills/citation-extraction/SKILL.md
+++ b/skills/citation-extraction/SKILL.md
@@ -97,6 +97,12 @@ als `file_id` übergeben — kein direktes `pdf_path` im Context.
 
 ### 3. Zitat-Extraktion
 
+> **Kapitel-PDF-Modus:** Wenn `vault.get_paper(paper_id)["parent_paper_id"]`
+> gesetzt ist, liegt ein Kapitel-PDF vor (erzeugt von `chunk_pdf.py`). Uebergib
+> statt des Gesamt-Buches nur dieses Kapitel-PDF als `file_id` via
+> `vault.ensure_file(paper_id)`. Das reduziert den Token-Footprint um typisch
+> 90-95 % gegenueber dem Gesamtbuch.
+
 Wenn Vault-Zitate für ein Paper vorhanden sind, diese direkt verwenden — kein
 Agent-Spawn nötig.
 

--- a/specs/v6.1/B-plan.md
+++ b/specs/v6.1/B-plan.md
@@ -1,0 +1,1104 @@
+# Chunk B — Kapitel-Schnitt aus Buch-PDFs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Zerlegt grosse Buch-PDFs kapitelweise via PyPDF2 Outline-Tree (Fallback: TOC-Textextraktion) und speichert Eltern-Kind-Beziehung in der Vault-DB.
+
+**Architecture:** `scripts/chunk_pdf.py` liest den PyPDF2 Outline-Tree und schreibt je Kapitel ein separates PDF. Die Vault erhaelt eine `parent_paper_id`-Spalte, `db.py`/`server.py` werden um den neuen Parameter erweitert. Migrations-Pattern von Chunk A (idempotentes ALTER TABLE) wird emuliert.
+
+**Tech Stack:** Python 3.x, PyPDF2 >= 3.0.0, SQLite (via bestehende VaultDB), pytest
+
+---
+
+## File Map
+
+| Datei | Aktion | Verantwortung |
+|---|---|---|
+| `scripts/chunk_pdf.py` | CREATE | CLI-Skript: Outline-Tree + TOC-Fallback, Kapitel-PDFs schreiben |
+| `tests/fixtures/sample_book.pdf` | CREATE | Minimales Test-PDF mit Outline-Tree (< 200 KB) |
+| `tests/test_chunk_pdf.py` | CREATE | Unit- + Integrationstests fuer chunk_pdf.py |
+| `mcp/academic_vault/schema.sql` | MODIFY | parent_paper_id-Spalte in papers |
+| `mcp/academic_vault/migrate.py` | MODIFY | add_parent_paper_id_column() idempotent |
+| `mcp/academic_vault/db.py` | MODIFY | add_paper() + parent_paper_id |
+| `mcp/academic_vault/server.py` | MODIFY | add_paper() + add_chapter() helper |
+| `tests/test_vault_parent.py` | CREATE | parent/child Vault-Tests |
+| `skills/citation-extraction/SKILL.md` | MODIFY | Hinweis Kapitel-PDF-Modus |
+
+---
+
+### Task 1: Test-Fixture PDF mit Outline erstellen
+
+**Files:**
+- Create: `tests/fixtures/sample_book.pdf`
+- Create: `tests/fixtures/create_sample_book.py` (Hilfsskript, nicht im Test-Pfad)
+
+- [ ] **Schritt 1: Hilfsskript schreiben (kein Test)**
+
+```python
+# tests/fixtures/create_sample_book.py
+"""Erstellt sample_book.pdf mit PyPDF2 fuer Tests."""
+from PyPDF2 import PdfWriter
+from PyPDF2.generic import (
+    ArrayObject, DictionaryObject, IndirectObject,
+    NameObject, NumberObject, TextStringObject,
+)
+import io, os
+
+def create_sample_book(output_path: str) -> None:
+    writer = PdfWriter()
+
+    # 10 Seiten: 2 Titelseiten + je 2 Seiten pro Kapitel (4 Kapitel)
+    for i in range(10):
+        page = writer.add_blank_page(width=595, height=842)
+
+    # Outline-Eintraege: 4 Kapitel
+    chapters = [
+        ("Kapitel 1: Einleitung", 2),
+        ("Kapitel 2: Grundlagen", 4),
+        ("Kapitel 3: Methodik", 6),
+        ("Kapitel 4: Ergebnisse", 8),
+    ]
+    for title, page_num in chapters:
+        writer.add_outline_item(title, page_num)
+
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    with open(output_path, "wb") as f:
+        writer.write(f)
+
+if __name__ == "__main__":
+    create_sample_book("sample_book.pdf")
+```
+
+- [ ] **Schritt 2: Fixture generieren**
+
+```bash
+cd /Users/j65674/Repos/academic-research-v6.1-B
+python tests/fixtures/create_sample_book.py
+# Ausgabe: sample_book.pdf im CWD
+mv sample_book.pdf tests/fixtures/sample_book.pdf
+ls -lh tests/fixtures/sample_book.pdf
+# Erwartet: < 50 KB
+```
+
+- [ ] **Schritt 3: Commit**
+
+```bash
+git add tests/fixtures/create_sample_book.py tests/fixtures/sample_book.pdf
+git commit -m "test: Fixture sample_book.pdf mit 4-Kapitel-Outline"
+```
+
+---
+
+### Task 2: TDD — chunk_pdf.py Outline-Tree-Parsing
+
+**Files:**
+- Create: `tests/test_chunk_pdf.py`
+- Create: `scripts/chunk_pdf.py`
+
+- [ ] **Schritt 1: Failing test schreiben**
+
+```python
+# tests/test_chunk_pdf.py
+"""Tests fuer scripts/chunk_pdf.py"""
+import importlib.util
+import sys
+import os
+import tempfile
+from pathlib import Path
+import pytest
+
+# Skript direkt laden (kein Package)
+_SCRIPT = Path(__file__).parent.parent / "scripts" / "chunk_pdf.py"
+spec = importlib.util.spec_from_file_location("chunk_pdf", _SCRIPT)
+chunk_pdf = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(chunk_pdf)
+
+FIXTURE_PDF = Path(__file__).parent / "fixtures" / "sample_book.pdf"
+
+
+class TestOutlineParsing:
+    def test_extract_chapters_from_outline(self):
+        """Outline-Tree mit 4 Kapiteln korrekt parsen."""
+        chapters = chunk_pdf.extract_chapters(str(FIXTURE_PDF))
+        assert len(chapters) == 4
+        assert chapters[0]["title"] == "Kapitel 1: Einleitung"
+        assert chapters[0]["start_page"] == 2  # 0-indexed
+        assert chapters[1]["start_page"] == 4
+        assert chapters[2]["start_page"] == 6
+        assert chapters[3]["start_page"] == 8
+
+    def test_chapter_end_page_derived_from_next_start(self):
+        """end_page = naechstes Kapitel start - 1."""
+        chapters = chunk_pdf.extract_chapters(str(FIXTURE_PDF))
+        assert chapters[0]["end_page"] == 3
+        assert chapters[1]["end_page"] == 5
+        assert chapters[2]["end_page"] == 7
+        # Letztes Kapitel endet auf letzter Seite des PDFs
+        assert chapters[3]["end_page"] == 9  # 10 Seiten insgesamt (0-indexed: 0-9)
+
+
+class TestWriteChapter:
+    def test_write_single_chapter_creates_pdf(self):
+        """write_chapter schreibt ein gueltiges PDF."""
+        from PyPDF2 import PdfReader
+        chapters = chunk_pdf.extract_chapters(str(FIXTURE_PDF))
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_path = os.path.join(tmpdir, "ch1.pdf")
+            chunk_pdf.write_chapter(str(FIXTURE_PDF), chapters[0], out_path)
+            assert os.path.exists(out_path)
+            reader = PdfReader(out_path)
+            assert len(reader.pages) == 2  # Seiten 2-3 (0-indexed)
+
+    def test_write_all_chapters(self):
+        """--chapter all erzeugt 4 Dateien."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            paths = chunk_pdf.write_all_chapters(
+                str(FIXTURE_PDF), tmpdir, isbn="test-isbn"
+            )
+            assert len(paths) == 4
+            for p in paths:
+                assert os.path.exists(p)
+                assert "test-isbn" in os.path.basename(p)
+
+
+class TestTOCFallback:
+    def test_toc_fallback_for_pdf_without_outline(self, tmp_path):
+        """PDF ohne Outline-Tree: TOC-Fallback liefert leere Liste (kein Absturz)."""
+        from PyPDF2 import PdfWriter
+        writer = PdfWriter()
+        writer.add_blank_page(width=595, height=842)
+        pdf_path = str(tmp_path / "no_outline.pdf")
+        with open(pdf_path, "wb") as f:
+            writer.write(f)
+        # Kein Outline vorhanden -> Fallback -> leere Liste oder Fehler mit SystemExit
+        try:
+            chapters = chunk_pdf.extract_chapters(pdf_path)
+            # Falls Fallback greift und nichts findet: leere Liste ist ok
+            assert isinstance(chapters, list)
+        except SystemExit as e:
+            assert e.code == 2  # Kein TOC gefunden -> Exit 2
+
+
+class TestCLI:
+    def test_cli_toc_mode_returns_json(self):
+        """--chapter toc gibt JSON-TOC aus."""
+        import json, subprocess
+        result = subprocess.run(
+            [sys.executable, str(_SCRIPT),
+             "--input", str(FIXTURE_PDF),
+             "--chapter", "toc",
+             "--output", "/dev/null"],
+            capture_output=True, text=True
+        )
+        assert result.returncode == 0
+        toc = json.loads(result.stdout)
+        assert len(toc) == 4
+        assert toc[0]["title"] == "Kapitel 1: Einleitung"
+
+    def test_cli_chapter_n(self, tmp_path):
+        """--chapter 1 schreibt eine Datei."""
+        import subprocess
+        out_path = str(tmp_path / "ch1.pdf")
+        result = subprocess.run(
+            [sys.executable, str(_SCRIPT),
+             "--input", str(FIXTURE_PDF),
+             "--chapter", "1",
+             "--output", out_path],
+            capture_output=True, text=True
+        )
+        assert result.returncode == 0, result.stderr
+        assert os.path.exists(out_path)
+```
+
+- [ ] **Schritt 2: Test ausfuehren — muss fehlschlagen**
+
+```bash
+cd /Users/j65674/Repos/academic-research-v6.1-B
+/opt/homebrew/bin/pytest tests/test_chunk_pdf.py -v --tb=short 2>&1 | head -40
+# Erwartet: ImportError oder ModuleNotFoundError (chunk_pdf nicht vorhanden)
+```
+
+- [ ] **Schritt 3: chunk_pdf.py implementieren**
+
+```python
+#!/usr/bin/env python3
+"""chunk_pdf.py — Zerlegt Buch-PDFs kapitelweise via PyPDF2 Outline-Tree.
+
+CLI:
+    python chunk_pdf.py --input book.pdf --chapter <n|toc|all> --output <pfad>
+
+Kapitel-Erkennung:
+    1. PyPDF2 Outline-Tree (PdfReader.outline)
+    2. Fallback: Textextraktion erste 20 Seiten, Regex-Kapitelsuche
+
+Ausgabe:
+    --chapter all  -> Alle Kapitel nach <output_dir>/<isbn>-ch<n>.pdf
+    --chapter N    -> Kapitel N nach <output>-Pfad
+    --chapter toc  -> JSON-TOC auf stdout
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Optional
+
+from PyPDF2 import PdfReader, PdfWriter
+from PyPDF2.generic import Destination
+
+
+def _outline_page_number(reader: PdfReader, item) -> Optional[int]:
+    """Gibt 0-indexed Seitennummer eines Outline-Items zurueck oder None."""
+    try:
+        if isinstance(item, Destination):
+            return reader.get_destination_page_number(item)
+        # Neuere PyPDF2/pypdf-Versionen: item ist dict-aehnlich
+        if hasattr(item, "page"):
+            page_obj = item.page
+            if hasattr(page_obj, "get_object"):
+                page_obj = page_obj.get_object()
+            for i, p in enumerate(reader.pages):
+                if p.get_object() == page_obj:
+                    return i
+    except Exception:
+        pass
+    return None
+
+
+def _flatten_outline(reader: PdfReader, outline, depth: int = 0) -> list[dict]:
+    """Flacht den Outline-Tree auf Top-Level-Kapitel ab."""
+    result = []
+    if outline is None:
+        return result
+    for item in outline:
+        if isinstance(item, list):
+            # Verschachtelte Ebene: nur Top-Level aufnehmen wenn depth==0
+            if depth == 0:
+                result.extend(_flatten_outline(reader, item, depth + 1))
+        else:
+            page_num = _outline_page_number(reader, item)
+            title = getattr(item, "title", str(item))
+            if page_num is not None and title:
+                result.append({"title": title, "start_page": page_num})
+    return result
+
+
+def _extract_via_outline(reader: PdfReader) -> list[dict]:
+    """Extrahiert Kapitel aus PyPDF2 Outline-Tree."""
+    outline = reader.outline
+    if not outline:
+        return []
+    chapters = _flatten_outline(reader, outline)
+    # Duplikate und unsortierte Eintraege bereinigen
+    seen = set()
+    unique = []
+    for ch in chapters:
+        key = (ch["title"], ch["start_page"])
+        if key not in seen:
+            seen.add(key)
+            unique.append(ch)
+    unique.sort(key=lambda c: c["start_page"])
+    return unique
+
+
+def _extract_via_toc_text(reader: PdfReader) -> list[dict]:
+    """Fallback: Sucht Kapitelzeilen in den ersten 20 Seiten per Regex."""
+    # Kapitel-Pattern: "1. Einleitung .... 5", "Kapitel 1 Einleitung 5", etc.
+    patterns = [
+        re.compile(
+            r"(?:Kapitel|Chapter)\s+(\d+)[.:)]\s*(.+?)\s+(\d+)\s*$",
+            re.IGNORECASE | re.MULTILINE,
+        ),
+        re.compile(
+            r"^(\d+)\.\s+([A-ZAEOEUÄÖÜ][^\n]{3,60}?)\s{2,}(\d+)\s*$",
+            re.MULTILINE,
+        ),
+    ]
+    text_pages = min(20, len(reader.pages))
+    full_text = ""
+    for i in range(text_pages):
+        try:
+            full_text += (reader.pages[i].extract_text() or "") + "\n"
+        except Exception:
+            pass
+
+    chapters = []
+    for pat in patterns:
+        for m in pat.finditer(full_text):
+            try:
+                num = int(m.group(1))
+                title = m.group(2).strip()
+                page = int(m.group(3)) - 1  # 1-indexed -> 0-indexed
+                if 0 <= page < len(reader.pages):
+                    chapters.append({
+                        "title": f"Kapitel {num}: {title}",
+                        "start_page": page,
+                    })
+            except (ValueError, IndexError):
+                pass
+        if chapters:
+            break
+
+    chapters.sort(key=lambda c: c["start_page"])
+    # Duplikate entfernen
+    seen = set()
+    unique = []
+    for ch in chapters:
+        key = ch["start_page"]
+        if key not in seen:
+            seen.add(key)
+            unique.append(ch)
+    return unique
+
+
+def _assign_end_pages(chapters: list[dict], total_pages: int) -> list[dict]:
+    """Berechnet end_page fuer jedes Kapitel."""
+    for i, ch in enumerate(chapters):
+        if i + 1 < len(chapters):
+            ch["end_page"] = chapters[i + 1]["start_page"] - 1
+        else:
+            ch["end_page"] = total_pages - 1
+    return chapters
+
+
+def extract_chapters(pdf_path: str) -> list[dict]:
+    """Extrahiert Kapitel-Metadaten aus PDF. Gibt [{title, start_page, end_page}] zurueck.
+
+    Raises SystemExit(2) wenn weder Outline noch TOC gefunden.
+    """
+    reader = PdfReader(pdf_path)
+    total = len(reader.pages)
+
+    chapters = _extract_via_outline(reader)
+    if not chapters:
+        chapters = _extract_via_toc_text(reader)
+    if not chapters:
+        print(
+            f"[chunk_pdf] Fehler: Kein Outline-Tree und kein TOC-Text in '{pdf_path}' gefunden.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    return _assign_end_pages(chapters, total)
+
+
+def write_chapter(pdf_path: str, chapter: dict, output_path: str) -> None:
+    """Schreibt einen Kapitel-Bereich als neues PDF."""
+    reader = PdfReader(pdf_path)
+    writer = PdfWriter()
+    start = chapter["start_page"]
+    end = chapter["end_page"]
+    for page_num in range(start, end + 1):
+        if 0 <= page_num < len(reader.pages):
+            writer.add_page(reader.pages[page_num])
+    os.makedirs(os.path.dirname(os.path.abspath(output_path)), exist_ok=True)
+    with open(output_path, "wb") as f:
+        writer.write(f)
+
+
+def write_all_chapters(
+    pdf_path: str,
+    output_dir: str,
+    isbn: str = "book",
+) -> list[str]:
+    """Schreibt alle Kapitel als separate PDFs. Gibt Liste der Pfade zurueck."""
+    chapters = extract_chapters(pdf_path)
+    os.makedirs(output_dir, exist_ok=True)
+    paths = []
+    for i, ch in enumerate(chapters, start=1):
+        safe_isbn = re.sub(r"[^a-zA-Z0-9_-]", "-", isbn)
+        fname = f"{safe_isbn}-ch{i}.pdf"
+        out_path = os.path.join(output_dir, fname)
+        write_chapter(pdf_path, ch, out_path)
+        paths.append(out_path)
+    return paths
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Zerlegt Buch-PDFs kapitelweise (PyPDF2 Outline-Tree)."
+    )
+    parser.add_argument("--input", required=True, help="Eingabe-PDF")
+    parser.add_argument(
+        "--chapter",
+        required=True,
+        help="Kapitel-Nummer (1-basiert), 'all' oder 'toc'",
+    )
+    parser.add_argument(
+        "--output", required=True, help="Ausgabe-Pfad oder Verzeichnis (bei --chapter all)"
+    )
+    parser.add_argument("--isbn", default="book", help="ISBN fuer Dateinamen (bei --chapter all)")
+    args = parser.parse_args()
+
+    if not os.path.exists(args.input):
+        print(f"[chunk_pdf] Eingabe-PDF nicht gefunden: {args.input}", file=sys.stderr)
+        return 1
+
+    if args.chapter == "toc":
+        chapters = extract_chapters(args.input)
+        print(json.dumps(
+            [{"title": c["title"], "start_page": c["start_page"], "end_page": c["end_page"]}
+             for c in chapters],
+            ensure_ascii=False, indent=2,
+        ))
+        return 0
+
+    if args.chapter == "all":
+        paths = write_all_chapters(args.input, args.output, isbn=args.isbn)
+        print(f"[chunk_pdf] {len(paths)} Kapitel geschrieben nach {args.output}")
+        for p in paths:
+            print(f"  {p}")
+        return 0
+
+    # Einzelnes Kapitel
+    try:
+        n = int(args.chapter)
+    except ValueError:
+        print(f"[chunk_pdf] Ungueltige Kapitel-Angabe: {args.chapter!r}", file=sys.stderr)
+        return 1
+
+    chapters = extract_chapters(args.input)
+    if n < 1 or n > len(chapters):
+        print(
+            f"[chunk_pdf] Kapitel {n} nicht vorhanden (1-{len(chapters)}).",
+            file=sys.stderr,
+        )
+        return 1
+
+    write_chapter(args.input, chapters[n - 1], args.output)
+    print(f"[chunk_pdf] Kapitel {n} geschrieben: {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Schritt 4: Tests ausfuehren — muessen gruen sein**
+
+```bash
+cd /Users/j65674/Repos/academic-research-v6.1-B
+/opt/homebrew/bin/pytest tests/test_chunk_pdf.py -v --tb=short 2>&1
+# Erwartet: alle Tests PASS
+```
+
+- [ ] **Schritt 5: Commit**
+
+```bash
+git add scripts/chunk_pdf.py tests/test_chunk_pdf.py
+git commit -m "feat: chunk_pdf.py — Kapitel-Schnitt via PyPDF2 Outline-Tree"
+```
+
+---
+
+### Task 3: Vault schema.sql — parent_paper_id Spalte
+
+**Files:**
+- Modify: `mcp/academic_vault/schema.sql`
+
+- [ ] **Schritt 1: Failing test schreiben**
+
+```python
+# tests/test_vault_parent.py (nur diese eine Test-Klasse)
+"""Tests fuer parent_paper_id in Vault."""
+import tempfile, os
+import pytest
+
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from mcp.academic_vault.db import VaultDB
+
+
+class TestParentPaperIdSchema:
+    def setup_method(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.db_path = self.tmp.name
+        self.tmp.close()
+        self.db = VaultDB(self.db_path)
+        self.db.init_schema()
+
+    def teardown_method(self):
+        os.unlink(self.db_path)
+
+    def test_parent_paper_id_column_exists(self):
+        """papers-Tabelle hat parent_paper_id-Spalte."""
+        import sqlite3
+        conn = sqlite3.connect(self.db_path)
+        cols = [row[1] for row in conn.execute("PRAGMA table_info(papers)").fetchall()]
+        conn.close()
+        assert "parent_paper_id" in cols
+
+    def test_add_paper_with_parent_paper_id(self):
+        """add_paper akzeptiert parent_paper_id."""
+        import json
+        # Eltern-Buch anlegen
+        self.db.add_paper(
+            paper_id="book-parent",
+            csl_json=json.dumps({"type": "book", "title": "Elternbuch"}),
+        )
+        # Kapitel mit parent_paper_id
+        self.db.add_paper(
+            paper_id="chapter-child",
+            csl_json=json.dumps({"type": "chapter", "title": "Kapitel 1"}),
+            parent_paper_id="book-parent",
+        )
+        paper = self.db.get_paper("chapter-child")
+        assert paper is not None
+        assert paper["parent_paper_id"] == "book-parent"
+
+    def test_parent_paper_id_nullable(self):
+        """parent_paper_id ist NULL wenn nicht gesetzt."""
+        import json
+        self.db.add_paper(
+            paper_id="standalone",
+            csl_json=json.dumps({"type": "article-journal", "title": "Artikel"}),
+        )
+        paper = self.db.get_paper("standalone")
+        assert paper["parent_paper_id"] is None
+```
+
+- [ ] **Schritt 2: Test ausfuehren — muss fehlschlagen**
+
+```bash
+cd /Users/j65674/Repos/academic-research-v6.1-B
+/opt/homebrew/bin/pytest tests/test_vault_parent.py::TestParentPaperIdSchema -v --tb=short
+# Erwartet: FAIL — 'parent_paper_id' not in cols
+```
+
+- [ ] **Schritt 3: schema.sql erweitern**
+
+In `mcp/academic_vault/schema.sql` die Zeile nach `container_title` einfuegen:
+
+```sql
+  container_title       TEXT,
+  parent_paper_id       TEXT REFERENCES papers(paper_id),
+```
+
+Die vollstaendige papers-Tabelle sieht danach so aus (nur die neue Zeile wird hinzugefuegt):
+
+```sql
+CREATE TABLE IF NOT EXISTS papers (
+  paper_id              TEXT PRIMARY KEY,
+  type                  TEXT NOT NULL DEFAULT 'article-journal'
+                          CHECK(type IN ('article-journal','book','chapter')),
+  csl_json              TEXT NOT NULL,
+  doi                   TEXT,
+  isbn                  TEXT,
+  pdf_path              TEXT,
+  file_id               TEXT,
+  file_id_expires_at    INTEGER,
+  page_offset           INTEGER DEFAULT 0,
+  ocr_done              INTEGER DEFAULT 0,
+  editor                TEXT,
+  chapter               TEXT,
+  page_first            INTEGER,
+  page_last             INTEGER,
+  container_title       TEXT,
+  parent_paper_id       TEXT REFERENCES papers(paper_id),
+  added_at              INTEGER NOT NULL,
+  updated_at            INTEGER NOT NULL
+);
+```
+
+- [ ] **Schritt 4: Tests ausfuehren — muessen gruen sein**
+
+```bash
+/opt/homebrew/bin/pytest tests/test_vault_parent.py::TestParentPaperIdSchema -v --tb=short
+# Erwartet: PASS (init_schema erstellt jetzt Tabelle mit neuer Spalte)
+```
+
+- [ ] **Schritt 5: Commit**
+
+```bash
+git add mcp/academic_vault/schema.sql
+git commit -m "feat(vault): parent_paper_id Spalte in papers-Tabelle"
+```
+
+---
+
+### Task 4: migrate.py — add_parent_paper_id_column()
+
+**Files:**
+- Modify: `mcp/academic_vault/migrate.py`
+
+- [ ] **Schritt 1: Failing test schreiben (zu tests/test_vault_parent.py hinzufuegen)**
+
+```python
+class TestMigrateParentPaperId:
+    def setup_method(self):
+        import tempfile
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.db_path = self.tmp.name
+        self.tmp.close()
+        # Altes Schema ohne parent_paper_id simulieren
+        import sqlite3
+        conn = sqlite3.connect(self.db_path)
+        conn.execute("""
+            CREATE TABLE papers (
+                paper_id TEXT PRIMARY KEY,
+                type TEXT NOT NULL DEFAULT 'article-journal',
+                csl_json TEXT NOT NULL,
+                added_at INTEGER NOT NULL DEFAULT 0,
+                updated_at INTEGER NOT NULL DEFAULT 0
+            )
+        """)
+        conn.commit()
+        conn.close()
+
+    def teardown_method(self):
+        os.unlink(self.db_path)
+
+    def test_add_parent_paper_id_column_idempotent(self):
+        """Migration fuegt Spalte hinzu; zweiter Lauf wirft keinen Fehler."""
+        from mcp.academic_vault.migrate import add_parent_paper_id_column
+        import sqlite3
+        # Erster Lauf
+        add_parent_paper_id_column(self.db_path)
+        cols = [
+            row[1] for row in
+            sqlite3.connect(self.db_path).execute("PRAGMA table_info(papers)").fetchall()
+        ]
+        assert "parent_paper_id" in cols
+        # Zweiter Lauf: kein Fehler
+        add_parent_paper_id_column(self.db_path)
+```
+
+- [ ] **Schritt 2: Test ausfuehren — muss fehlschlagen**
+
+```bash
+/opt/homebrew/bin/pytest tests/test_vault_parent.py::TestMigrateParentPaperId -v --tb=short
+# Erwartet: AttributeError — add_parent_paper_id_column nicht vorhanden
+```
+
+- [ ] **Schritt 3: Funktion in migrate.py hinzufuegen**
+
+Am Ende der Datei (vor `main()`), nach `add_book_columns()`:
+
+```python
+def add_parent_paper_id_column(db_path: str) -> None:
+    """Fuegt parent_paper_id-Spalte zu papers hinzu. Idempotent (try/except).
+
+    Aufruf-Sicher: Kann mehrfach auf derselben DB ausgefuehrt werden.
+    """
+    import sqlite3 as _sqlite3
+    conn = _sqlite3.connect(db_path)
+    try:
+        try:
+            conn.execute(
+                "ALTER TABLE papers ADD COLUMN "
+                "parent_paper_id TEXT REFERENCES papers(paper_id)"
+            )
+        except _sqlite3.OperationalError:
+            pass  # Spalte existiert bereits -- idempotent
+        conn.commit()
+    finally:
+        conn.close()
+```
+
+- [ ] **Schritt 4: Tests ausfuehren**
+
+```bash
+/opt/homebrew/bin/pytest tests/test_vault_parent.py -v --tb=short
+# Erwartet: alle TestMigrateParentPaperId-Tests PASS
+```
+
+- [ ] **Schritt 5: Commit**
+
+```bash
+git add mcp/academic_vault/migrate.py tests/test_vault_parent.py
+git commit -m "feat(vault): add_parent_paper_id_column() idempotente Migration"
+```
+
+---
+
+### Task 5: db.py — add_paper() um parent_paper_id erweitern
+
+**Files:**
+- Modify: `mcp/academic_vault/db.py`
+
+- [ ] **Schritt 1: Failing test (in TestParentPaperIdSchema bereits enthalten)**
+
+Der Test `test_add_paper_with_parent_paper_id` aus Task 3 schlaegt bei diesem
+Schritt fehl, weil `add_paper()` noch keinen `parent_paper_id`-Parameter hat.
+Pruefen:
+
+```bash
+/opt/homebrew/bin/pytest tests/test_vault_parent.py::TestParentPaperIdSchema::test_add_paper_with_parent_paper_id -v --tb=short
+# Erwartet: FAIL — TypeError: add_paper() got unexpected keyword argument
+```
+
+- [ ] **Schritt 2: db.py add_paper() erweitern**
+
+Die Methode `add_paper` in `mcp/academic_vault/db.py` erhielt folgende Signatur
+(nach Chunk A):
+
+```python
+def add_paper(
+    self,
+    paper_id: str,
+    csl_json: str,
+    doi: Optional[str] = None,
+    isbn: Optional[str] = None,
+    pdf_path: Optional[str] = None,
+    page_offset: int = 0,
+    editor: Optional[str] = None,
+    chapter: Optional[str] = None,
+    page_first: Optional[int] = None,
+    page_last: Optional[int] = None,
+    container_title: Optional[str] = None,
+) -> None:
+```
+
+Erweitern um `parent_paper_id: Optional[str] = None`:
+
+```python
+def add_paper(
+    self,
+    paper_id: str,
+    csl_json: str,
+    doi: Optional[str] = None,
+    isbn: Optional[str] = None,
+    pdf_path: Optional[str] = None,
+    page_offset: int = 0,
+    editor: Optional[str] = None,
+    chapter: Optional[str] = None,
+    page_first: Optional[int] = None,
+    page_last: Optional[int] = None,
+    container_title: Optional[str] = None,
+    parent_paper_id: Optional[str] = None,
+) -> None:
+    """Upsert eines Papers in die papers-Tabelle.
+
+    type wird aus csl_json extrahiert. Erlaubte Werte: article-journal, book, chapter.
+    """
+    try:
+        csl = json.loads(csl_json)
+        paper_type = csl.get("type", "article-journal")
+    except Exception:
+        paper_type = "article-journal"
+
+    if paper_type not in VALID_PAPER_TYPES:
+        raise ValueError(
+            f"Ungueltiger type '{paper_type}' -- erlaubt: {sorted(VALID_PAPER_TYPES)}"
+        )
+
+    now = int(time.time())
+    conn = self._get_conn()
+    own_conn = self._conn is None
+    conn.execute(
+        """
+        INSERT INTO papers
+          (paper_id, type, csl_json, doi, isbn, pdf_path, page_offset,
+           editor, chapter, page_first, page_last, container_title,
+           parent_paper_id,
+           added_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(paper_id) DO UPDATE SET
+          type           = excluded.type,
+          csl_json       = excluded.csl_json,
+          doi            = excluded.doi,
+          isbn           = excluded.isbn,
+          pdf_path       = excluded.pdf_path,
+          page_offset    = excluded.page_offset,
+          editor         = excluded.editor,
+          chapter        = excluded.chapter,
+          page_first     = excluded.page_first,
+          page_last      = excluded.page_last,
+          container_title= excluded.container_title,
+          parent_paper_id= excluded.parent_paper_id,
+          updated_at     = excluded.updated_at
+        """,
+        (
+            paper_id, paper_type, csl_json, doi, isbn, pdf_path, page_offset,
+            editor, chapter, page_first, page_last, container_title,
+            parent_paper_id,
+            now, now,
+        ),
+    )
+    if own_conn:
+        conn.commit()
+        conn.close()
+```
+
+- [ ] **Schritt 3: Tests ausfuehren**
+
+```bash
+/opt/homebrew/bin/pytest tests/test_vault_parent.py -v --tb=short
+# Erwartet: alle Tests PASS
+```
+
+- [ ] **Schritt 4: Commit**
+
+```bash
+git add mcp/academic_vault/db.py
+git commit -m "feat(vault): db.add_paper() + parent_paper_id Parameter"
+```
+
+---
+
+### Task 6: server.py — add_paper() + add_chapter() erweitern
+
+**Files:**
+- Modify: `mcp/academic_vault/server.py`
+
+- [ ] **Schritt 1: Failing test hinzufuegen (zu test_vault_parent.py)**
+
+```python
+class TestServerAddChapter:
+    def setup_method(self):
+        import tempfile
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.db_path = self.tmp.name
+        self.tmp.close()
+
+    def teardown_method(self):
+        os.unlink(self.db_path)
+
+    def test_add_chapter_via_server(self):
+        """server.add_chapter() legt Kapitel mit parent_paper_id an."""
+        import json
+        from mcp.academic_vault import server as vault_server
+        # Elternbuch anlegen
+        vault_server.add_paper(
+            self.db_path, "buch-001",
+            csl_json=json.dumps({"type": "book", "title": "Grundlagen"}),
+        )
+        # Kapitel via add_chapter
+        vault_server.add_chapter(
+            db_path=self.db_path,
+            parent_paper_id="buch-001",
+            chapter_number=1,
+            csl_json=json.dumps({"type": "chapter", "title": "Einleitung"}),
+            paper_id="buch-001-ch1",
+        )
+        paper = vault_server.get_paper(self.db_path, "buch-001-ch1")
+        assert paper is not None
+        assert paper["parent_paper_id"] == "buch-001"
+        assert paper["type"] == "chapter"
+
+    def test_server_add_paper_accepts_parent_paper_id(self):
+        """server.add_paper() akzeptiert parent_paper_id."""
+        import json
+        from mcp.academic_vault import server as vault_server
+        vault_server.add_paper(
+            self.db_path, "root-book",
+            csl_json=json.dumps({"type": "book", "title": "Root"}),
+        )
+        vault_server.add_paper(
+            self.db_path, "ch-2",
+            csl_json=json.dumps({"type": "chapter", "title": "Kap 2"}),
+            parent_paper_id="root-book",
+        )
+        paper = vault_server.get_paper(self.db_path, "ch-2")
+        assert paper["parent_paper_id"] == "root-book"
+```
+
+- [ ] **Schritt 2: Test ausfuehren — muss fehlschlagen**
+
+```bash
+/opt/homebrew/bin/pytest tests/test_vault_parent.py::TestServerAddChapter -v --tb=short
+# Erwartet: AttributeError — add_chapter nicht in server
+```
+
+- [ ] **Schritt 3: server.py erweitern**
+
+In `mcp/academic_vault/server.py`:
+
+1. `add_paper()`-Funktion um `parent_paper_id` erweitern:
+
+```python
+def add_paper(
+    db_path: str,
+    paper_id: str,
+    csl_json: str,
+    pdf_path: Optional[str] = None,
+    doi: Optional[str] = None,
+    isbn: Optional[str] = None,
+    page_offset: int = 0,
+    editor: Optional[str] = None,
+    chapter: Optional[str] = None,
+    page_first: Optional[int] = None,
+    page_last: Optional[int] = None,
+    container_title: Optional[str] = None,
+    parent_paper_id: Optional[str] = None,
+) -> None:
+    """Upsert eines Papers in den Vault. Unterstuetzt type=book|chapter."""
+    db = VaultDB(db_path)
+    db.init_schema()
+    db.add_paper(
+        paper_id, csl_json,
+        doi=doi, isbn=isbn, pdf_path=pdf_path, page_offset=page_offset,
+        editor=editor, chapter=chapter,
+        page_first=page_first, page_last=page_last,
+        container_title=container_title,
+        parent_paper_id=parent_paper_id,
+    )
+```
+
+2. Neue Funktion `add_chapter()` nach `add_paper()`:
+
+```python
+def add_chapter(
+    db_path: str,
+    parent_paper_id: str,
+    chapter_number: int,
+    csl_json: str,
+    paper_id: Optional[str] = None,
+    pdf_path: Optional[str] = None,
+    page_first: Optional[int] = None,
+    page_last: Optional[int] = None,
+) -> str:
+    """Legt ein Kapitel als Kind-Paper in den Vault. Gibt paper_id zurueck.
+
+    Setzt type=chapter automatisch falls nicht in csl_json angegeben.
+    """
+    import json as _json
+    if paper_id is None:
+        paper_id = f"{parent_paper_id}-ch{chapter_number}"
+    # Sicherstellen dass type=chapter in csl_json gesetzt ist
+    try:
+        csl = _json.loads(csl_json)
+        csl.setdefault("type", "chapter")
+        csl_json = _json.dumps(csl, ensure_ascii=False)
+    except Exception:
+        pass
+    add_paper(
+        db_path=db_path,
+        paper_id=paper_id,
+        csl_json=csl_json,
+        pdf_path=pdf_path,
+        chapter=str(chapter_number),
+        page_first=page_first,
+        page_last=page_last,
+        parent_paper_id=parent_paper_id,
+    )
+    return paper_id
+```
+
+3. Im `_build_mcp_server()`-Block: `vault.add_paper` und `vault.add_chapter` aktualisieren:
+
+```python
+@mcp.tool(name="vault.add_paper")
+def _vault_add_paper(
+    paper_id: str,
+    csl_json: str,
+    pdf_path: str = None,
+    doi: str = None,
+    isbn: str = None,
+    page_offset: int = 0,
+    editor: str = None,
+    chapter: str = None,
+    page_first: int = None,
+    page_last: int = None,
+    container_title: str = None,
+    parent_paper_id: str = None,
+) -> None:
+    """Upsert eines Papers. type aus csl_json; book|chapter|article-journal erlaubt."""
+    add_paper(
+        db_path, paper_id, csl_json,
+        pdf_path=pdf_path, doi=doi, isbn=isbn, page_offset=page_offset,
+        editor=editor, chapter=chapter,
+        page_first=page_first, page_last=page_last,
+        container_title=container_title,
+        parent_paper_id=parent_paper_id,
+    )
+
+@mcp.tool(name="vault.add_chapter")
+def _vault_add_chapter(
+    parent_paper_id: str,
+    chapter_number: int,
+    csl_json: str,
+    paper_id: str = None,
+    pdf_path: str = None,
+    page_first: int = None,
+    page_last: int = None,
+) -> str:
+    """Legt Kapitel als Kind-Paper an. Gibt paper_id zurueck."""
+    return add_chapter(
+        db_path=db_path,
+        parent_paper_id=parent_paper_id,
+        chapter_number=chapter_number,
+        csl_json=csl_json,
+        paper_id=paper_id,
+        pdf_path=pdf_path,
+        page_first=page_first,
+        page_last=page_last,
+    )
+```
+
+- [ ] **Schritt 4: Tests ausfuehren**
+
+```bash
+/opt/homebrew/bin/pytest tests/test_vault_parent.py -v --tb=short
+# Erwartet: alle Tests PASS
+```
+
+- [ ] **Schritt 5: Commit**
+
+```bash
+git add mcp/academic_vault/server.py tests/test_vault_parent.py
+git commit -m "feat(vault): server.add_chapter() + parent_paper_id in add_paper()"
+```
+
+---
+
+### Task 7: skills/citation-extraction/SKILL.md anpassen
+
+**Files:**
+- Modify: `skills/citation-extraction/SKILL.md`
+
+- [ ] **Schritt 1: Hinweis in SKILL.md einfuegen**
+
+Im Abschnitt `### 3. Zitat-Extraktion` (nach dem ersten Absatz, vor dem JSON-Block) folgendes einfuegen:
+
+```markdown
+> **Kapitel-PDF-Modus:** Wenn `vault.get_paper(paper_id)["parent_paper_id"]` gesetzt
+> ist, liegt ein Kapitel-PDF vor (erzeugt von `chunk_pdf.py`). Uebergib statt des
+> Gesamt-Buches nur dieses Kapitel-PDF als `file_id` via `vault.ensure_file(paper_id)`.
+> Das reduziert den Token-Footprint um typisch 90-95 % gegenueber dem Gesamtbuch.
+```
+
+- [ ] **Schritt 2: Kein automatisierter Test fuer Skill-Docs erforderlich**
+
+Die Skill-Doku ist prose — kein pytest-Test noetig. Sicherstellen dass
+`test_skills_manifest.py` weiterhin gruен ist:
+
+```bash
+/opt/homebrew/bin/pytest tests/test_skills_manifest.py -v --tb=short -k "not token_reduction"
+# Erwartet: PASS
+```
+
+- [ ] **Schritt 3: Commit**
+
+```bash
+git add skills/citation-extraction/SKILL.md
+git commit -m "docs(skill): citation-extraction Hinweis fuer Kapitel-PDF-Modus"
+```
+
+---
+
+### Task 8: Full Test Suite + Abschluss-Verifikation
+
+- [ ] **Schritt 1: Alle Tests ausfuehren**
+
+```bash
+cd /Users/j65674/Repos/academic-research-v6.1-B
+/opt/homebrew/bin/pytest tests/ --tb=short -q 2>&1 | tail -20
+# Erwartet:
+# - PASSED: alle neuen Tests (test_chunk_pdf.py, test_vault_parent.py)
+# - FAILED: nur test_token_reduction[chapter-writer] und test_token_reduction[citation-extraction]
+#   (vorbestehende Fehler)
+# - 0 neue Fehler
+```
+
+- [ ] **Schritt 2: state.yaml aktualisieren**
+
+```bash
+# phase auf pr_ready setzen
+```
+
+Die Datei `/Users/j65674/Repos/academic-research-v6.1-B/.orchestrator/chunks/B/state.yaml`
+wird nach Abschluss der Implementierung auf `phase: pr_ready` gesetzt.

--- a/specs/v6.1/B.md
+++ b/specs/v6.1/B.md
@@ -1,0 +1,99 @@
+# Chunk B — F2.2: Kapitel-Schnitt aus Buch-PDFs (PyPDF2 Outline-Tree)
+
+## Ticket
+
+\#72 — v6.1 · F2.2
+
+## Ziel
+
+Grosse Buch-PDFs (600+ Seiten) so zerlegen, dass pro Kapitel ein separates PDF
+entsteht. Damit sinkt der Token-Footprint je API-Call von bis zu 600 Seiten auf
+typisch < 30 Seiten pro Kapitel.
+
+## Deliverables
+
+### 1. `scripts/chunk_pdf.py`
+
+CLI-Skript mit Subkommando-Stil:
+
+```
+python scripts/chunk_pdf.py \
+  --input book.pdf \
+  --chapter <n|toc|all> \
+  --output <pfad-oder-verzeichnis>
+```
+
+**Kapitel-Erkennung (Prioritaet):**
+
+1. **PyPDF2 Outline-Tree** (`PdfReader.outline`) — iteriert die Struktur,
+   mappt Kapitel auf Seitenbereiche, schreibt PDFs via `PdfWriter`.
+2. **Fallback: TOC-Textextraktion** — liest die ersten 20 Seiten, sucht per
+   Regex nach Kapitelzeilen (`Kapitel N`, `Chapter N`, `\d+\.\s+\w+`) inkl.
+   Seitenzahlen. Wird aktiviert wenn Outline-Tree leer ist.
+
+**Ausgabe-Konvention:**
+
+- `--chapter all` → alle Kapitel nach `<session>/pdfs/<isbn>-ch<n>.pdf`
+  (oder `<output_dir>/<isbn>-ch<n>.pdf`)
+- `--chapter N` → einzelnes Kapitel nach `--output`-Pfad
+- `--chapter toc` → Gibt nur JSON-TOC aus (Kapitel-Nummern + Seiten)
+
+**Fehlerverhalten:**
+- Kein Outline UND kein TOC-Text gefunden → `SystemExit(2)` mit klarer
+  Meldung, keine leeren PDFs.
+
+### 2. `mcp/academic_vault/schema.sql`
+
+Neue Spalte in `papers`:
+
+```sql
+parent_paper_id TEXT REFERENCES papers(paper_id)
+```
+
+Idempotent in `CREATE TABLE IF NOT EXISTS`-Block aufgenommen.
+
+### 3. `mcp/academic_vault/migrate.py`
+
+Neue Funktion `add_parent_paper_id_column(db_path)`:
+
+- Pattern identisch zu `add_book_columns()` — `ALTER TABLE papers ADD COLUMN`
+  in try/except auf `OperationalError`.
+- Wird von `main()` bei Bedarf aufgerufen (opt-in Flag `--add-parent`).
+
+### 4. `mcp/academic_vault/db.py`
+
+`add_paper()` um Parameter `parent_paper_id: Optional[str] = None`
+erweitern — sowohl in INSERT als auch in ON CONFLICT DO UPDATE.
+
+### 5. `mcp/academic_vault/server.py`
+
+- `add_paper()` um `parent_paper_id` erweitern.
+- Neue Hilfsfunktion `add_chapter(parent_paper_id, chapter_number, ...)` als
+  convenience-Wrapper (ruft `add_paper` mit `type=chapter` auf).
+- MCP-Tool `vault.add_paper` + `vault.add_chapter` exponieren.
+
+### 6. `skills/citation-extraction/SKILL.md`
+
+Hinweis-Block in Schritt 3 (Zitat-Extraktion):
+
+> Wenn `parent_paper_id` gesetzt ist, liegt ein Kapitel-PDF vor. Statt des
+> Gesamt-Buches nur dieses Kapitel als `file_id` uebergeben — reduziert
+> Token-Footprint um ~95 %.
+
+### 7. Tests
+
+- `tests/test_chunk_pdf.py` — unit + integration (Fixture-PDF)
+- `tests/test_vault_parent.py` — parent/child-Beziehung in Vault
+- `tests/fixtures/sample_book.pdf` — minimales PDF mit Outline (< 200 KB)
+
+## Akzeptanzkriterien
+
+- [ ] 1 OA-Buch (>= 400 Seiten) -> 8+ Kapitel-PDFs in `<session>/pdfs/<isbn>-ch<n>.pdf`
+- [ ] Kapitel-Token-Footprint < 30k pro API-Call
+- [ ] Migration idempotent (kann mehrfach laufen)
+- [ ] Tests: alle bestehenden pass + neue tests grueen
+
+## Abhaengigkeiten
+
+- Chunk A muss gemergt sein (schema.sql mit book-columns, db.py-Signatur)
+- PyPDF2 >= 3.0.0 bereits in `scripts/requirements.txt`

--- a/tests/fixtures/create_sample_book.py
+++ b/tests/fixtures/create_sample_book.py
@@ -33,8 +33,35 @@ def create_sample_book(output_path: str) -> None:
     print(f"Erstellt: {output_path} ({os.path.getsize(output_path)} Bytes)")
 
 
+def create_large_book(output_path: str, num_chapters: int = 8, pages_per_chapter: int = 55) -> None:
+    """Erstellt synthetisches PDF mit num_chapters Kapiteln und pages_per_chapter Seiten je Kapitel.
+
+    8 x 55 = 440 Seiten, Outline-Tree korrekt gesetzt.
+    """
+    from PyPDF2 import PdfWriter
+
+    writer = PdfWriter()
+
+    total_pages = num_chapters * pages_per_chapter
+    for _ in range(total_pages):
+        writer.add_blank_page(width=595, height=842)
+
+    # Outline-Eintraege: num_chapters Kapitel (0-indexed Seitennummern)
+    for i in range(num_chapters):
+        title = f"Kapitel {i + 1}: Abschnitt {i + 1}"
+        start_page = i * pages_per_chapter
+        writer.add_outline_item(title, start_page)
+
+    os.makedirs(os.path.dirname(os.path.abspath(output_path)), exist_ok=True)
+    with open(output_path, "wb") as f:
+        writer.write(f)
+    print(f"Erstellt: {output_path} ({os.path.getsize(output_path)} Bytes, {total_pages} Seiten, {num_chapters} Kapitel)")
+
+
 if __name__ == "__main__":
     out = sys.argv[1] if len(sys.argv) > 1 else str(
         Path(__file__).parent / "sample_book.pdf"
     )
     create_sample_book(out)
+    large_out = str(Path(__file__).parent / "large_book.pdf")
+    create_large_book(large_out)

--- a/tests/fixtures/create_sample_book.py
+++ b/tests/fixtures/create_sample_book.py
@@ -1,0 +1,40 @@
+"""Erstellt sample_book.pdf mit PyPDF2 fuer Tests.
+
+Erzeugt ein minimales PDF mit 4 Kapiteln im Outline-Tree.
+Aufruf: python tests/fixtures/create_sample_book.py
+"""
+import os
+import sys
+from pathlib import Path
+
+
+def create_sample_book(output_path: str) -> None:
+    from PyPDF2 import PdfWriter
+
+    writer = PdfWriter()
+
+    # 10 Seiten: 2 Titelseiten + je 2 Seiten pro Kapitel (4 Kapitel)
+    for i in range(10):
+        writer.add_blank_page(width=595, height=842)
+
+    # Outline-Eintraege: 4 Kapitel (0-indexed Seitennummern)
+    chapters = [
+        ("Kapitel 1: Einleitung", 2),
+        ("Kapitel 2: Grundlagen", 4),
+        ("Kapitel 3: Methodik", 6),
+        ("Kapitel 4: Ergebnisse", 8),
+    ]
+    for title, page_num in chapters:
+        writer.add_outline_item(title, page_num)
+
+    os.makedirs(os.path.dirname(os.path.abspath(output_path)), exist_ok=True)
+    with open(output_path, "wb") as f:
+        writer.write(f)
+    print(f"Erstellt: {output_path} ({os.path.getsize(output_path)} Bytes)")
+
+
+if __name__ == "__main__":
+    out = sys.argv[1] if len(sys.argv) > 1 else str(
+        Path(__file__).parent / "sample_book.pdf"
+    )
+    create_sample_book(out)

--- a/tests/fixtures/large_book.pdf
+++ b/tests/fixtures/large_book.pdf
@@ -1,0 +1,4578 @@
+%PDF-1.3
+%‚„œ”
+1 0 obj
+<<
+/Type /Pages
+/Count 440
+/Kids [ 4 0 R 5 0 R 6 0 R 7 0 R 8 0 R 9 0 R 10 0 R 11 0 R 12 0 R 13 0 R 14 0 R 15 0 R 16 0 R 17 0 R 18 0 R 19 0 R 20 0 R 21 0 R 22 0 R 23 0 R 24 0 R 25 0 R 26 0 R 27 0 R 28 0 R 29 0 R 30 0 R 31 0 R 32 0 R 33 0 R 34 0 R 35 0 R 36 0 R 37 0 R 38 0 R 39 0 R 40 0 R 41 0 R 42 0 R 43 0 R 44 0 R 45 0 R 46 0 R 47 0 R 48 0 R 49 0 R 50 0 R 51 0 R 52 0 R 53 0 R 54 0 R 55 0 R 56 0 R 57 0 R 58 0 R 59 0 R 60 0 R 61 0 R 62 0 R 63 0 R 64 0 R 65 0 R 66 0 R 67 0 R 68 0 R 69 0 R 70 0 R 71 0 R 72 0 R 73 0 R 74 0 R 75 0 R 76 0 R 77 0 R 78 0 R 79 0 R 80 0 R 81 0 R 82 0 R 83 0 R 84 0 R 85 0 R 86 0 R 87 0 R 88 0 R 89 0 R 90 0 R 91 0 R 92 0 R 93 0 R 94 0 R 95 0 R 96 0 R 97 0 R 98 0 R 99 0 R 100 0 R 101 0 R 102 0 R 103 0 R 104 0 R 105 0 R 106 0 R 107 0 R 108 0 R 109 0 R 110 0 R 111 0 R 112 0 R 113 0 R 114 0 R 115 0 R 116 0 R 117 0 R 118 0 R 119 0 R 120 0 R 121 0 R 122 0 R 123 0 R 124 0 R 125 0 R 126 0 R 127 0 R 128 0 R 129 0 R 130 0 R 131 0 R 132 0 R 133 0 R 134 0 R 135 0 R 136 0 R 137 0 R 138 0 R 139 0 R 140 0 R 141 0 R 142 0 R 143 0 R 144 0 R 145 0 R 146 0 R 147 0 R 148 0 R 149 0 R 150 0 R 151 0 R 152 0 R 153 0 R 154 0 R 155 0 R 156 0 R 157 0 R 158 0 R 159 0 R 160 0 R 161 0 R 162 0 R 163 0 R 164 0 R 165 0 R 166 0 R 167 0 R 168 0 R 169 0 R 170 0 R 171 0 R 172 0 R 173 0 R 174 0 R 175 0 R 176 0 R 177 0 R 178 0 R 179 0 R 180 0 R 181 0 R 182 0 R 183 0 R 184 0 R 185 0 R 186 0 R 187 0 R 188 0 R 189 0 R 190 0 R 191 0 R 192 0 R 193 0 R 194 0 R 195 0 R 196 0 R 197 0 R 198 0 R 199 0 R 200 0 R 201 0 R 202 0 R 203 0 R 204 0 R 205 0 R 206 0 R 207 0 R 208 0 R 209 0 R 210 0 R 211 0 R 212 0 R 213 0 R 214 0 R 215 0 R 216 0 R 217 0 R 218 0 R 219 0 R 220 0 R 221 0 R 222 0 R 223 0 R 224 0 R 225 0 R 226 0 R 227 0 R 228 0 R 229 0 R 230 0 R 231 0 R 232 0 R 233 0 R 234 0 R 235 0 R 236 0 R 237 0 R 238 0 R 239 0 R 240 0 R 241 0 R 242 0 R 243 0 R 244 0 R 245 0 R 246 0 R 247 0 R 248 0 R 249 0 R 250 0 R 251 0 R 252 0 R 253 0 R 254 0 R 255 0 R 256 0 R 257 0 R 258 0 R 259 0 R 260 0 R 261 0 R 262 0 R 263 0 R 264 0 R 265 0 R 266 0 R 267 0 R 268 0 R 269 0 R 270 0 R 271 0 R 272 0 R 273 0 R 274 0 R 275 0 R 276 0 R 277 0 R 278 0 R 279 0 R 280 0 R 281 0 R 282 0 R 283 0 R 284 0 R 285 0 R 286 0 R 287 0 R 288 0 R 289 0 R 290 0 R 291 0 R 292 0 R 293 0 R 294 0 R 295 0 R 296 0 R 297 0 R 298 0 R 299 0 R 300 0 R 301 0 R 302 0 R 303 0 R 304 0 R 305 0 R 306 0 R 307 0 R 308 0 R 309 0 R 310 0 R 311 0 R 312 0 R 313 0 R 314 0 R 315 0 R 316 0 R 317 0 R 318 0 R 319 0 R 320 0 R 321 0 R 322 0 R 323 0 R 324 0 R 325 0 R 326 0 R 327 0 R 328 0 R 329 0 R 330 0 R 331 0 R 332 0 R 333 0 R 334 0 R 335 0 R 336 0 R 337 0 R 338 0 R 339 0 R 340 0 R 341 0 R 342 0 R 343 0 R 344 0 R 345 0 R 346 0 R 347 0 R 348 0 R 349 0 R 350 0 R 351 0 R 352 0 R 353 0 R 354 0 R 355 0 R 356 0 R 357 0 R 358 0 R 359 0 R 360 0 R 361 0 R 362 0 R 363 0 R 364 0 R 365 0 R 366 0 R 367 0 R 368 0 R 369 0 R 370 0 R 371 0 R 372 0 R 373 0 R 374 0 R 375 0 R 376 0 R 377 0 R 378 0 R 379 0 R 380 0 R 381 0 R 382 0 R 383 0 R 384 0 R 385 0 R 386 0 R 387 0 R 388 0 R 389 0 R 390 0 R 391 0 R 392 0 R 393 0 R 394 0 R 395 0 R 396 0 R 397 0 R 398 0 R 399 0 R 400 0 R 401 0 R 402 0 R 403 0 R 404 0 R 405 0 R 406 0 R 407 0 R 408 0 R 409 0 R 410 0 R 411 0 R 412 0 R 413 0 R 414 0 R 415 0 R 416 0 R 417 0 R 418 0 R 419 0 R 420 0 R 421 0 R 422 0 R 423 0 R 424 0 R 425 0 R 426 0 R 427 0 R 428 0 R 429 0 R 430 0 R 431 0 R 432 0 R 433 0 R 434 0 R 435 0 R 436 0 R 437 0 R 438 0 R 439 0 R 440 0 R 441 0 R 442 0 R 443 0 R ]
+>>
+endobj
+2 0 obj
+<<
+/Producer (PyPDF2)
+>>
+endobj
+3 0 obj
+<<
+/Type /Catalog
+/Pages 1 0 R
+/Outlines 445 0 R
+>>
+endobj
+4 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+5 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+6 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+7 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+8 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+9 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+10 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+11 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+12 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+13 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+14 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+15 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+16 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+17 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+18 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+19 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+20 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+21 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+22 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+23 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+24 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+25 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+26 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+27 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+28 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+29 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+30 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+31 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+32 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+33 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+34 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+35 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+36 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+37 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+38 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+39 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+40 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+41 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+42 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+43 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+44 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+45 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+46 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+47 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+48 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+49 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+50 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+51 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+52 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+53 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+54 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+55 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+56 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+57 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+58 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+59 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+60 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+61 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+62 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+63 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+64 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+65 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+66 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+67 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+68 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+69 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+70 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+71 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+72 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+73 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+74 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+75 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+76 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+77 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+78 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+79 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+80 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+81 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+82 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+83 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+84 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+85 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+86 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+87 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+88 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+89 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+90 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+91 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+92 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+93 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+94 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+95 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+96 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+97 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+98 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+99 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+100 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+101 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+102 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+103 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+104 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+105 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+106 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+107 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+108 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+109 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+110 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+111 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+112 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+113 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+114 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+115 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+116 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+117 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+118 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+119 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+120 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+121 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+122 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+123 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+124 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+125 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+126 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+127 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+128 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+129 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+130 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+131 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+132 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+133 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+134 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+135 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+136 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+137 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+138 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+139 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+140 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+141 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+142 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+143 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+144 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+145 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+146 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+147 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+148 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+149 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+150 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+151 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+152 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+153 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+154 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+155 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+156 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+157 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+158 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+159 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+160 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+161 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+162 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+163 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+164 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+165 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+166 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+167 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+168 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+169 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+170 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+171 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+172 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+173 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+174 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+175 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+176 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+177 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+178 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+179 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+180 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+181 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+182 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+183 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+184 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+185 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+186 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+187 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+188 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+189 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+190 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+191 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+192 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+193 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+194 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+195 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+196 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+197 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+198 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+199 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+200 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+201 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+202 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+203 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+204 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+205 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+206 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+207 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+208 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+209 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+210 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+211 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+212 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+213 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+214 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+215 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+216 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+217 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+218 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+219 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+220 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+221 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+222 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+223 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+224 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+225 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+226 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+227 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+228 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+229 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+230 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+231 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+232 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+233 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+234 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+235 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+236 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+237 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+238 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+239 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+240 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+241 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+242 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+243 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+244 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+245 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+246 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+247 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+248 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+249 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+250 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+251 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+252 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+253 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+254 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+255 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+256 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+257 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+258 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+259 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+260 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+261 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+262 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+263 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+264 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+265 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+266 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+267 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+268 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+269 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+270 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+271 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+272 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+273 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+274 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+275 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+276 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+277 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+278 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+279 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+280 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+281 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+282 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+283 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+284 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+285 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+286 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+287 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+288 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+289 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+290 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+291 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+292 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+293 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+294 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+295 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+296 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+297 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+298 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+299 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+300 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+301 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+302 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+303 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+304 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+305 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+306 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+307 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+308 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+309 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+310 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+311 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+312 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+313 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+314 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+315 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+316 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+317 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+318 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+319 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+320 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+321 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+322 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+323 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+324 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+325 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+326 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+327 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+328 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+329 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+330 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+331 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+332 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+333 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+334 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+335 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+336 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+337 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+338 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+339 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+340 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+341 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+342 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+343 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+344 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+345 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+346 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+347 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+348 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+349 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+350 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+351 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+352 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+353 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+354 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+355 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+356 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+357 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+358 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+359 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+360 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+361 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+362 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+363 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+364 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+365 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+366 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+367 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+368 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+369 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+370 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+371 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+372 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+373 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+374 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+375 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+376 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+377 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+378 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+379 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+380 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+381 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+382 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+383 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+384 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+385 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+386 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+387 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+388 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+389 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+390 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+391 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+392 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+393 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+394 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+395 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+396 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+397 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+398 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+399 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+400 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+401 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+402 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+403 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+404 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+405 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+406 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+407 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+408 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+409 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+410 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+411 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+412 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+413 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+414 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+415 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+416 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+417 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+418 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+419 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+420 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+421 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+422 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+423 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+424 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+425 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+426 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+427 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+428 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+429 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+430 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+431 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+432 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+433 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+434 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+435 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+436 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+437 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+438 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+439 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+440 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+441 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+442 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+443 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+444 0 obj
+<<
+/D [ 4 0 R /Fit ]
+/S /GoTo
+>>
+endobj
+445 0 obj
+<<
+/First 446 0 R
+/Count 8
+/Last 460 0 R
+>>
+endobj
+446 0 obj
+<<
+/A 444 0 R
+/Title (Kapitel\0401\072\040Abschnitt\0401)
+/Parent 445 0 R
+/Next 448 0 R
+>>
+endobj
+447 0 obj
+<<
+/D [ 59 0 R /Fit ]
+/S /GoTo
+>>
+endobj
+448 0 obj
+<<
+/A 447 0 R
+/Title (Kapitel\0402\072\040Abschnitt\0402)
+/Prev 446 0 R
+/Parent 445 0 R
+/Next 450 0 R
+>>
+endobj
+449 0 obj
+<<
+/D [ 114 0 R /Fit ]
+/S /GoTo
+>>
+endobj
+450 0 obj
+<<
+/A 449 0 R
+/Title (Kapitel\0403\072\040Abschnitt\0403)
+/Prev 448 0 R
+/Parent 445 0 R
+/Next 452 0 R
+>>
+endobj
+451 0 obj
+<<
+/D [ 169 0 R /Fit ]
+/S /GoTo
+>>
+endobj
+452 0 obj
+<<
+/A 451 0 R
+/Title (Kapitel\0404\072\040Abschnitt\0404)
+/Prev 450 0 R
+/Parent 445 0 R
+/Next 454 0 R
+>>
+endobj
+453 0 obj
+<<
+/D [ 224 0 R /Fit ]
+/S /GoTo
+>>
+endobj
+454 0 obj
+<<
+/A 453 0 R
+/Title (Kapitel\0405\072\040Abschnitt\0405)
+/Prev 452 0 R
+/Parent 445 0 R
+/Next 456 0 R
+>>
+endobj
+455 0 obj
+<<
+/D [ 279 0 R /Fit ]
+/S /GoTo
+>>
+endobj
+456 0 obj
+<<
+/A 455 0 R
+/Title (Kapitel\0406\072\040Abschnitt\0406)
+/Prev 454 0 R
+/Parent 445 0 R
+/Next 458 0 R
+>>
+endobj
+457 0 obj
+<<
+/D [ 334 0 R /Fit ]
+/S /GoTo
+>>
+endobj
+458 0 obj
+<<
+/A 457 0 R
+/Title (Kapitel\0407\072\040Abschnitt\0407)
+/Prev 456 0 R
+/Parent 445 0 R
+/Next 460 0 R
+>>
+endobj
+459 0 obj
+<<
+/D [ 389 0 R /Fit ]
+/S /GoTo
+>>
+endobj
+460 0 obj
+<<
+/A 459 0 R
+/Title (Kapitel\0408\072\040Abschnitt\0408)
+/Prev 458 0 R
+/Parent 445 0 R
+>>
+endobj
+xref
+0 461
+0000000000 65535 f 
+0000000015 00000 n 
+0000003488 00000 n 
+0000003528 00000 n 
+0000003595 00000 n 
+0000003685 00000 n 
+0000003775 00000 n 
+0000003865 00000 n 
+0000003955 00000 n 
+0000004045 00000 n 
+0000004135 00000 n 
+0000004226 00000 n 
+0000004317 00000 n 
+0000004408 00000 n 
+0000004499 00000 n 
+0000004590 00000 n 
+0000004681 00000 n 
+0000004772 00000 n 
+0000004863 00000 n 
+0000004954 00000 n 
+0000005045 00000 n 
+0000005136 00000 n 
+0000005227 00000 n 
+0000005318 00000 n 
+0000005409 00000 n 
+0000005500 00000 n 
+0000005591 00000 n 
+0000005682 00000 n 
+0000005773 00000 n 
+0000005864 00000 n 
+0000005955 00000 n 
+0000006046 00000 n 
+0000006137 00000 n 
+0000006228 00000 n 
+0000006319 00000 n 
+0000006410 00000 n 
+0000006501 00000 n 
+0000006592 00000 n 
+0000006683 00000 n 
+0000006774 00000 n 
+0000006865 00000 n 
+0000006956 00000 n 
+0000007047 00000 n 
+0000007138 00000 n 
+0000007229 00000 n 
+0000007320 00000 n 
+0000007411 00000 n 
+0000007502 00000 n 
+0000007593 00000 n 
+0000007684 00000 n 
+0000007775 00000 n 
+0000007866 00000 n 
+0000007957 00000 n 
+0000008048 00000 n 
+0000008139 00000 n 
+0000008230 00000 n 
+0000008321 00000 n 
+0000008412 00000 n 
+0000008503 00000 n 
+0000008594 00000 n 
+0000008685 00000 n 
+0000008776 00000 n 
+0000008867 00000 n 
+0000008958 00000 n 
+0000009049 00000 n 
+0000009140 00000 n 
+0000009231 00000 n 
+0000009322 00000 n 
+0000009413 00000 n 
+0000009504 00000 n 
+0000009595 00000 n 
+0000009686 00000 n 
+0000009777 00000 n 
+0000009868 00000 n 
+0000009959 00000 n 
+0000010050 00000 n 
+0000010141 00000 n 
+0000010232 00000 n 
+0000010323 00000 n 
+0000010414 00000 n 
+0000010505 00000 n 
+0000010596 00000 n 
+0000010687 00000 n 
+0000010778 00000 n 
+0000010869 00000 n 
+0000010960 00000 n 
+0000011051 00000 n 
+0000011142 00000 n 
+0000011233 00000 n 
+0000011324 00000 n 
+0000011415 00000 n 
+0000011506 00000 n 
+0000011597 00000 n 
+0000011688 00000 n 
+0000011779 00000 n 
+0000011870 00000 n 
+0000011961 00000 n 
+0000012052 00000 n 
+0000012143 00000 n 
+0000012234 00000 n 
+0000012325 00000 n 
+0000012417 00000 n 
+0000012509 00000 n 
+0000012601 00000 n 
+0000012693 00000 n 
+0000012785 00000 n 
+0000012877 00000 n 
+0000012969 00000 n 
+0000013061 00000 n 
+0000013153 00000 n 
+0000013245 00000 n 
+0000013337 00000 n 
+0000013429 00000 n 
+0000013521 00000 n 
+0000013613 00000 n 
+0000013705 00000 n 
+0000013797 00000 n 
+0000013889 00000 n 
+0000013981 00000 n 
+0000014073 00000 n 
+0000014165 00000 n 
+0000014257 00000 n 
+0000014349 00000 n 
+0000014441 00000 n 
+0000014533 00000 n 
+0000014625 00000 n 
+0000014717 00000 n 
+0000014809 00000 n 
+0000014901 00000 n 
+0000014993 00000 n 
+0000015085 00000 n 
+0000015177 00000 n 
+0000015269 00000 n 
+0000015361 00000 n 
+0000015453 00000 n 
+0000015545 00000 n 
+0000015637 00000 n 
+0000015729 00000 n 
+0000015821 00000 n 
+0000015913 00000 n 
+0000016005 00000 n 
+0000016097 00000 n 
+0000016189 00000 n 
+0000016281 00000 n 
+0000016373 00000 n 
+0000016465 00000 n 
+0000016557 00000 n 
+0000016649 00000 n 
+0000016741 00000 n 
+0000016833 00000 n 
+0000016925 00000 n 
+0000017017 00000 n 
+0000017109 00000 n 
+0000017201 00000 n 
+0000017293 00000 n 
+0000017385 00000 n 
+0000017477 00000 n 
+0000017569 00000 n 
+0000017661 00000 n 
+0000017753 00000 n 
+0000017845 00000 n 
+0000017937 00000 n 
+0000018029 00000 n 
+0000018121 00000 n 
+0000018213 00000 n 
+0000018305 00000 n 
+0000018397 00000 n 
+0000018489 00000 n 
+0000018581 00000 n 
+0000018673 00000 n 
+0000018765 00000 n 
+0000018857 00000 n 
+0000018949 00000 n 
+0000019041 00000 n 
+0000019133 00000 n 
+0000019225 00000 n 
+0000019317 00000 n 
+0000019409 00000 n 
+0000019501 00000 n 
+0000019593 00000 n 
+0000019685 00000 n 
+0000019777 00000 n 
+0000019869 00000 n 
+0000019961 00000 n 
+0000020053 00000 n 
+0000020145 00000 n 
+0000020237 00000 n 
+0000020329 00000 n 
+0000020421 00000 n 
+0000020513 00000 n 
+0000020605 00000 n 
+0000020697 00000 n 
+0000020789 00000 n 
+0000020881 00000 n 
+0000020973 00000 n 
+0000021065 00000 n 
+0000021157 00000 n 
+0000021249 00000 n 
+0000021341 00000 n 
+0000021433 00000 n 
+0000021525 00000 n 
+0000021617 00000 n 
+0000021709 00000 n 
+0000021801 00000 n 
+0000021893 00000 n 
+0000021985 00000 n 
+0000022077 00000 n 
+0000022169 00000 n 
+0000022261 00000 n 
+0000022353 00000 n 
+0000022445 00000 n 
+0000022537 00000 n 
+0000022629 00000 n 
+0000022721 00000 n 
+0000022813 00000 n 
+0000022905 00000 n 
+0000022997 00000 n 
+0000023089 00000 n 
+0000023181 00000 n 
+0000023273 00000 n 
+0000023365 00000 n 
+0000023457 00000 n 
+0000023549 00000 n 
+0000023641 00000 n 
+0000023733 00000 n 
+0000023825 00000 n 
+0000023917 00000 n 
+0000024009 00000 n 
+0000024101 00000 n 
+0000024193 00000 n 
+0000024285 00000 n 
+0000024377 00000 n 
+0000024469 00000 n 
+0000024561 00000 n 
+0000024653 00000 n 
+0000024745 00000 n 
+0000024837 00000 n 
+0000024929 00000 n 
+0000025021 00000 n 
+0000025113 00000 n 
+0000025205 00000 n 
+0000025297 00000 n 
+0000025389 00000 n 
+0000025481 00000 n 
+0000025573 00000 n 
+0000025665 00000 n 
+0000025757 00000 n 
+0000025849 00000 n 
+0000025941 00000 n 
+0000026033 00000 n 
+0000026125 00000 n 
+0000026217 00000 n 
+0000026309 00000 n 
+0000026401 00000 n 
+0000026493 00000 n 
+0000026585 00000 n 
+0000026677 00000 n 
+0000026769 00000 n 
+0000026861 00000 n 
+0000026953 00000 n 
+0000027045 00000 n 
+0000027137 00000 n 
+0000027229 00000 n 
+0000027321 00000 n 
+0000027413 00000 n 
+0000027505 00000 n 
+0000027597 00000 n 
+0000027689 00000 n 
+0000027781 00000 n 
+0000027873 00000 n 
+0000027965 00000 n 
+0000028057 00000 n 
+0000028149 00000 n 
+0000028241 00000 n 
+0000028333 00000 n 
+0000028425 00000 n 
+0000028517 00000 n 
+0000028609 00000 n 
+0000028701 00000 n 
+0000028793 00000 n 
+0000028885 00000 n 
+0000028977 00000 n 
+0000029069 00000 n 
+0000029161 00000 n 
+0000029253 00000 n 
+0000029345 00000 n 
+0000029437 00000 n 
+0000029529 00000 n 
+0000029621 00000 n 
+0000029713 00000 n 
+0000029805 00000 n 
+0000029897 00000 n 
+0000029989 00000 n 
+0000030081 00000 n 
+0000030173 00000 n 
+0000030265 00000 n 
+0000030357 00000 n 
+0000030449 00000 n 
+0000030541 00000 n 
+0000030633 00000 n 
+0000030725 00000 n 
+0000030817 00000 n 
+0000030909 00000 n 
+0000031001 00000 n 
+0000031093 00000 n 
+0000031185 00000 n 
+0000031277 00000 n 
+0000031369 00000 n 
+0000031461 00000 n 
+0000031553 00000 n 
+0000031645 00000 n 
+0000031737 00000 n 
+0000031829 00000 n 
+0000031921 00000 n 
+0000032013 00000 n 
+0000032105 00000 n 
+0000032197 00000 n 
+0000032289 00000 n 
+0000032381 00000 n 
+0000032473 00000 n 
+0000032565 00000 n 
+0000032657 00000 n 
+0000032749 00000 n 
+0000032841 00000 n 
+0000032933 00000 n 
+0000033025 00000 n 
+0000033117 00000 n 
+0000033209 00000 n 
+0000033301 00000 n 
+0000033393 00000 n 
+0000033485 00000 n 
+0000033577 00000 n 
+0000033669 00000 n 
+0000033761 00000 n 
+0000033853 00000 n 
+0000033945 00000 n 
+0000034037 00000 n 
+0000034129 00000 n 
+0000034221 00000 n 
+0000034313 00000 n 
+0000034405 00000 n 
+0000034497 00000 n 
+0000034589 00000 n 
+0000034681 00000 n 
+0000034773 00000 n 
+0000034865 00000 n 
+0000034957 00000 n 
+0000035049 00000 n 
+0000035141 00000 n 
+0000035233 00000 n 
+0000035325 00000 n 
+0000035417 00000 n 
+0000035509 00000 n 
+0000035601 00000 n 
+0000035693 00000 n 
+0000035785 00000 n 
+0000035877 00000 n 
+0000035969 00000 n 
+0000036061 00000 n 
+0000036153 00000 n 
+0000036245 00000 n 
+0000036337 00000 n 
+0000036429 00000 n 
+0000036521 00000 n 
+0000036613 00000 n 
+0000036705 00000 n 
+0000036797 00000 n 
+0000036889 00000 n 
+0000036981 00000 n 
+0000037073 00000 n 
+0000037165 00000 n 
+0000037257 00000 n 
+0000037349 00000 n 
+0000037441 00000 n 
+0000037533 00000 n 
+0000037625 00000 n 
+0000037717 00000 n 
+0000037809 00000 n 
+0000037901 00000 n 
+0000037993 00000 n 
+0000038085 00000 n 
+0000038177 00000 n 
+0000038269 00000 n 
+0000038361 00000 n 
+0000038453 00000 n 
+0000038545 00000 n 
+0000038637 00000 n 
+0000038729 00000 n 
+0000038821 00000 n 
+0000038913 00000 n 
+0000039005 00000 n 
+0000039097 00000 n 
+0000039189 00000 n 
+0000039281 00000 n 
+0000039373 00000 n 
+0000039465 00000 n 
+0000039557 00000 n 
+0000039649 00000 n 
+0000039741 00000 n 
+0000039833 00000 n 
+0000039925 00000 n 
+0000040017 00000 n 
+0000040109 00000 n 
+0000040201 00000 n 
+0000040293 00000 n 
+0000040385 00000 n 
+0000040477 00000 n 
+0000040569 00000 n 
+0000040661 00000 n 
+0000040753 00000 n 
+0000040845 00000 n 
+0000040937 00000 n 
+0000041029 00000 n 
+0000041121 00000 n 
+0000041213 00000 n 
+0000041305 00000 n 
+0000041397 00000 n 
+0000041489 00000 n 
+0000041581 00000 n 
+0000041673 00000 n 
+0000041765 00000 n 
+0000041857 00000 n 
+0000041949 00000 n 
+0000042041 00000 n 
+0000042133 00000 n 
+0000042225 00000 n 
+0000042317 00000 n 
+0000042409 00000 n 
+0000042501 00000 n 
+0000042593 00000 n 
+0000042685 00000 n 
+0000042777 00000 n 
+0000042869 00000 n 
+0000042961 00000 n 
+0000043053 00000 n 
+0000043145 00000 n 
+0000043237 00000 n 
+0000043329 00000 n 
+0000043421 00000 n 
+0000043513 00000 n 
+0000043605 00000 n 
+0000043697 00000 n 
+0000043789 00000 n 
+0000043881 00000 n 
+0000043973 00000 n 
+0000044023 00000 n 
+0000044084 00000 n 
+0000044192 00000 n 
+0000044243 00000 n 
+0000044365 00000 n 
+0000044417 00000 n 
+0000044539 00000 n 
+0000044591 00000 n 
+0000044713 00000 n 
+0000044765 00000 n 
+0000044887 00000 n 
+0000044939 00000 n 
+0000045061 00000 n 
+0000045113 00000 n 
+0000045235 00000 n 
+0000045287 00000 n 
+trailer
+<<
+/Size 461
+/Root 3 0 R
+/Info 2 0 R
+>>
+startxref
+45395
+%%EOF

--- a/tests/fixtures/sample_book.pdf
+++ b/tests/fixtures/sample_book.pdf
@@ -1,0 +1,210 @@
+%PDF-1.3
+%‚„œ”
+1 0 obj
+<<
+/Type /Pages
+/Count 10
+/Kids [ 4 0 R 5 0 R 6 0 R 7 0 R 8 0 R 9 0 R 10 0 R 11 0 R 12 0 R 13 0 R ]
+>>
+endobj
+2 0 obj
+<<
+/Producer (PyPDF2)
+>>
+endobj
+3 0 obj
+<<
+/Type /Catalog
+/Pages 1 0 R
+/Outlines 15 0 R
+>>
+endobj
+4 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+5 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+6 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+7 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+8 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+9 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+10 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+11 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+12 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+13 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 595 842 ]
+/Parent 1 0 R
+>>
+endobj
+14 0 obj
+<<
+/D [ 6 0 R /Fit ]
+/S /GoTo
+>>
+endobj
+15 0 obj
+<<
+/First 16 0 R
+/Count 4
+/Last 22 0 R
+>>
+endobj
+16 0 obj
+<<
+/A 14 0 R
+/Title (Kapitel\0401\072\040Einleitung)
+/Parent 15 0 R
+/Next 18 0 R
+>>
+endobj
+17 0 obj
+<<
+/D [ 8 0 R /Fit ]
+/S /GoTo
+>>
+endobj
+18 0 obj
+<<
+/A 17 0 R
+/Title (Kapitel\0402\072\040Grundlagen)
+/Prev 16 0 R
+/Parent 15 0 R
+/Next 20 0 R
+>>
+endobj
+19 0 obj
+<<
+/D [ 10 0 R /Fit ]
+/S /GoTo
+>>
+endobj
+20 0 obj
+<<
+/A 19 0 R
+/Title (Kapitel\0403\072\040Methodik)
+/Prev 18 0 R
+/Parent 15 0 R
+/Next 22 0 R
+>>
+endobj
+21 0 obj
+<<
+/D [ 12 0 R /Fit ]
+/S /GoTo
+>>
+endobj
+22 0 obj
+<<
+/A 21 0 R
+/Title (Kapitel\0404\072\040Ergebnisse)
+/Prev 20 0 R
+/Parent 15 0 R
+>>
+endobj
+xref
+0 23
+0000000000 65535 f 
+0000000015 00000 n 
+0000000133 00000 n 
+0000000173 00000 n 
+0000000239 00000 n 
+0000000329 00000 n 
+0000000419 00000 n 
+0000000509 00000 n 
+0000000599 00000 n 
+0000000689 00000 n 
+0000000779 00000 n 
+0000000870 00000 n 
+0000000961 00000 n 
+0000001052 00000 n 
+0000001143 00000 n 
+0000001192 00000 n 
+0000001250 00000 n 
+0000001350 00000 n 
+0000001399 00000 n 
+0000001512 00000 n 
+0000001562 00000 n 
+0000001673 00000 n 
+0000001723 00000 n 
+trailer
+<<
+/Size 23
+/Root 3 0 R
+/Info 2 0 R
+>>
+startxref
+1823
+%%EOF

--- a/tests/test_chunk_pdf.py
+++ b/tests/test_chunk_pdf.py
@@ -1,0 +1,152 @@
+"""Tests fuer scripts/chunk_pdf.py"""
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# Skript direkt laden (kein Package)
+_SCRIPT = Path(__file__).parent.parent / "scripts" / "chunk_pdf.py"
+
+# Lazy-load: Modul erst importieren wenn benoetigt, damit fehlende Datei
+# nicht alle Tests blockiert.
+_chunk_pdf = None
+
+
+def _get_module():
+    global _chunk_pdf
+    if _chunk_pdf is None:
+        spec = importlib.util.spec_from_file_location("chunk_pdf", _SCRIPT)
+        _chunk_pdf = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(_chunk_pdf)
+    return _chunk_pdf
+
+
+FIXTURE_PDF = Path(__file__).parent / "fixtures" / "sample_book.pdf"
+
+
+class TestOutlineParsing:
+    def test_extract_chapters_from_outline(self):
+        """Outline-Tree mit 4 Kapiteln korrekt parsen."""
+        m = _get_module()
+        chapters = m.extract_chapters(str(FIXTURE_PDF))
+        assert len(chapters) == 4
+        assert chapters[0]["title"] == "Kapitel 1: Einleitung"
+        assert chapters[0]["start_page"] == 2  # 0-indexed
+        assert chapters[1]["start_page"] == 4
+        assert chapters[2]["start_page"] == 6
+        assert chapters[3]["start_page"] == 8
+
+    def test_chapter_end_page_derived_from_next_start(self):
+        """end_page = naechstes Kapitel start - 1."""
+        m = _get_module()
+        chapters = m.extract_chapters(str(FIXTURE_PDF))
+        assert chapters[0]["end_page"] == 3
+        assert chapters[1]["end_page"] == 5
+        assert chapters[2]["end_page"] == 7
+        # Letztes Kapitel endet auf letzter Seite des PDFs (0-indexed: Seite 9)
+        assert chapters[3]["end_page"] == 9  # 10 Seiten insgesamt
+
+
+class TestWriteChapter:
+    def test_write_single_chapter_creates_pdf(self):
+        """write_chapter schreibt ein gueltiges PDF."""
+        from PyPDF2 import PdfReader
+        m = _get_module()
+        chapters = m.extract_chapters(str(FIXTURE_PDF))
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_path = os.path.join(tmpdir, "ch1.pdf")
+            m.write_chapter(str(FIXTURE_PDF), chapters[0], out_path)
+            assert os.path.exists(out_path)
+            reader = PdfReader(out_path)
+            assert len(reader.pages) == 2  # Seiten 2-3 (0-indexed)
+
+    def test_write_all_chapters(self):
+        """write_all_chapters erzeugt 4 Dateien."""
+        m = _get_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            paths = m.write_all_chapters(
+                str(FIXTURE_PDF), tmpdir, isbn="test-isbn"
+            )
+            assert len(paths) == 4
+            for p in paths:
+                assert os.path.exists(p)
+                assert "test-isbn" in os.path.basename(p)
+
+
+class TestTOCFallback:
+    def test_toc_fallback_for_pdf_without_outline(self, tmp_path):
+        """PDF ohne Outline-Tree: Fallback liefert leere Liste oder SystemExit(2)."""
+        from PyPDF2 import PdfWriter
+        m = _get_module()
+        writer = PdfWriter()
+        writer.add_blank_page(width=595, height=842)
+        pdf_path = str(tmp_path / "no_outline.pdf")
+        with open(pdf_path, "wb") as f:
+            writer.write(f)
+        # Kein Outline vorhanden -> Fallback -> kein TOC-Text -> SystemExit(2)
+        try:
+            chapters = m.extract_chapters(pdf_path)
+            # Falls Fallback greift und nichts findet: leere Liste unmoeglich
+            # (extract_chapters muss SystemExit werfen oder chapters zurueckgeben)
+            assert isinstance(chapters, list)
+        except SystemExit as e:
+            assert e.code == 2  # Kein TOC gefunden -> Exit 2
+
+
+class TestCLI:
+    def test_cli_toc_mode_returns_json(self):
+        """--chapter toc gibt JSON-TOC auf stdout aus."""
+        result = subprocess.run(
+            [sys.executable, str(_SCRIPT),
+             "--input", str(FIXTURE_PDF),
+             "--chapter", "toc",
+             "--output", "/dev/null"],
+            capture_output=True, text=True
+        )
+        assert result.returncode == 0, result.stderr
+        toc = json.loads(result.stdout)
+        assert len(toc) == 4
+        assert toc[0]["title"] == "Kapitel 1: Einleitung"
+
+    def test_cli_chapter_n(self, tmp_path):
+        """--chapter 1 schreibt eine Datei."""
+        out_path = str(tmp_path / "ch1.pdf")
+        result = subprocess.run(
+            [sys.executable, str(_SCRIPT),
+             "--input", str(FIXTURE_PDF),
+             "--chapter", "1",
+             "--output", out_path],
+            capture_output=True, text=True
+        )
+        assert result.returncode == 0, result.stderr
+        assert os.path.exists(out_path)
+
+    def test_cli_chapter_all(self, tmp_path):
+        """--chapter all schreibt alle 4 Kapitel."""
+        result = subprocess.run(
+            [sys.executable, str(_SCRIPT),
+             "--input", str(FIXTURE_PDF),
+             "--chapter", "all",
+             "--output", str(tmp_path),
+             "--isbn", "978-3-test"],
+            capture_output=True, text=True
+        )
+        assert result.returncode == 0, result.stderr
+        pdfs = list(tmp_path.glob("*.pdf"))
+        assert len(pdfs) == 4
+
+    def test_cli_missing_input_returns_error(self, tmp_path):
+        """Nicht-existente Eingabedatei -> returncode 1."""
+        result = subprocess.run(
+            [sys.executable, str(_SCRIPT),
+             "--input", str(tmp_path / "nope.pdf"),
+             "--chapter", "1",
+             "--output", str(tmp_path / "out.pdf")],
+            capture_output=True, text=True
+        )
+        assert result.returncode == 1

--- a/tests/test_chunk_pdf.py
+++ b/tests/test_chunk_pdf.py
@@ -150,3 +150,38 @@ class TestCLI:
             capture_output=True, text=True
         )
         assert result.returncode == 1
+
+
+LARGE_BOOK_PDF = Path(__file__).parent / "fixtures" / "large_book.pdf"
+
+
+class TestLargeBook:
+    def test_write_all_chapters_400_pages_8_chapters(self):
+        """AC1: 1 OA-Buch >= 400 Seiten -> 8 Kapitel-PDFs (8 x 55 = 440 Seiten)."""
+        from PyPDF2 import PdfReader
+
+        m = _get_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            isbn = "978-3-large-test"
+            paths = m.write_all_chapters(
+                str(LARGE_BOOK_PDF), tmpdir, isbn=isbn
+            )
+            # Genau 8 Output-Dateien
+            assert len(paths) == 8, f"Erwartet 8 Kapitel, erhalten: {len(paths)}"
+
+            # Namenskonvention: <isbn>-ch<n>.pdf (n=1..8)
+            safe_isbn = "978-3-large-test"
+            for i, p in enumerate(paths, start=1):
+                basename = os.path.basename(p)
+                assert basename == f"{safe_isbn}-ch{i}.pdf", (
+                    f"Unerwarteter Dateiname: {basename}"
+                )
+                assert os.path.exists(p), f"Datei existiert nicht: {p}"
+
+            # Gesamtseitenanzahl >= 400
+            total_pages = sum(
+                len(PdfReader(p).pages) for p in paths
+            )
+            assert total_pages >= 400, (
+                f"Gesamtseitenanzahl zu niedrig: {total_pages}"
+            )

--- a/tests/test_vault_parent.py
+++ b/tests/test_vault_parent.py
@@ -1,0 +1,157 @@
+"""Tests fuer parent_paper_id in Vault (schema, migration, db, server)."""
+import json
+import os
+import sqlite3
+import tempfile
+
+import pytest
+
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from mcp.academic_vault.db import VaultDB
+
+
+class TestParentPaperIdSchema:
+    def setup_method(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.db_path = self.tmp.name
+        self.tmp.close()
+        self.db = VaultDB(self.db_path)
+        self.db.init_schema()
+
+    def teardown_method(self):
+        os.unlink(self.db_path)
+
+    def test_parent_paper_id_column_exists(self):
+        """papers-Tabelle hat parent_paper_id-Spalte."""
+        conn = sqlite3.connect(self.db_path)
+        cols = [row[1] for row in conn.execute("PRAGMA table_info(papers)").fetchall()]
+        conn.close()
+        assert "parent_paper_id" in cols
+
+    def test_add_paper_with_parent_paper_id(self):
+        """add_paper akzeptiert parent_paper_id."""
+        # Eltern-Buch anlegen
+        self.db.add_paper(
+            paper_id="book-parent",
+            csl_json=json.dumps({"type": "book", "title": "Elternbuch"}),
+        )
+        # Kapitel mit parent_paper_id
+        self.db.add_paper(
+            paper_id="chapter-child",
+            csl_json=json.dumps({"type": "chapter", "title": "Kapitel 1"}),
+            parent_paper_id="book-parent",
+        )
+        paper = self.db.get_paper("chapter-child")
+        assert paper is not None
+        assert paper["parent_paper_id"] == "book-parent"
+
+    def test_parent_paper_id_nullable(self):
+        """parent_paper_id ist NULL wenn nicht gesetzt."""
+        self.db.add_paper(
+            paper_id="standalone",
+            csl_json=json.dumps({"type": "article-journal", "title": "Artikel"}),
+        )
+        paper = self.db.get_paper("standalone")
+        assert paper["parent_paper_id"] is None
+
+
+class TestMigrateParentPaperId:
+    def setup_method(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.db_path = self.tmp.name
+        self.tmp.close()
+        # Altes Schema ohne parent_paper_id simulieren
+        conn = sqlite3.connect(self.db_path)
+        conn.execute("""
+            CREATE TABLE papers (
+                paper_id TEXT PRIMARY KEY,
+                type TEXT NOT NULL DEFAULT 'article-journal',
+                csl_json TEXT NOT NULL,
+                added_at INTEGER NOT NULL DEFAULT 0,
+                updated_at INTEGER NOT NULL DEFAULT 0
+            )
+        """)
+        conn.commit()
+        conn.close()
+
+    def teardown_method(self):
+        os.unlink(self.db_path)
+
+    def test_add_parent_paper_id_column_idempotent(self):
+        """Migration fuegt Spalte hinzu; zweiter Lauf wirft keinen Fehler."""
+        from mcp.academic_vault.migrate import add_parent_paper_id_column
+        # Erster Lauf
+        add_parent_paper_id_column(self.db_path)
+        cols = [
+            row[1] for row in
+            sqlite3.connect(self.db_path).execute("PRAGMA table_info(papers)").fetchall()
+        ]
+        assert "parent_paper_id" in cols
+        # Zweiter Lauf: kein Fehler
+        add_parent_paper_id_column(self.db_path)
+
+
+class TestServerAddChapter:
+    def setup_method(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.db_path = self.tmp.name
+        self.tmp.close()
+
+    def teardown_method(self):
+        os.unlink(self.db_path)
+
+    def test_add_chapter_via_server(self):
+        """server.add_chapter() legt Kapitel mit parent_paper_id an."""
+        from mcp.academic_vault import server as vault_server
+        # Elternbuch anlegen
+        vault_server.add_paper(
+            self.db_path, "buch-001",
+            csl_json=json.dumps({"type": "book", "title": "Grundlagen"}),
+        )
+        # Kapitel via add_chapter
+        vault_server.add_chapter(
+            db_path=self.db_path,
+            parent_paper_id="buch-001",
+            chapter_number=1,
+            csl_json=json.dumps({"type": "chapter", "title": "Einleitung"}),
+            paper_id="buch-001-ch1",
+        )
+        paper = vault_server.get_paper(self.db_path, "buch-001-ch1")
+        assert paper is not None
+        assert paper["parent_paper_id"] == "buch-001"
+        assert paper["type"] == "chapter"
+
+    def test_server_add_paper_accepts_parent_paper_id(self):
+        """server.add_paper() akzeptiert parent_paper_id."""
+        from mcp.academic_vault import server as vault_server
+        vault_server.add_paper(
+            self.db_path, "root-book",
+            csl_json=json.dumps({"type": "book", "title": "Root"}),
+        )
+        vault_server.add_paper(
+            self.db_path, "ch-2",
+            csl_json=json.dumps({"type": "chapter", "title": "Kap 2"}),
+            parent_paper_id="root-book",
+        )
+        paper = vault_server.get_paper(self.db_path, "ch-2")
+        assert paper["parent_paper_id"] == "root-book"
+
+    def test_add_chapter_auto_sets_chapter_type(self):
+        """add_chapter setzt type=chapter automatisch wenn nicht in csl_json."""
+        from mcp.academic_vault import server as vault_server
+        vault_server.add_paper(
+            self.db_path, "buch-002",
+            csl_json=json.dumps({"type": "book", "title": "Buch Zwei"}),
+        )
+        paper_id = vault_server.add_chapter(
+            db_path=self.db_path,
+            parent_paper_id="buch-002",
+            chapter_number=2,
+            csl_json=json.dumps({"title": "Kap Zwei"}),  # kein type
+        )
+        paper = vault_server.get_paper(self.db_path, paper_id)
+        assert paper is not None
+        assert paper["type"] == "chapter"
+        assert paper["parent_paper_id"] == "buch-002"


### PR DESCRIPTION
## Summary

Chunk B der v6.1-Wave 1. Kapitel-Schnitt für Buch-PDFs + Vault parent/child-Beziehung.

- **#72 — F2.2 — Kapitel-Schnitt + Vault parent_paper_id**
- `scripts/chunk_pdf.py` — CLI mit `--chapter <n|toc|all>`, PyPDF2 Outline-Tree + TOC-Fallback
- Vault-Schema: `parent_paper_id TEXT REFERENCES papers(paper_id)` (idempotente Migration)
- `db.add_paper(parent_paper_id=...)` + `server.add_chapter()` + MCP-Tool `vault.add_chapter`
- Fixture `tests/fixtures/sample_book.pdf` (2.3 KB, 4-Kapitel-Outline)

## Closes
- #72

## Files (12)

| Datei | Δ |
|---|---|
| `scripts/chunk_pdf.py` | neu (CLI mit PyPDF2 Outline-Tree) |
| `mcp/academic_vault/schema.sql` | +parent_paper_id |
| `mcp/academic_vault/migrate.py` | +add_parent_paper_id_column (idempotent) |
| `mcp/academic_vault/db.py` | +parent_paper_id Parameter |
| `mcp/academic_vault/server.py` | +add_chapter() + MCP-Tool |
| `tests/fixtures/sample_book.pdf` | neu (4-Kapitel-Sample) |
| `tests/fixtures/create_sample_book.py` | neu (Reproduzierbarkeit) |
| `tests/test_chunk_pdf.py` | neu (9 Tests) |
| `tests/test_vault_parent.py` | neu (7 Tests) |
| `skills/citation-extraction/SKILL.md` | +Kapitel-PDF-Note → wieder entfernt (Boundary-Drift) |
| `specs/v6.1/B.md` + `B-plan.md` | mmp-Provenance |

## Test plan
- [x] `pytest tests/test_chunk_pdf.py` — 9/9 passing
- [x] `pytest tests/test_vault_parent.py` — 7/7 passing
- [x] Full suite: 216 passed, 1 preexisting failure (`test_token_reduction[chapter-writer]`)
- [ ] AC: 1 OA-Buch ≥400 S. → 8 Kapitel-PDFs (Live-Test mit echtem Buch)
- [ ] AC: Kapitel-Token-Footprint < 30k pro API-Call (Live-Messung)

## mmp metadata
- Milestone: v6.1 Wave 1, Chunk B (depends_on: [A] — A bereits gemerged)
- Spec: `specs/v6.1/B.md`
- Plan: `specs/v6.1/B-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)