### PR TITLE
fix(vault): export_snapshot/restore_snapshot als @mcp.tool registrieren (#204)

### DIFF
--- a/academic_vault/server.py
+++ b/academic_vault/server.py
@@ -964,6 +964,37 @@ def _build_mcp_server():
         """Prueft ob Vault fuer Slug gelockt ist."""
         return is_locked(db_path, slug=slug)
 
+    @mcp.tool(name="vault.export_snapshot")
+    def _vault_export_snapshot(
+        slug: str,
+        project_dir: str = ".",
+        snapshots_dir: Optional[str] = None,
+    ) -> Optional[str]:
+        """Exportiert State-Dateien + Vault-DB als .tgz-Snapshot.
+
+        Schreibt <snapshots_dir>/<slug>/<YYYYMMDD-HHMM>.tgz und gibt den Pfad
+        zurueck (None bei Fehler). snapshots_dir default: ~/.academic-research/snapshots.
+        """
+        return export_snapshot(
+            db_path, slug, project_dir=project_dir, snapshots_dir=snapshots_dir
+        )
+
+    @mcp.tool(name="vault.restore_snapshot")
+    def _vault_restore_snapshot(
+        slug: str,
+        ts: str,
+        snapshots_dir: Optional[str] = None,
+        target_dir: str = ".",
+    ) -> bool:
+        """Stellt einen Snapshot zurueck: entpackt <slug>/<ts>.tgz nach target_dir.
+
+        ts ist der Timestamp-String (Dateiname ohne .tgz). Gibt True bei Erfolg,
+        False bei Fehler. snapshots_dir default: ~/.academic-research/snapshots.
+        """
+        return restore_snapshot(
+            slug, ts, snapshots_dir=snapshots_dir, target_dir=target_dir
+        )
+
     return mcp
 
 

--- a/tests/test_vault_snapshot_tools.py
+++ b/tests/test_vault_snapshot_tools.py
@@ -1,0 +1,101 @@
+"""Registrierungstests fuer die Snapshot-MCP-Tools des academic_vault-Servers.
+
+Deckt #204 ab: ``README.md`` dokumentiert ``vault.export_snapshot`` und
+``vault.restore_snapshot`` als MCP-Tools, aber die vorhandenen Funktionen
+``export_snapshot`` (server.py) und ``restore_snapshot`` waren nicht mit
+``@mcp.tool(...)`` registriert. Der Backup-/Restore-Workflow war damit ueber
+MCP nicht aufrufbar.
+
+Zwei Test-Ebenen:
+
+* AST-basiert (``test_*_decorated_in_build_block``): introspiziert den
+  ``_build_mcp_server``-Registrierungsblock der ``server.py``-Quelle und
+  prueft, dass beide Tools mit ``@mcp.tool(name="vault.export_snapshot")``
+  bzw. ``...restore_snapshot`` dekoriert sind. Funktioniert ohne installiertes
+  ``mcp``-SDK und schlaegt gegen die ungefixte ``server.py`` fehl.
+* Laufzeit-basiert (``test_*_in_tools_list``): introspiziert die
+  ``tools/list``-Antwort des frisch gebauten FastMCP-Servers, sofern das
+  ``mcp``-SDK installiert ist (sonst ``skip``).
+"""
+import asyncio
+import ast
+import importlib
+import inspect
+import sys
+from pathlib import Path
+
+import pytest
+
+# Repo-Root auf den Pfad, damit `academic_vault` (Top-Level) importierbar ist.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+
+def _registered_tool_names_from_source():
+    """Liest die ``@mcp.tool(name=...)``-Namen aus dem ``_build_mcp_server``-Block.
+
+    SDK-unabhaengig: parst die Quelle der ``server.py`` per AST und sammelt alle
+    String-Literale aus ``name=``-Keywords von ``@mcp.tool(...)``-Dekoratoren
+    innerhalb der ``_build_mcp_server``-Funktion.
+    """
+    server = importlib.import_module("academic_vault.server")
+    source = inspect.getsource(server._build_mcp_server)
+    tree = ast.parse(source)
+
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        for deco in node.decorator_list:
+            # Form: @mcp.tool(name="...")
+            if not isinstance(deco, ast.Call):
+                continue
+            func = deco.func
+            if not (isinstance(func, ast.Attribute) and func.attr == "tool"):
+                continue
+            for kw in deco.keywords:
+                if kw.arg == "name" and isinstance(kw.value, ast.Constant):
+                    names.add(kw.value.value)
+    return names
+
+
+def _registered_tool_names_from_runtime():
+    pytest.importorskip("mcp.server.fastmcp")
+    server = importlib.import_module("academic_vault.server")
+    mcp_server = server._build_mcp_server()
+    assert mcp_server is not None, (
+        "mcp SDK nicht installiert — setup.sh muss mcp>=1.0 ins venv installieren"
+    )
+    tools = asyncio.run(mcp_server.list_tools())
+    return {t.name for t in tools}
+
+
+def test_export_snapshot_decorated_in_build_block():
+    """``vault.export_snapshot`` ist im Registrierungsblock dekoriert (#204)."""
+    names = _registered_tool_names_from_source()
+    assert "vault.export_snapshot" in names, (
+        f"vault.export_snapshot nicht als @mcp.tool registriert: {sorted(names)}"
+    )
+
+
+def test_restore_snapshot_decorated_in_build_block():
+    """``vault.restore_snapshot`` ist im Registrierungsblock dekoriert (#204)."""
+    names = _registered_tool_names_from_source()
+    assert "vault.restore_snapshot" in names, (
+        f"vault.restore_snapshot nicht als @mcp.tool registriert: {sorted(names)}"
+    )
+
+
+def test_snapshot_tools_in_tools_list():
+    """Frisch gebauter Server listet beide Snapshot-Tools (#204).
+
+    Erfordert das ``mcp``-SDK; ohne SDK ``skip``.
+    """
+    names = _registered_tool_names_from_runtime()
+    assert "vault.export_snapshot" in names, (
+        f"vault.export_snapshot fehlt in tools/list: {sorted(names)}"
+    )
+    assert "vault.restore_snapshot" in names, (
+        f"vault.restore_snapshot fehlt in tools/list: {sorted(names)}"
+    )


### PR DESCRIPTION
## Problem

`README.md` (Z. 516) dokumentiert `vault.export_snapshot()` und `vault.restore_snapshot(ts)` als nutzbare MCP-Tools. Die Funktionen `export_snapshot` (`academic_vault/server.py:581`) und `restore_snapshot` (`:654`) existierten zwar, waren im `_build_mcp_server`-Registrierungsblock aber **nicht** mit `@mcp.tool(...)` dekoriert. Damit war der Backup-/Restore-Workflow ueber MCP nicht aufrufbar — README log.

## Fix

Beide Funktionen werden nun als duenne Wrapper analog zu den bestehenden Registrierungen als `@mcp.tool(name="vault.export_snapshot")` bzw. `@mcp.tool(name="vault.restore_snapshot")` registriert. Die Wrapper-Signaturen/Doku sind an die vorhandenen Funktionen angepasst; `db_path` kommt aus dem Closure. Keine Verhaltensaenderung der bestehenden Funktionen, kein Scope-Creep.

## TDD-Belege

Neuer Test `tests/test_vault_snapshot_tools.py` mit zwei Ebenen:

- **AST-basiert** (SDK-unabhaengig): introspiziert den `_build_mcp_server`-Registrierungsblock und assertet, dass beide Tools als `@mcp.tool(name=...)` dekoriert sind.
- **Laufzeit-basiert**: introspiziert die `tools/list`-Antwort des frisch gebauten FastMCP-Servers (`skip`, wenn das `mcp`-SDK nicht installiert ist).

Belege:
- **Vorher (rot):** Gegen die ungefixte `server.py` schlagen die beiden AST-Tests fehl (`vault.export_snapshot`/`vault.restore_snapshot` nicht in den registrierten Namen). Die Laufzeit-Tests werden uebersprungen, weil das `mcp`-SDK in der venv fehlt.
- **Nachher (gruen):** `tests/test_vault_snapshot_tools.py` + `tests/test_vault_server_start.py` + `tests/test_history_restore.py` -> 9 passed, 2 skipped. Gesamte Vault-Suite (`-k vault`): 133 passed, 8 skipped.

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)