### PR TITLE
fix(skill): doppelte ### 4.-Nummerierung in chapter-writer/SKILL.md beheben (#171)

### DIFF
--- a/skills/chapter-writer/SKILL.md
+++ b/skills/chapter-writer/SKILL.md
@@ -138,7 +138,7 @@ Bevor geschrieben wird, erstelle einen kurzen internen Plan:
 
 Plan dem User zur Freigabe vorlegen, bevor gedraftet wird.
 
-### 4. Draften
+### 5. Draften
 
 Schreibe das Kapitel Abschnitt für Abschnitt. Für jeden Abschnitt:
 
@@ -165,7 +165,7 @@ Beim Zitieren die Daten aus dem `citation-extraction`-Skill nutzen (inline-forma
 - **Zusammenfassung** — Argumentation einer Quelle verdichten, mit Zitat
 - **Synthese** — Mehrere Quellen kombinieren, um einen Punkt zu stützen
 
-### 5. User-Review-Zyklus
+### 6. User-Review-Zyklus
 
 Nach dem Vorstellen jedes Abschnittsentwurfs:
 
@@ -176,7 +176,7 @@ Nach dem Vorstellen jedes Abschnittsentwurfs:
 
 Liefert der User eigene Notizen oder Stichpunkte, bau sie zu akademischer Prosa aus und bewahre die inhaltliche Absicht.
 
-### 6. Kapitel-Zusammensetzung
+### 7. Kapitel-Zusammensetzung
 
 Nachdem alle Abschnitte reviewt und freigegeben sind:
 
@@ -186,7 +186,7 @@ Nachdem alle Abschnitte reviewt und freigegeben sind:
 4. Kapitel-Einleitung (außer bei Thesis-Einleitung) und Kapitel-Zusammenfassung ergänzen
 5. Finale Wortzahl berichten
 
-### 7. Writing-State aktualisieren
+### 8. Writing-State aktualisieren
 
 Nach der Freigabe des Kapitels durch den User:
 

--- a/tests/test_chapter_writer_headings.py
+++ b/tests/test_chapter_writer_headings.py
@@ -1,0 +1,33 @@
+"""Regression guard: chapter-writer/SKILL.md ### N. Überschriften sind eindeutig und fortlaufend."""
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+SKILL_MD = REPO_ROOT / "skills" / "chapter-writer" / "SKILL.md"
+
+# Findet alle ### N. Überschriften (z.B. ### 4. Draften)
+NUMBERED_HEADING_RE = re.compile(r"^### (\d+)\.", re.MULTILINE)
+
+
+def _extract_numbers(text: str) -> list[int]:
+    return [int(m.group(1)) for m in NUMBERED_HEADING_RE.finditer(text)]
+
+
+def test_chapter_writer_headings_unique():
+    """Keine ### N.-Nummer darf doppelt vorkommen."""
+    text = SKILL_MD.read_text(encoding="utf-8")
+    numbers = _extract_numbers(text)
+    assert len(numbers) == len(set(numbers)), (
+        f"Doppelte ### N.-Nummern in {SKILL_MD}: {numbers}"
+    )
+
+
+def test_chapter_writer_headings_sequential():
+    """### N.-Nummern müssen bei 1 starten und lückenlos aufsteigen."""
+    text = SKILL_MD.read_text(encoding="utf-8")
+    numbers = _extract_numbers(text)
+    assert numbers, f"Keine nummerierten ### N.-Überschriften in {SKILL_MD} gefunden"
+    expected = list(range(1, len(numbers) + 1))
+    assert numbers == expected, (
+        f"Nummern in {SKILL_MD} sind nicht fortlaufend: {numbers} (erwartet: {expected})"
+    )


### PR DESCRIPTION
## Zusammenfassung

Closes #171

Die zweite `### 4. Draften`-Überschrift (Zeile 141) in `skills/chapter-writer/SKILL.md` wurde auf `### 5. Draften` korrigiert. Die Folgeüberschriften wurden entsprechend von 5–7 auf 6–8 hochgezählt. Die acht Workflow-Schritte sind jetzt eindeutig und fortlaufend nummeriert (1–8).

**Geänderte Nummern:**
- `### 4. Draften` → `### 5. Draften`
- `### 5. User-Review-Zyklus` → `### 6. User-Review-Zyklus`
- `### 6. Kapitel-Zusammensetzung` → `### 7. Kapitel-Zusammensetzung`
- `### 7. Writing-State aktualisieren` → `### 8. Writing-State aktualisieren`

## TDD-Belege

Neuer Regressions-Test: `tests/test_chapter_writer_headings.py`

**Vor dem Fix (rot):**
```
FAILED tests/test_chapter_writer_headings.py::test_chapter_writer_headings_unique
  AssertionError: Doppelte ### N.-Nummern: [1, 2, 3, 4, 4, 5, 6, 7]
FAILED tests/test_chapter_writer_headings.py::test_chapter_writer_headings_sequential
  AssertionError: Nummern sind nicht fortlaufend: [1, 2, 3, 4, 4, 5, 6, 7] (erwartet: [1, 2, 3, 4, 5, 6, 7, 8])
```

**Nach dem Fix (grün):**
```
2 passed in 0.01s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)