### PR TITLE
fix(doc): README Hook-Stack korrigiert: 7 Events, SessionMid entfernt (#205)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,11 +44,13 @@ Format nach [Keep a Changelog](https://keepachangelog.com/de/1.1.0/), Versionier
 - **PRISMA-Flow (#92):** Neuer Skill `prisma-flow`. Mermaid-Diagramm + 27-Punkte-PRISMA-2020-Checkliste. Integration in `/search` (schreibt `n_identified`, `n_after_dedup`) und `relevance-scorer` (`excluded_screening`).
 - **Meta-Analysis (#150):** Neuer Agent `meta-analysis`. DerSimonian-Laird Random-Effects-Modell. Mermaid-Forest-Plot. Output via `scripts/meta_analysis.py`.
 - **Risk-of-Bias (#100):** Neuer Agent `risk-of-bias`. Cochrane RoB 2, ROBINS-I, CASP Assessment. Ergebnisse in `vault.add_risk_of_bias()`.
-- **Hooks-Stack (#91, #103):** Vier Hooks:
-  - `pre-compact.mjs`: Snapshot-Backup vor Claude-Compaction nach `~/.academic-research/snapshots/`.
-  - `post-tool-use-decisions.mjs`: Decision-Log für alle `*.md`-Schreiboperationen.
-  - `mid-session-reinforcement.mjs`: Anti-Fabrikations-Erinnerung.
-  - `verbatim-guard.mjs`: Blockt Kapitel-Writes mit nicht-verifizierten Zitaten.
+- **Hooks-Stack (#91, #103):** 7 Hook-Events (5 Skript-Dateien + 1 Inline-Bash):
+  - `pre-compact.mjs` (`PreCompact`): Snapshot-Backup vor Claude-Compaction nach `~/.academic-research/snapshots/`.
+  - `post-tool-use-decisions.mjs` (`PostToolUse(Write)`): Decision-Log für alle `*.md`-Schreiboperationen.
+  - `mid-session-reinforcement.mjs` (`Notification` + `PostCompact`): Anti-Fabrikations-Erinnerung nach ~20 Nachrichten bzw. nach Compaction.
+  - `verbatim-guard.mjs` (`PreToolUse(Write)`): Blockt Kapitel-Writes mit nicht-verifizierten Zitaten.
+  - `onboard-project-uni-prompt.sh` (`SessionStart`): Prüft Python-venv-Bereitschaft.
+  - Inline-Bash (`Stop`): Hinweis bei ungesicherten `academic_context.md`-Änderungen.
   - `/academic-research:history --restore <ts>`: Snapshot-Restore.
 - **Citation-Styles MLA/Vancouver/Springer-AD (#106):** Drei neue Varianten in `citation-extraction/references/`.
 - **CSL-JSON Import (#93):** Neuer Skill `citation-style-import`. Lädt beliebige `.csl`-Datei aus CSL-Repository, parst zu promptfähigen Regeln, speichert als `references/custom-<style>.md`.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Das Plugin kommt mit vorkonfigurierten **Per-Uni-Profilen** für Leibniz FH, TU 
 | **Material-Passport** | v6.4 | Unveränderlicher Artefakt-Passport mit Repro-Lock. |
 | **NotebookLM-Bundle** | v6.3 | PDF-Pack für manuelle NotebookLM-Uploads (Riesen-Bücher >600 Seiten). |
 | **Zotero-Import** | v6.3 | pyzotero-Pull-only mit DOI/ISBN-Dedup in den Vault. |
-| **Hooks-Stack** | v6.4 | PreCompact-Snapshot, Post-Tool-Use Decision-Log, Mid-Session-Reinforcement, Verbatim-Guard. |
+| **Hooks-Stack** | v6.4 | 7 Hook-Events: PreToolUse, PostToolUse, PreCompact, Notification, PostCompact, SessionStart, Stop. |
 | **LaTeX-Export** | v6.5 | Markdown-Kapitel → `.tex`, Bibliographie → `.bib` (biblatex DIN-1505). Per-Uni-Template-Slot. |
 | **Contextual Retrieval** | v6.5 | Hybrid BM25 + vec0 mit Reciprocal-Rank-Fusion. Anthropic-Contextual-Embedding-Cache. |
 | **Topic-Brainstorm** | v6.5 | 3-5 Kandidaten mit Feasibility/Novelty/Career-Fit-Scores + Pilot-Paper-Sets. |
@@ -558,14 +558,17 @@ Jedes Paper wird nach 5 Dimensionen bewertet (0–1):
 
 ## Hooks-Stack
 
-Das Plugin installiert vier Hooks via `hooks/hooks.json`:
+Das Plugin konfiguriert 7 Events in `hooks/hooks.json` (5 Skript-Dateien + 1 Inline-Bash):
 
-| Hook | Typ | Beschreibung |
-|------|-----|-------------|
+| Hook | Event | Beschreibung |
+|------|-------|-------------|
 | `verbatim-guard.mjs` | `PreToolUse(Write)` | Blockt Kapitel-Writes mit nicht-verifizierten Zitaten |
-| `pre-compact.mjs` | `PreCompact` | Snapshot-Backup vor Claude-Compaction |
 | `post-tool-use-decisions.mjs` | `PostToolUse(Write)` | Decision-Log: jede `.md`-Änderung wird protokolliert |
-| `mid-session-reinforcement.mjs` | `SessionMid` | Erinnerung an Anti-Fabrikations-Regeln |
+| `pre-compact.mjs` | `PreCompact` | Snapshot-Backup vor Claude-Compaction |
+| `mid-session-reinforcement.mjs` | `Notification` | Erinnerung an Anti-Fabrikations-Regeln (nach ~20 Nachrichten) |
+| `mid-session-reinforcement.mjs` | `PostCompact` | Erinnerung an Anti-Fabrikations-Regeln nach Compaction |
+| `onboard-project-uni-prompt.sh` | `SessionStart` | Prüft Python-venv-Bereitschaft beim Session-Start |
+| *(Inline-Bash)* | `Stop` | Hinweis bei ungesicherten `academic_context.md`-Änderungen |
 
 ---
 

--- a/docs/MIGRATION-v5-to-v6.md
+++ b/docs/MIGRATION-v5-to-v6.md
@@ -116,20 +116,23 @@ Nein — nicht nötig, aber auch kein Problem. Das Plugin liest sie weiterhin al
 
 ## 4. Hooks installieren
 
-v6.x installiert vier Hooks. Das Setup erledigt das automatisch. Zur manuellen Überprüfung:
+v6.x konfiguriert 7 Hook-Events (5 Skript-Dateien + 1 Inline-Bash). Das Setup erledigt das automatisch. Zur manuellen Überprüfung:
 
 ```bash
 cat ~/.claude/plugins/cache/academic-research/hooks/hooks.json
 ```
 
-Sollte vier Einträge zeigen:
+Sollte sieben Event-Einträge zeigen:
 
 | Hook | Trigger | Zweck |
 |------|---------|-------|
 | `verbatim-guard.mjs` | `PreToolUse(Write)` für `kapitel/*.md` | Zitat-Validation gegen Vault |
 | `pre-compact.mjs` | `PreCompact` | Snapshot-Backup vor Compaction |
 | `post-tool-use-decisions.mjs` | `PostToolUse(Write)` für `*.md` | Decision-Log |
-| `mid-session-reinforcement.mjs` | `SessionMid` | Anti-Fabrikations-Erinnerung |
+| `mid-session-reinforcement.mjs` | `Notification` | Anti-Fabrikations-Erinnerung (nach ~20 Nachrichten) |
+| `mid-session-reinforcement.mjs` | `PostCompact` | Anti-Fabrikations-Erinnerung nach Compaction |
+| `onboard-project-uni-prompt.sh` | `SessionStart` | Python-venv-Bereitschaft prüfen |
+| *(Inline-Bash)* | `Stop` | Hinweis bei ungesicherten `academic_context.md`-Änderungen |
 
 ### Manuelle Hook-Aktivierung
 

--- a/tests/test_readme_hook_stack_doc.py
+++ b/tests/test_readme_hook_stack_doc.py
@@ -1,0 +1,89 @@
+"""Regressions-Tests fuer README/Doku-Konsistenz des Hook-Stacks (#205).
+
+Testet:
+  (a) README enthaelt NICHT den erfundenen "SessionMid"-Event.
+  (b) Die im README genannten Hook-Events stimmen mit den real in hooks/hooks.json
+      konfigurierten Events ueberein.
+  (c) MIGRATION-v5-to-v6.md enthaelt ebenfalls kein "SessionMid".
+"""
+
+import json
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+README = REPO_ROOT / "README.md"
+HOOKS_JSON = REPO_ROOT / "hooks" / "hooks.json"
+MIGRATION_GUIDE = REPO_ROOT / "docs" / "MIGRATION-v5-to-v6.md"
+
+
+def _readme_hooks_section() -> str:
+    """Gibt den Inhalt der Hooks-Stack-Sektion aus dem README zurueck."""
+    text = README.read_text(encoding="utf-8")
+    match = re.search(r"## Hooks-Stack.*?(?=\n## |\Z)", text, re.DOTALL)
+    assert match, "README enthaelt keine '## Hooks-Stack'-Sektion"
+    return match.group(0)
+
+
+def test_readme_does_not_contain_session_mid():
+    """README darf 'SessionMid' nicht erwaehnen — dieser Event existiert nicht in Claude Code."""
+    readme_text = README.read_text(encoding="utf-8")
+    assert "SessionMid" not in readme_text, (
+        "README enthaelt den nicht-existierenden Claude-Code-Event 'SessionMid'. "
+        "Der echte Event-Name ist 'Notification' (und 'PostCompact')."
+    )
+
+
+def test_migration_guide_does_not_contain_session_mid():
+    """MIGRATION-v5-to-v6.md darf 'SessionMid' nicht erwaehnen."""
+    if not MIGRATION_GUIDE.exists():
+        import pytest
+        pytest.skip("MIGRATION-v5-to-v6.md nicht vorhanden")
+    migration_text = MIGRATION_GUIDE.read_text(encoding="utf-8")
+    assert "SessionMid" not in migration_text, (
+        "MIGRATION-v5-to-v6.md enthaelt den nicht-existierenden Event 'SessionMid'."
+    )
+
+
+def test_readme_hook_events_match_hooks_json():
+    """Die Hook-Events in der README-Tabelle muessen mit hooks/hooks.json uebereinstimmen."""
+    hooks_data = json.loads(HOOKS_JSON.read_text(encoding="utf-8"))
+    real_events = set(hooks_data["hooks"].keys())
+
+    hooks_section = _readme_hooks_section()
+
+    # Alle bekannten echten Events muessen in der Hooks-Sektion erwaehnt sein
+    for event in real_events:
+        assert event in hooks_section, (
+            f"Event '{event}' ist in hooks/hooks.json konfiguriert, "
+            f"wird aber in der README-Hooks-Stack-Sektion nicht erwaehnt."
+        )
+
+
+def test_readme_hook_count_not_four():
+    """README soll nicht mehr behaupten, es gaebe 'vier Hooks' (tatsaechlich 7 Events)."""
+    hooks_section = _readme_hooks_section()
+    assert "vier Hooks" not in hooks_section, (
+        "README behauptet noch 'vier Hooks', aber hooks/hooks.json konfiguriert 7 Events."
+    )
+
+
+def test_hooks_json_has_expected_events():
+    """hooks/hooks.json muss alle sieben erwarteten Events enthalten."""
+    hooks_data = json.loads(HOOKS_JSON.read_text(encoding="utf-8"))
+    real_events = set(hooks_data["hooks"].keys())
+
+    expected_events = {
+        "PreToolUse",
+        "PostToolUse",
+        "PreCompact",
+        "Notification",
+        "PostCompact",
+        "SessionStart",
+        "Stop",
+    }
+    assert expected_events == real_events, (
+        f"hooks.json enthaelt andere Events als erwartet.\n"
+        f"Erwartet: {sorted(expected_events)}\n"
+        f"Gefunden: {sorted(real_events)}"
+    )


### PR DESCRIPTION
## Zusammenfassung

- README-Sektion `## Hooks-Stack` komplett neu geschrieben: statt erfundenem "SessionMid"-Event und "vier Hooks" werden jetzt alle 7 echten Events aus `hooks/hooks.json` korrekt aufgeführt (PreToolUse, PostToolUse, PreCompact, Notification, PostCompact, SessionStart, Stop).
- `docs/MIGRATION-v5-to-v6.md`: Hook-Tabelle ebenfalls korrigiert, "SessionMid" entfernt, alle 7 Events ergänzt.
- `CHANGELOG.md` v6.4 Hooks-Stack-Eintrag: "Vier Hooks" → "7 Hook-Events", Events korrekt benannt.

## TDD-Belege

Neuer Test: `tests/test_readme_hook_stack_doc.py`

**Vor dem Fix (rot):**
```
FAILED test_readme_does_not_contain_session_mid
FAILED test_migration_guide_does_not_contain_session_mid
FAILED test_readme_hook_events_match_hooks_json   (Stop fehlte)
FAILED test_readme_hook_count_not_four            ("vier Hooks")
4 failed, 1 passed
```

**Nach dem Fix (grün):**
```
5 passed in 0.01s
```

## Test-Plan

- [x] `tests/test_readme_hook_stack_doc.py` — alle 5 Tests grün
- [x] `tests/test_hook_midsession.py`, `test_hook_decisions_log.py`, `test_hook_snapshot.py` — alle 23 Tests grün

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)