### PR TITLE
fix(vault): vault.db-Pfad auf eine Quelle der Wahrheit konsolidieren (#190)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,10 @@ Thumbs.db
 sessions/
 pdfs/
 
+# Vault-Datenbank — Forschungs-PII, nie ins Repo (Issue #190, CWE-538)
+*.db
+vault.db
+
 # Debug logs
 firebase-debug.log
 

--- a/.mcp.json
+++ b/.mcp.json
@@ -5,7 +5,7 @@
       "args": ["-m", "academic_vault.server"],
       "env": {
         "PYTHONPATH": "${CLAUDE_PLUGIN_ROOT}",
-        "VAULT_DB_PATH": "${CLAUDE_PLUGIN_ROOT}/vault.db",
+        "VAULT_DB_PATH": "${HOME}/.academic-research/projects/${PWD##*/}/vault.db",
         "SQLITE_VEC_PATH": ""
       }
     }

--- a/academic_vault/db.py
+++ b/academic_vault/db.py
@@ -16,6 +16,41 @@ _SCHEMA_PATH = Path(__file__).parent / "schema.sql"
 VALID_PAPER_TYPES = frozenset({"article-journal", "book", "chapter"})
 
 
+def project_slug(cwd: Optional[str] = None) -> str:
+    """Kanonischer Projekt-Slug fuer den DB-Pfad: basename(CWD).
+
+    Eine einzige Quelle der Wahrheit (Issue #190). Hooks und MCP-Server
+    muessen denselben Algorithmus verwenden, damit alle Komponenten gegen
+    dieselbe vault.db schreiben.
+    """
+    base = Path(cwd) if cwd is not None else Path.cwd()
+    return base.name or "default"
+
+
+def default_db_path() -> str:
+    """Kanonischer Default-Pfad zur vault.db (Single Source of Truth, Issue #190).
+
+    Reihenfolge:
+      1. Falls ``VAULT_DB_PATH`` gesetzt ist, wird dieser Pfad verwendet.
+      2. Sonst ``~/.academic-research/projects/<slug>/vault.db`` mit
+         ``slug = basename(CWD)``.
+
+    Bewusst NICHT das CWD direkt ("vault.db") und NICHT das Plugin-Verzeichnis
+    (``CLAUDE_PLUGIN_ROOT``/``REPO_ROOT``), um Datenverlust bei Plugin-Updates
+    und das versehentliche Committen von Forschungs-PII zu vermeiden (CWE-538).
+    """
+    env = os.environ.get("VAULT_DB_PATH")
+    if env:
+        return env
+    return str(
+        Path.home()
+        / ".academic-research"
+        / "projects"
+        / project_slug()
+        / "vault.db"
+    )
+
+
 class VaultDB:
     """SQLite-Datenbankzugriff fuer den academic_vault MCP-Server."""
 

--- a/academic_vault/server.py
+++ b/academic_vault/server.py
@@ -12,11 +12,12 @@ from pathlib import Path
 from uuid import uuid4
 from typing import Optional
 
-from .db import VaultDB
+from .db import VaultDB, default_db_path
 from .files_api import FilesAPIClient
 
-# VAULT_DB_PATH aus Env; Fallback auf vault.db im CWD
-_DEFAULT_DB = os.environ.get("VAULT_DB_PATH", "vault.db")
+# Kanonischer DB-Default (Single Source of Truth, Issue #190):
+# VAULT_DB_PATH aus Env, sonst ~/.academic-research/projects/<slug>/vault.db.
+_DEFAULT_DB = default_db_path()
 _ANTHROPIC_KEY = os.environ.get("ANTHROPIC_API_KEY", "")
 
 

--- a/hooks/mid-session-reinforcement.mjs
+++ b/hooks/mid-session-reinforcement.mjs
@@ -20,7 +20,7 @@
 
 import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { dirname, join, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -29,8 +29,12 @@ const HOOK_DIR = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = dirname(HOOK_DIR);
 const VAULT_SRC = REPO_ROOT;
 
+// Kanonischer DB-Default (Single Source of Truth, Issue #190):
+// VAULT_DB_PATH aus Env, sonst ~/.academic-research/projects/<slug>/vault.db
+// mit slug=basename(CWD). Kein hart kodierter 'default'-Bucket mehr.
+const SLUG = basename(process.env.CLAUDE_PROJECT_DIR || process.cwd()) || 'default';
 const VAULT_DB = process.env.VAULT_DB_PATH
-  || join(os.homedir(), '.academic-research', 'projects', 'default', 'vault.db');
+  || join(os.homedir(), '.academic-research', 'projects', SLUG, 'vault.db');
 
 const STATE_FILE = process.env.ACADEMIC_REINFORCEMENT_STATE
   || join(os.homedir(), '.academic-research', 'reinforcement-state.json');

--- a/hooks/pre-compact.mjs
+++ b/hooks/pre-compact.mjs
@@ -41,8 +41,12 @@ const SNAPSHOTS_DIR = process.env.ACADEMIC_SNAPSHOTS_DIR
   || join(os.homedir(), '.academic-research', 'snapshots');
 const SLUG = process.env.ACADEMIC_PROJECT_SLUG || 'default';
 const PROJECT_DIR = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+// Kanonischer DB-Default (Single Source of Truth, Issue #190):
+// VAULT_DB_PATH aus Env, sonst ~/.academic-research/projects/<slug>/vault.db
+// mit slug=basename(CWD) — identisch zu den anderen Hooks und dem MCP-Server.
+const DB_SLUG = basename(PROJECT_DIR) || 'default';
 const VAULT_DB = process.env.VAULT_DB_PATH
-  || join(os.homedir(), '.academic-research', 'projects', SLUG, 'vault.db');
+  || join(os.homedir(), '.academic-research', 'projects', DB_SLUG, 'vault.db');
 const VAULT_SRC = REPO_ROOT;
 
 // Zu sichernde State-Dateien (relativ zu PROJECT_DIR)

--- a/hooks/verbatim-guard.mjs
+++ b/hooks/verbatim-guard.mjs
@@ -17,8 +17,9 @@
 
 import { execFileSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
-import { join, dirname } from 'node:path';
+import { join, dirname, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import * as os from 'node:os';
 
 // ---------------------------------------------------------------------------
 // Konfiguration
@@ -27,7 +28,12 @@ import { fileURLToPath } from 'node:url';
 const HOOK_DIR = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = dirname(HOOK_DIR);
 const VAULT_SRC = REPO_ROOT;
-const VAULT_DB = process.env.VAULT_DB_PATH || join(REPO_ROOT, 'vault.db');
+// Kanonischer DB-Default (Single Source of Truth, Issue #190):
+// VAULT_DB_PATH aus Env, sonst ~/.academic-research/projects/<slug>/vault.db
+// mit slug=basename(CWD). NICHT mehr REPO_ROOT/vault.db (= Plugin-Verzeichnis).
+const SLUG = basename(process.env.CLAUDE_PROJECT_DIR || process.cwd()) || 'default';
+const VAULT_DB = process.env.VAULT_DB_PATH
+  || join(os.homedir(), '.academic-research', 'projects', SLUG, 'vault.db');
 // Mindestlänge eines Zitat-Spans (in Zeichen). Muss mit den Regex-Quantifizierern übereinstimmen.
 const MIN_QUOTE_LEN = 10;
 // Pattern fuer Figure-Referenzen (Abb., Abbildung, Tab., Tabelle, Fig., Figure + Nummer)

--- a/scripts/bootstrap/gitignore.fragment
+++ b/scripts/bootstrap/gitignore.fragment
@@ -5,3 +5,6 @@ sessions/
 credentials.json
 .DS_Store
 .claude/settings.local.json
+# Vault-Datenbank — Forschungs-PII, nie ins Repo (Issue #190)
+*.db
+vault.db

--- a/tests/test_vault_db_path_consistency.py
+++ b/tests/test_vault_db_path_consistency.py
@@ -1,0 +1,107 @@
+"""Tests fuer Issue #190 — vault.db-Pfad-Konsistenz.
+
+Stellt sicher:
+  (a) .gitignore (Repo-Wurzel) UND das Bootstrap-Fragment ignorieren *.db / vault.db,
+      damit keine Forschungs-PII versehentlich committet wird (CWE-538).
+  (b) Es gibt genau EINE kanonische Quelle der Wahrheit fuer den DB-Default:
+      academic_vault.db.default_db_path(). Der MCP-Server (server.py) leitet
+      seinen Default davon ab, und der Default zeigt NICHT mehr ins CWD oder
+      ins Plugin-Verzeichnis, sondern nach ~/.academic-research/projects/<slug>/vault.db.
+
+TDD: Diese Tests schlagen gegen den Zustand auf origin/main fehl, weil dort
+weder .gitignore noch das Fragment *.db ignorieren und es keine zentrale
+default_db_path()-Funktion gibt (server.py:19 nutzt hart "vault.db" im CWD).
+"""
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+# ---------------------------------------------------------------------------
+# (a) .gitignore — vault.db / *.db duerfen nicht ins Repo gelangen
+# ---------------------------------------------------------------------------
+
+def _matches_db_pattern(lines: list[str]) -> bool:
+    """True, wenn irgendeine .gitignore-Zeile vault.db bzw. *.db erfasst."""
+    db_patterns = {"*.db", "vault.db", "**/*.db", "*.db*"}
+    return any(ln.strip() in db_patterns for ln in lines)
+
+
+def test_repo_gitignore_ignores_db_files():
+    gitignore = REPO_ROOT / ".gitignore"
+    assert gitignore.exists(), ".gitignore fehlt in der Repo-Wurzel"
+    lines = gitignore.read_text(encoding="utf-8").splitlines()
+    assert _matches_db_pattern(lines), (
+        ".gitignore muss ein Pattern enthalten, das vault.db/*.db ignoriert "
+        "(Forschungs-PII darf nicht committet werden — CWE-538)."
+    )
+
+
+def test_bootstrap_gitignore_fragment_ignores_db_files():
+    fragment = REPO_ROOT / "scripts" / "bootstrap" / "gitignore.fragment"
+    assert fragment.exists(), "bootstrap/gitignore.fragment fehlt"
+    lines = fragment.read_text(encoding="utf-8").splitlines()
+    assert _matches_db_pattern(lines), (
+        "Das Bootstrap-Fragment muss vault.db/*.db ignorieren, damit "
+        "bootstrappte Projekte ihre DB nicht versehentlich committen."
+    )
+
+
+# ---------------------------------------------------------------------------
+# (b) Single Source of Truth fuer den DB-Default
+# ---------------------------------------------------------------------------
+
+def test_canonical_resolver_exists():
+    from academic_vault import db
+
+    assert hasattr(db, "default_db_path"), (
+        "academic_vault.db muss eine kanonische Resolver-Funktion "
+        "default_db_path() exportieren (Single Source of Truth)."
+    )
+
+
+def test_canonical_resolver_respects_env(monkeypatch):
+    from academic_vault import db
+
+    monkeypatch.setenv("VAULT_DB_PATH", "/tmp/explicit/vault.db")
+    assert db.default_db_path() == "/tmp/explicit/vault.db"
+
+
+def test_canonical_resolver_default_is_under_home_projects(monkeypatch, tmp_path):
+    """Ohne VAULT_DB_PATH liegt der Default unter ~/.academic-research/projects/<slug>/vault.db
+    und NICHT im CWD oder im Plugin-Verzeichnis."""
+    from academic_vault import db
+
+    monkeypatch.delenv("VAULT_DB_PATH", raising=False)
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+
+    workdir = tmp_path / "meine-facharbeit"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+
+    resolved = Path(db.default_db_path())
+    expected = fake_home / ".academic-research" / "projects" / "meine-facharbeit" / "vault.db"
+    assert resolved == expected, f"erwartet {expected}, war {resolved}"
+    # Darf nicht im CWD und nicht im Plugin-Repo liegen
+    assert Path(resolved).parent != workdir
+    assert REPO_ROOT not in Path(resolved).parents
+
+
+def test_server_default_derives_from_canonical_resolver(monkeypatch):
+    """server.py darf den Default nicht mehr hart als 'vault.db' (CWD) setzen,
+    sondern muss ihn aus dem kanonischen Resolver ableiten."""
+    src = (REPO_ROOT / "academic_vault" / "server.py").read_text(encoding="utf-8")
+    # Kein hart kodierter CWD-Fallback "vault.db" mehr als Default-Quelle.
+    assert 'os.environ.get("VAULT_DB_PATH", "vault.db")' not in src, (
+        "server.py darf den CWD-Fallback 'vault.db' nicht mehr verwenden; "
+        "muss default_db_path() referenzieren."
+    )
+    assert "default_db_path" in src, (
+        "server.py muss die kanonische default_db_path()-Funktion verwenden."
+    )


### PR DESCRIPTION
Closes #190

## Problem

Der Pfad zur `vault.db` war ueber 5 Stellen inkonsistent definiert. Ohne gesetztes `VAULT_DB_PATH` schrieb jede Komponente gegen eine andere DB (Datenverlust / Lesen aus falscher Quelle), und `${CLAUDE_PLUGIN_ROOT}/vault.db` legte Forschungs-PII im Plugin-Repo ab, das bei Plugin-Updates ueberschrieben werden kann (CWE-538).

## Fix

Single Source of Truth: neue Funktion `academic_vault.db.default_db_path()`.
- Reihenfolge: `VAULT_DB_PATH` (Env) -> sonst `~/.academic-research/projects/<slug>/vault.db` mit `slug = basename(CWD)`.
- Bewusst NICHT das CWD direkt und NICHT das Plugin-Verzeichnis.

Alle anderen Stellen leiten davon ab bzw. spiegeln denselben Algorithmus:

| Datei | vorher | nachher |
|---|---|---|
| `academic_vault/server.py:19` | `os.environ.get("VAULT_DB_PATH", "vault.db")` (CWD) | `default_db_path()` |
| `hooks/verbatim-guard.mjs:30` | Fallback `REPO_ROOT/vault.db` (Plugin-Dir) | `~/.academic-research/projects/<slug>/vault.db` |
| `hooks/mid-session-reinforcement.mjs:33` | `'default'`-Bucket | `slug = basename(CWD)` |
| `hooks/pre-compact.mjs:44` | VAULT_DB-Fallback an `ACADEMIC_PROJECT_SLUG` gekoppelt | `slug = basename(CWD)` (Snapshot-SLUG unveraendert) |
| `.mcp.json:8` | `${CLAUDE_PLUGIN_ROOT}/vault.db` | `${HOME}/.academic-research/projects/${PWD##*/}/vault.db` |

Plus `.gitignore` und `scripts/bootstrap/gitignore.fragment`: ignorieren jetzt `*.db` / `vault.db` (auf main fehlte das komplett).

## TDD-Belege

Test: `tests/test_vault_db_path_consistency.py` (6 Tests)
- Vorher (origin/main): **6 rot** — keine `default_db_path()`-Funktion, `server.py` nutzt hart `"vault.db"`, weder `.gitignore` noch das Fragment matchen `*.db`.
- Nachher: **6 gruen**.
- Abgedeckte Eigenschaften: (a) `.gitignore` + Bootstrap-Fragment matchen `vault.db`/`*.db`; (b) `default_db_path()` existiert, respektiert `VAULT_DB_PATH`, liefert sonst `~/.academic-research/projects/<slug>/vault.db` (nicht CWD/Plugin-Dir); (c) `server.py` leitet aus dem Resolver ab.

Regression: betroffene Bestandstests gruen — `tests/test_vault_parent.py`, `test_vault_book_chapter.py`, `test_vault_score_history.py`, `test_history_restore.py`, `test_hook_midsession.py`, `test_hook_snapshot.py`, `test_project_bootstrap.py`. Gesamtsuite: 968 passed, 149 skipped. `jq empty .mcp.json` + `node --check` auf alle 3 geaenderten Hooks gruen.

## Hinweis (Scope)

Migrations-Pfad fuer User mit bestehender `${CLAUDE_PLUGIN_ROOT}/vault.db` (move + symlink-fallback, Akzeptanzkriterium 6) ist bewusst NICHT Teil dieses fokussierten PRs und sollte als Folge-Issue behandelt werden. Dieser PR adressiert die Pfad-Konsolidierung + .gitignore-Schutz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
