### PR TITLE
fix(ci+tests): pytest grün in frischer venv + GitHub-Actions-CI (#197, #184)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,138 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # 1. JSON-Manifeste muessen valide sein
+  manifest-validation:
+    name: Manifest-Validierung (JSON)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: jq empty auf allen Manifesten
+        run: |
+          set -euo pipefail
+          jq empty .claude-plugin/plugin.json
+          jq empty .claude-plugin/marketplace.json
+          jq empty .mcp.json
+          jq empty hooks/hooks.json
+          echo "Alle Manifeste sind valides JSON."
+
+  # 2. Hook-Quelldateien muessen syntaktisch valide sein
+  hook-syntax:
+    name: Hook-Syntax (node --check)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: node --check fuer alle .mjs-Hooks
+        run: |
+          set -euo pipefail
+          for f in hooks/*.mjs; do
+            echo "→ $f"
+            node --check "$f"
+          done
+
+  # 3. Jede Command/Agent-Datei braucht Frontmatter mit nicht-leerer description
+  frontmatter-coverage:
+    name: Frontmatter-Coverage (commands + agents)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Frontmatter + description pruefen
+        run: |
+          python3 - <<'PY'
+          import sys, glob, pathlib, re
+          bad = []
+          files = sorted(
+              glob.glob("commands/**/*.md", recursive=True)
+              + glob.glob("agents/**/*.md", recursive=True)
+          )
+          for f in files:
+              lines = pathlib.Path(f).read_text(encoding="utf-8").splitlines()
+              if not lines or lines[0].strip() != "---":
+                  bad.append((f, "kein Frontmatter (--- am Dateianfang fehlt)")); continue
+              end = next((i for i in range(1, len(lines)) if lines[i].strip() == "---"), None)
+              if end is None:
+                  bad.append((f, "kein schliessendes ---")); continue
+              fm = lines[1:end]
+              di = next((i for i, l in enumerate(fm) if re.match(r"^description\s*:", l)), None)
+              if di is None:
+                  bad.append((f, "kein description-Feld")); continue
+              val = re.match(r"^description\s*:\s*(.*)$", fm[di]).group(1).strip()
+              if val in (">", "|", ">-", "|-", ">+", "|+", ""):
+                  block = [fm[j].strip() for j in range(di + 1, len(fm)) if fm[j].strip()]
+                  if not block:
+                      bad.append((f, "description-Block leer"))
+          print(f"geprueft: {len(files)} Dateien (commands + agents)")
+          if bad:
+              print("PROBLEME:")
+              for f, why in bad:
+                  print(f"  {f}: {why}")
+              sys.exit(1)
+          print("ALLE OK — Frontmatter + nicht-leere description vorhanden")
+          PY
+
+  # 4. Schnelle Skill-Manifest- und Naming-Checks
+  skill-tests:
+    name: Skill-Manifest- & Naming-Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Python-Deps installieren
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r scripts/requirements.txt pytest
+      - name: pytest (Skills)
+        run: pytest tests/test_skills_manifest.py tests/test_skill_naming.py -v
+
+  # 5. Vollstaendige Test-Suite auf macOS + Ubuntu
+  python-tests:
+    name: pytest (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      # Hook-Tests starten .mjs-Hooks per `node` — daher zwingend noetig
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Python-Deps installieren (erster Step, vgl. #197)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r scripts/requirements.txt
+          pip install pytest pytest-cov
+      - name: Smoke-Test der Kern-Importe
+        run: python -c "import requests, httpx, anthropic, yaml, barcode, lxml"
+      - name: pytest mit Coverage
+        run: |
+          pytest tests/ -p no:cacheprovider \
+            --cov=scripts --cov=academic_vault \
+            --cov-report=term-missing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  version-match:
+    name: Manifest-Version == Tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Tag vs. plugin.json-Version vergleichen
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME#v}"
+          MANIFEST="$(jq -r '.version' .claude-plugin/plugin.json)"
+          echo "Tag:      $TAG"
+          echo "Manifest: $MANIFEST"
+          if [ "$TAG" != "$MANIFEST" ]; then
+            echo "::error::Tag ($TAG) stimmt nicht mit plugin.json version ($MANIFEST) ueberein."
+            exit 1
+          fi
+          echo "Version stimmt ueberein."

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Academic Research v6.5
 
+[![CI](https://github.com/jamski105/academic-research/actions/workflows/ci.yml/badge.svg)](https://github.com/jamski105/academic-research/actions/workflows/ci.yml)
 [![Version](https://img.shields.io/badge/version-6.5.0-blue.svg)](CHANGELOG.md)
 [![Skills](https://img.shields.io/badge/skills-23+-orange.svg)](#skills-übersicht)
-[![Tests](https://img.shields.io/badge/tests-~60%20passing-success.svg)](#entwicklung-und-evals)
+[![Tests](https://img.shields.io/badge/tests-963%20passing-success.svg)](#entwicklung-und-evals)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-8A2BE2.svg)](https://code.claude.com/docs/en/plugins)
 

--- a/academic_vault/db.py
+++ b/academic_vault/db.py
@@ -62,10 +62,27 @@ class VaultDB:
         return self._open(self.db_path)
 
     def load_vec_extension(self, conn: Optional[sqlite3.Connection] = None) -> bool:
-        """Versucht sqlite_vec Extension zu laden. Gibt True bei Erfolg zurueck."""
+        """Versucht sqlite_vec Extension zu laden. Gibt True bei Erfolg zurueck.
+
+        Python-Builds ohne ``--enable-loadable-sqlite-extensions`` (z.B. das
+        macOS-System-Python und die macOS-Builds von actions/setup-python)
+        haben ``enable_load_extension`` nicht bzw. werfen beim Aufruf. Dann ist
+        die Vektor-Suche schlicht nicht verfuegbar (optionales Feature) und
+        ``vec_available`` bleibt False — der Rest des Vault funktioniert weiter.
+        """
         vec_path = os.environ.get("SQLITE_VEC_PATH", "")
         target = conn if conn is not None else self._get_conn()
-        target.enable_load_extension(True)
+
+        if not hasattr(target, "enable_load_extension"):
+            self.vec_available = False
+            return False
+
+        try:
+            target.enable_load_extension(True)
+        except (AttributeError, sqlite3.OperationalError, sqlite3.NotSupportedError):
+            self.vec_available = False
+            return False
+
         try:
             if vec_path:
                 target.load_extension(vec_path)
@@ -75,7 +92,10 @@ class VaultDB:
         except Exception:
             self.vec_available = False
         finally:
-            target.enable_load_extension(False)
+            try:
+                target.enable_load_extension(False)
+            except Exception:
+                pass
         return self.vec_available
 
     def init_schema(self) -> None:

--- a/agents/figure-verifier.md
+++ b/agents/figure-verifier.md
@@ -1,5 +1,11 @@
 ---
 name: figure-verifier
+description: >
+  Verifiziert Figures und Tabellen in akademischen PDFs per VLM. Extrahiert
+  exakte Captions, erstellt aussagekraeftige Bildbeschreibungen (>= 50 Zeichen)
+  und schreibt bei Tabellen die Datenpunkte als JSON-Array in den Vault
+  (vault.add_figure). Aufrufen, wenn Abbildungen/Tabellen eines Papers
+  erfasst, beschrieben oder auf Datenkonsistenz geprueft werden sollen.
 model: sonnet
 color: purple
 tools:

--- a/commands/latex.md
+++ b/commands/latex.md
@@ -1,3 +1,8 @@
+---
+description: Exportiert Kapitel des aktuellen Projekts als .tex-Dateien und generiert eine biblatex-konforme .bib-Datei aus dem Vault.
+argument-hint: --kapitel <n>|all --output <datei.tex> [--bib <datei.bib>] [--template <uni>]
+---
+
 # /academic-research:latex — LaTeX-Export
 
 ## Beschreibung

--- a/hooks/onboard-project-uni-prompt.sh
+++ b/hooks/onboard-project-uni-prompt.sh
@@ -37,7 +37,12 @@ while [[ $# -gt 0 ]]; do
 done
 
 # ── Verfuegbare Profile sammeln ───────────────────────────────────────────────
-mapfile -t SLUGS < <(
+# Hinweis: 'mapfile'/'readarray' gibt es erst ab bash 4 — macOS liefert noch
+# bash 3.2 aus. Daher portable while-read-Schleife statt 'mapfile -t'.
+SLUGS=()
+while IFS= read -r _slug; do
+  [[ -n "${_slug}" ]] && SLUGS+=("${_slug}")
+done < <(
   find "${PROFILES_DIR}" -maxdepth 1 -name "*.yaml" ! -name "_*" \
     -exec basename {} .yaml \; | sort
 )

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -6,6 +6,8 @@ openpyxl>=3.1
 pandas>=2.0
 requests>=2.28.0
 lxml>=4.9.0
+# Barcode-Generierung fuer /academic-research:pickup (Skill: barcode_utils)
+python-barcode[images]>=0.15.0
 # academic-vault MCP-Server (Vault): FastMCP-SDK + Vektor-Suche-Extension
 mcp>=1.0
 sqlite-vec>=0.1.0

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -8,7 +8,7 @@
 #   4. Check: globaler browser-use Claude-Skill
 #   5. Claude-Code-Permissions via configure_permissions.py
 
-set -e
+set -euo pipefail
 
 BASE="$HOME/.academic-research"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -29,6 +29,14 @@ fi
 
 "$BASE/venv/bin/pip" install --quiet --upgrade pip
 "$BASE/venv/bin/pip" install --quiet -r "$SCRIPT_DIR/requirements.txt"
+
+# Smoke-Test: bricht laut ab, wenn der Install still fehlschlug (vgl. #197).
+# Deckt die Kern-Abhaengigkeiten ab, die Scripts/Tests zur Importzeit brauchen.
+if ! "$BASE/venv/bin/python" -c "import requests, httpx, anthropic, yaml, barcode" 2>/dev/null; then
+  echo "❌ Smoke-Test fehlgeschlagen: Kern-Module fehlen nach 'pip install'." >&2
+  echo "   Bitte erneut ausfuehren oder 'pip install -r $SCRIPT_DIR/requirements.txt' manuell pruefen." >&2
+  exit 1
+fi
 
 # Leere Seed-Dateien
 touch "$BASE/citations.bib"


### PR DESCRIPTION
## Ziel

pytest läuft in frischer venv vollständig grün, ein GitHub-Actions-Workflow führt pytest bei push/PR aus, und die Issues #197 + #184 werden geschlossen.

## Root Cause (#197)

`scripts/requirements.txt` war unvollständig: `requests` war zwar gelistet (die aktive venv war nur out-of-sync), aber **`python-barcode[images]`** — von `scripts/barcode_utils.py` zur Laufzeit gebraucht — fehlte komplett. Die alte venv hatte das Paket manuell installiert, was die Lücke verdeckte. In einer frischen venv schlug `test_barcode_generates_png` fehl (`generate_isbn_barcode` gab `None` zurück).

## Änderungen

**Tests / Setup (#197)**
- `scripts/requirements.txt`: `python-barcode[images]>=0.15.0` ergänzt
- `scripts/setup.sh`: `set -euo pipefail` + Smoke-Test (`import requests, httpx, anthropic, yaml, barcode`) — der Install scheitert jetzt **laut** statt still

**CI (#184)** — `.github/workflows/ci.yml` mit 5 Jobs:
1. `manifest-validation` — `jq empty` auf plugin/marketplace/.mcp/hooks.json
2. `hook-syntax` — `node --check` für alle `hooks/*.mjs`
3. `frontmatter-coverage` — alle `commands/*.md` + `agents/*.md` brauchen Frontmatter mit nicht-leerer `description`
4. `skill-tests` — `pytest test_skills_manifest.py test_skill_naming.py`
5. `python-tests` — volle Suite auf Matrix **ubuntu-latest + macos-latest** mit Coverage; installiert requirements als ersten Step (#197) und richtet `node` ein (Hook-Tests spawnen `.mjs`-Hooks via node)

- `.github/workflows/release.yml`: Tag-Push prüft `plugin.json`-Version == Tag
- `commands/latex.md`: fehlendes Frontmatter + `description` ergänzt
- `agents/figure-verifier.md`: fehlendes `description`-Feld ergänzt
- `README.md`: CI-Status-Badge + Test-Zahl aktualisiert

## Verifikation

Frische venv (Python **3.12** und **3.14**), auch mit leerem `HOME` (frischer-Runner-Simulation):
```
963 passed, 148 skipped, 0 failed, 0 errors
```
Die 148 Skips sind datengetrieben (fehlende `trigger_evals.json`, leere Baselines) bzw. `ANTHROPIC_API_KEY nicht gesetzt` — keine fehlenden Module.

Closes #197
Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)