### PR TITLE
fix(manifest): Version 5.4.0 -> 6.5.0, 28 Skills, v6-Keywords (#166)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,8 +9,8 @@
     {
       "name": "academic-research",
       "source": "./",
-      "description": "Modulares akademisches Forschungs-Toolkit mit 13 selbstaktivierenden Skills, 5D-Scoring, Excel-Export und KI-Stil-Erkennung.",
-      "version": "5.4.0"
+      "description": "Modulares akademisches Forschungs-Toolkit mit 28 selbstaktivierenden Skills, Vault-MCP-Server (SQLite + FTS5 + sqlite-vec), Universal Book Fetcher (8-Tier-Pipeline), humanizer-de Anti-KI-Audit, LaTeX-Export, Per-Uni-Profile, 5D-Scoring.",
+      "version": "6.5.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "academic-research",
-  "version": "5.4.0",
-  "description": "Modulares akademisches Forschungs-Toolkit mit 13 selbstaktivierenden Skills, 5D-Scoring, Excel-Export und KI-Stil-Erkennung. Durchsucht Semantic Scholar, CrossRef, OpenAlex, BASE, Google Scholar und weitere Quellen.",
+  "version": "6.5.0",
+  "description": "Modulares akademisches Forschungs-Toolkit mit 28 selbstaktivierenden Skills, Vault-MCP-Server (SQLite + FTS5 + sqlite-vec), Universal Book Fetcher (8-Tier-Pipeline), humanizer-de Anti-KI-Audit, LaTeX-Export, Per-Uni-Profile, 5D-Scoring. Durchsucht Semantic Scholar, CrossRef, OpenAlex, BASE, Google Scholar und 9 weitere wissenschaftliche Quellen.",
   "author": {
     "name": "Jonas Ahler",
     "email": "jam@ahler.org",
@@ -22,6 +22,12 @@
     "excel",
     "scoring",
     "thesis",
-    "facharbeit"
+    "facharbeit",
+    "vault",
+    "latex",
+    "bibtex",
+    "book-fetcher",
+    "humanizer",
+    "open-access"
   ]
 }

--- a/tests/test_manifest_version.py
+++ b/tests/test_manifest_version.py
@@ -1,0 +1,91 @@
+"""
+Tests für Issue #166: Manifest-Version 5.4.0 -> 6.5.0 + Description-Sync (28 Skills, v6-Features)
+
+Regressions-Tests, die sicherstellen, dass:
+- plugin.json und marketplace.json beide Version 6.5.0 deklarieren
+- plugin.json description "28" enthält
+- Beide JSON-Dateien valide sind
+"""
+
+import json
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+PLUGIN_JSON = REPO_ROOT / ".claude-plugin" / "plugin.json"
+MARKETPLACE_JSON = REPO_ROOT / ".claude-plugin" / "marketplace.json"
+
+
+def test_plugin_json_version():
+    """plugin.json muss Version 6.5.0 deklarieren."""
+    data = json.loads(PLUGIN_JSON.read_text())
+    version = data["version"]
+    assert re.match(r"^6\.5\.", version), (
+        f"plugin.json version erwartet ^6.5.x, got '{version}' — "
+        "vermutlich noch auf altem Stand (5.4.0)"
+    )
+
+
+def test_marketplace_json_version():
+    """marketplace.json plugins[0].version muss 6.5.0 deklarieren."""
+    data = json.loads(MARKETPLACE_JSON.read_text())
+    version = data["plugins"][0]["version"]
+    assert re.match(r"^6\.5\.", version), (
+        f"marketplace.json plugins[0].version erwartet ^6.5.x, got '{version}' — "
+        "vermutlich noch auf altem Stand (5.4.0)"
+    )
+
+
+def test_plugin_json_description_mentions_28_skills():
+    """plugin.json description soll '28' Skills nennen, nicht '13'."""
+    data = json.loads(PLUGIN_JSON.read_text())
+    description = data["description"]
+    assert "28" in description, (
+        f"plugin.json description enthält nicht '28': '{description}'"
+    )
+
+
+def test_plugin_json_version_matches_marketplace():
+    """Beide Manifeste müssen exakt dieselbe version tragen."""
+    plugin_data = json.loads(PLUGIN_JSON.read_text())
+    marketplace_data = json.loads(MARKETPLACE_JSON.read_text())
+    plugin_version = plugin_data["version"]
+    marketplace_version = marketplace_data["plugins"][0]["version"]
+    assert plugin_version == marketplace_version, (
+        f"Versions-Diskrepanz: plugin.json='{plugin_version}', "
+        f"marketplace.json='{marketplace_version}'"
+    )
+
+
+def test_plugin_json_keywords_contain_vault():
+    """plugin.json keywords sollen 'vault' enthalten (Issue #166 AC)."""
+    data = json.loads(PLUGIN_JSON.read_text())
+    keywords = data.get("keywords", [])
+    assert "vault" in keywords, (
+        f"'vault' fehlt in plugin.json keywords: {keywords}"
+    )
+
+
+def test_plugin_json_keywords_contain_latex():
+    """plugin.json keywords sollen 'latex' enthalten (Issue #166 AC)."""
+    data = json.loads(PLUGIN_JSON.read_text())
+    keywords = data.get("keywords", [])
+    assert "latex" in keywords, (
+        f"'latex' fehlt in plugin.json keywords: {keywords}"
+    )
+
+
+def test_plugin_json_valid_json():
+    """plugin.json muss valides JSON sein."""
+    try:
+        json.loads(PLUGIN_JSON.read_text())
+    except json.JSONDecodeError as e:
+        raise AssertionError(f"plugin.json ist kein valides JSON: {e}")
+
+
+def test_marketplace_json_valid_json():
+    """marketplace.json muss valides JSON sein."""
+    try:
+        json.loads(MARKETPLACE_JSON.read_text())
+    except json.JSONDecodeError as e:
+        raise AssertionError(f"marketplace.json ist kein valides JSON: {e}")


### PR DESCRIPTION
## Zusammenfassung

Behebt den Versions-Konflikt zwischen README/CHANGELOG (v6.5.0) und den Manifest-Dateien (v5.4.0).

- `.claude-plugin/plugin.json` `version` von `5.4.0` auf `6.5.0` angehoben
- `.claude-plugin/marketplace.json` `plugins[0].version` von `5.4.0` auf `6.5.0` angehoben
- `description` in beiden Manifesten aktualisiert: **28 Skills** (statt 13), nennt Vault-MCP-Server, Universal Book Fetcher (8-Tier-Pipeline), humanizer-de Anti-KI-Audit, LaTeX-Export, Per-Uni-Profile, 5D-Scoring
- `keywords` in plugin.json um `vault`, `latex`, `bibtex`, `book-fetcher`, `humanizer`, `open-access` erweitert (Issue #166 AC)
- Beide JSON-Dateien: `jq empty` grün

## TDD-Belege

Neuer Test: `tests/test_manifest_version.py` (8 Tests)

**Vor dem Fix (rot — 5 Failures):**
```
FAILED test_plugin_json_version          — got '5.4.0'
FAILED test_marketplace_json_version     — got '5.4.0'
FAILED test_plugin_json_description_mentions_28_skills — '28' nicht in description
FAILED test_plugin_json_keywords_contain_vault — 'vault' fehlte
FAILED test_plugin_json_keywords_contain_latex — 'latex' fehlte
5 failed, 3 passed
```

**Nach dem Fix (grün):**
```
8 passed in 0.01s
```

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)