### PR TITLE
fix(notebook-bundle): split-Modus respektiert output_path (kein cwd-Leak)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,9 +26,6 @@ pdfs/
 # Debug logs
 firebase-debug.log
 
-# Test artifacts (notebook-bundle output)
-/notebook-bundle-*.pdf
-
 # Secrets
 .env
 .env.local

--- a/skills/notebook-bundle/scripts/bundle.py
+++ b/skills/notebook-bundle/scripts/bundle.py
@@ -187,13 +187,17 @@ def build_bundle(
         toc_reader = PdfReader(io.BytesIO(toc_bytes))
 
         def _make_out_path(part: Optional[int] = None) -> str:
-            if output_path is not None and part is None:
-                return output_path
-            base = output_dir or os.getcwd()
             if part is None:
+                if output_path is not None:
+                    return output_path
+                base = output_dir or os.getcwd()
                 return str(Path(base) / f"notebook-bundle-{ts}.pdf")
-            else:
-                return str(Path(base) / f"notebook-bundle-{ts}-part{part}.pdf")
+            # Split-Modus: respektiere output_path-Verzeichnis und -Stem, wenn gesetzt
+            if output_path is not None:
+                p = Path(output_path)
+                return str(p.parent / f"{p.stem}-part{part}{p.suffix or '.pdf'}")
+            base = output_dir or os.getcwd()
+            return str(Path(base) / f"notebook-bundle-{ts}-part{part}.pdf")
 
         need_split = False
         part = 1

--- a/tests/test_notebook_bundle.py
+++ b/tests/test_notebook_bundle.py
@@ -94,6 +94,11 @@ class TestSplitOver500MB:
         assert len(result["output_files"]) > 1
         for f in result["output_files"]:
             assert Path(f).exists()
+            # Split-Outputs müssen im angegebenen output_path-Verzeichnis liegen,
+            # nicht im Repo-Root / cwd
+            assert Path(f).parent == tmp_path, (
+                f"Split-Output '{f}' nicht im tmp_path '{tmp_path}'"
+            )
 
 
 class TestMissingPDFSkipped:


### PR DESCRIPTION
## Summary
Folgefix zu #144 (v6.3 F9 NotebookLM-Bundle):
- `_make_out_path()` ignorierte im Split-Modus den expliziten `output_path` und fiel auf `os.getcwd()` zurück → Test-Outputs landeten im Repo-Root statt im `tmp_path`
- Fix: Wenn `output_path` gesetzt ist, werden Split-Parts als `<stem>-part<N><suffix>` im selben Verzeichnis erzeugt
- Test-Verschärfung in `test_split_produces_multiple_files`: explizite Assertion `Path(f).parent == tmp_path`
- `.gitignore`-Workaround-Eintrag entfernt — root cause behoben

## Test plan
- [x] `pytest tests/test_notebook_bundle.py -v` (6/6 grün)
- [x] `ls notebook-bundle-*.pdf` im Repo-Root nach Test-Run: leer
- [x] Verschärfter Test fängt Regression zukünftig automatisch ab

🤖 Generated with [Claude Code](https://claude.com/claude-code)