### PR TITLE
fix(security): verbatim-guard + decision-log auch bei Edit/MultiEdit (#220)

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -2,7 +2,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Write",
+        "matcher": "Write|Edit|MultiEdit",
         "hooks": [
           {
             "type": "command",
@@ -14,7 +14,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Write",
+        "matcher": "Write|Edit|MultiEdit",
         "hooks": [
           {
             "type": "command",

--- a/hooks/post-tool-use-decisions.mjs
+++ b/hooks/post-tool-use-decisions.mjs
@@ -29,6 +29,25 @@ const DEFAULT_LOG = path.join(os.homedir(), '.academic-research', 'decisions.log
 const DECISIONS_LOG = process.env.ACADEMIC_DECISIONS_LOG || DEFAULT_LOG;
 const PROJECT_DIR = process.env.CLAUDE_PROJECT_DIR || process.cwd();
 
+// Tools die Dateiinhalte schreiben und daher protokolliert werden (#220).
+const WRITE_LIKE_TOOLS = new Set(['Write', 'Edit', 'MultiEdit']);
+
+/**
+ * Extrahiert den geschriebenen Text aus tool_input — abhaengig vom Tool:
+ *   - Write:     tool_input.content
+ *   - Edit:      tool_input.new_string
+ *   - MultiEdit: alle edits[].new_string (zusammengefuegt)
+ */
+function extractContent(toolName, toolInput) {
+  if (toolName === 'MultiEdit' && Array.isArray(toolInput.edits)) {
+    return toolInput.edits.map((e) => (e && e.new_string) || '').join('\n');
+  }
+  if (toolName === 'Edit') {
+    return toolInput.new_string || '';
+  }
+  return toolInput.content || '';
+}
+
 // ---------------------------------------------------------------------------
 // Stdin lesen
 // ---------------------------------------------------------------------------
@@ -68,9 +87,9 @@ function isMdInProject(filePath) {
 
 /**
  * Schreibt eine Zeile in decisions.log.
- * Format: ISO-Timestamp | Write | <relativer-Pfad> | <Δ-Summary>
+ * Format: ISO-Timestamp | <Tool> | <relativer-Pfad> | <Δ-Summary>
  */
-function writeLogLine(filePath, content) {
+function writeLogLine(toolName, filePath, content) {
   const ts = new Date().toISOString();
 
   // Relativer Pfad wenn moeglich
@@ -85,7 +104,7 @@ function writeLogLine(filePath, content) {
   const firstLine = (content || '').split('\n')[0].slice(0, 60).trim();
   const delta = firstLine || '<leer>';
 
-  const line = `${ts} | Write | ${relPath} | ${delta}\n`;
+  const line = `${ts} | ${toolName} | ${relPath} | ${delta}\n`;
 
   try {
     // Log-Verzeichnis sicherstellen
@@ -115,22 +134,22 @@ async function main() {
     process.exit(0);
   }
 
-  // Nur Write-Events
+  // Schreibende Tool-Events protokollieren: Write, Edit, MultiEdit (#220)
   const toolName = input?.tool_name || input?.hook_event_name || '';
-  if (toolName !== 'Write') {
+  if (!WRITE_LIKE_TOOLS.has(toolName)) {
     process.exit(0);
   }
 
   const toolInput = input?.tool_input || {};
   const filePath = toolInput.file_path || '';
-  const content = toolInput.content || '';
+  const content = extractContent(toolName, toolInput);
 
   // Nur .md-Dateien im Projekt
   if (!isMdInProject(filePath)) {
     process.exit(0);
   }
 
-  writeLogLine(filePath, content);
+  writeLogLine(toolName, filePath, content);
   process.exit(0);
 }
 

--- a/hooks/verbatim-guard.mjs
+++ b/hooks/verbatim-guard.mjs
@@ -66,6 +66,30 @@ function isProtectedPath(filePath) {
 }
 
 // ---------------------------------------------------------------------------
+// Tool-Erkennung + Content-Extraktion
+// ---------------------------------------------------------------------------
+
+// Tools die Dateiinhalte schreiben und daher geprueft werden muessen (#220).
+const WRITE_LIKE_TOOLS = new Set(['Write', 'Edit', 'MultiEdit']);
+
+/**
+ * Extrahiert den zu pruefenden Text aus tool_input — abhaengig vom Tool:
+ *   - Write:     tool_input.content
+ *   - Edit:      tool_input.new_string
+ *   - MultiEdit: alle edits[].new_string (zusammengefuegt)
+ */
+function extractContent(toolName, toolInput) {
+  if (toolName === 'MultiEdit' && Array.isArray(toolInput.edits)) {
+    return toolInput.edits.map((e) => e?.new_string || '').join('\n');
+  }
+  if (toolName === 'Edit') {
+    return toolInput.new_string || '';
+  }
+  // Write (und Fallback)
+  return toolInput.content || '';
+}
+
+// ---------------------------------------------------------------------------
 // Quote-Parser
 // ---------------------------------------------------------------------------
 
@@ -194,15 +218,15 @@ async function main() {
     process.exit(0);
   }
 
-  // Nur Write-Tool-Calls pruefen
+  // Schreibende Tool-Calls pruefen: Write, Edit, MultiEdit (#220)
   const toolName = input?.tool_name || input?.hook_event_name || '';
-  if (toolName !== 'Write') {
+  if (!WRITE_LIKE_TOOLS.has(toolName)) {
     process.exit(0);
   }
 
   const toolInput = input?.tool_input || {};
   const filePath = toolInput.file_path || '';
-  const content = toolInput.content || '';
+  const content = extractContent(toolName, toolInput);
 
   // Pfad-Match
   if (!isProtectedPath(filePath)) {

--- a/tests/test_hook_decisions_log.py
+++ b/tests/test_hook_decisions_log.py
@@ -152,3 +152,71 @@ def test_hook_appends_multiple_writes(tmp_path):
 
     lines = [l for l in log_file.read_text().strip().splitlines() if l.strip()]
     assert len(lines) >= 3, f"Erwartet 3 Log-Zeilen, got {len(lines)}: {lines}"
+
+
+# ---------------------------------------------------------------------------
+# Regression #220: Edit/MultiEdit duerfen verbatim-guard + decision-log
+# nicht umgehen. Der Hook muss auch bei Edit (new_string) und MultiEdit
+# (edits[].new_string) eine Log-Zeile schreiben.
+# ---------------------------------------------------------------------------
+
+
+def test_hook_logs_md_edit(tmp_path):
+    """Regression #220: Edit-Event auf *.md erzeugt eine Log-Zeile.
+
+    Edit-Tool-Input hat kein 'content', sondern old_string/new_string.
+    """
+    log_file = tmp_path / "decisions.log"
+    md_file = tmp_path / "kapitel" / "kap1.md"
+    md_file.parent.mkdir(parents=True)
+
+    payload = {
+        "tool_name": "Edit",
+        "tool_input": {
+            "file_path": str(md_file),
+            "old_string": "alter Absatz",
+            "new_string": "# Kapitel 1\nNeu eingefuegter Absatz",
+        },
+    }
+    env_overrides = {
+        "ACADEMIC_DECISIONS_LOG": str(log_file),
+        "CLAUDE_PROJECT_DIR": str(tmp_path),
+    }
+
+    result = run_hook(payload, env_overrides=env_overrides)
+    assert result.returncode == 0, f"Erwartet 0, got {result.returncode}. stderr: {result.stderr}"
+
+    assert log_file.exists(), "decisions.log wurde bei Edit nicht erstellt (Hook umgangen)"
+    lines = [l for l in log_file.read_text().strip().splitlines() if l.strip()]
+    assert len(lines) >= 1, f"Erwartet >=1 Log-Zeile bei Edit, got {len(lines)}"
+    assert "kap1.md" in lines[0], f"Dateiname fehlt in: {lines[0]}"
+
+
+def test_hook_logs_md_multiedit(tmp_path):
+    """Regression #220: MultiEdit-Event auf *.md erzeugt eine Log-Zeile."""
+    log_file = tmp_path / "decisions.log"
+    md_file = tmp_path / "kapitel" / "kap2.md"
+    md_file.parent.mkdir(parents=True)
+
+    payload = {
+        "tool_name": "MultiEdit",
+        "tool_input": {
+            "file_path": str(md_file),
+            "edits": [
+                {"old_string": "a", "new_string": "# Kapitel 2\nErster Block"},
+                {"old_string": "b", "new_string": "Zweiter Block"},
+            ],
+        },
+    }
+    env_overrides = {
+        "ACADEMIC_DECISIONS_LOG": str(log_file),
+        "CLAUDE_PROJECT_DIR": str(tmp_path),
+    }
+
+    result = run_hook(payload, env_overrides=env_overrides)
+    assert result.returncode == 0, f"Erwartet 0, got {result.returncode}. stderr: {result.stderr}"
+
+    assert log_file.exists(), "decisions.log wurde bei MultiEdit nicht erstellt (Hook umgangen)"
+    lines = [l for l in log_file.read_text().strip().splitlines() if l.strip()]
+    assert len(lines) >= 1, f"Erwartet >=1 Log-Zeile bei MultiEdit, got {len(lines)}"
+    assert "kap2.md" in lines[0], f"Dateiname fehlt in: {lines[0]}"

--- a/tests/test_verbatim_figure_guard.py
+++ b/tests/test_verbatim_figure_guard.py
@@ -150,3 +150,98 @@ def test_existing_quote_check_still_works(tmp_path):
         env_overrides={"VAULT_DB_PATH": db_path},
     )
     assert result.returncode == 2, f"Erwartet exit 2 (Quote-Block), got {result.returncode}"
+
+
+# ---------------------------------------------------------------------------
+# Regression #220: Edit/MultiEdit duerfen verbatim-guard nicht umgehen.
+# Edit-Tool-Input traegt den neuen Text in new_string; MultiEdit in
+# edits[].new_string. Der Guard muss diese Pfade ebenso pruefen wie Write.
+# ---------------------------------------------------------------------------
+
+
+def run_hook_raw(payload: dict, env_overrides: dict = None) -> subprocess.CompletedProcess:
+    """Startet den Hook mit beliebiger Payload (fuer Edit/MultiEdit-Shape)."""
+    env = os.environ.copy()
+    env["VAULT_DB_PATH"] = str(WORKTREE_ROOT / "nonexistent_vault_for_tests.db")
+    if env_overrides:
+        env.update(env_overrides)
+    return subprocess.run(
+        ["node", str(HOOK_PATH)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=15,
+    )
+
+
+def _empty_vault(tmp_path, name="empty_vault.db"):
+    sys.path.insert(0, str(WORKTREE_ROOT))
+    from academic_vault.db import VaultDB
+    from academic_vault.server import add_paper
+
+    db_path = str(tmp_path / name)
+    db = VaultDB(db_path)
+    db.init_schema()
+    add_paper(
+        db_path=db_path,
+        paper_id="paper-001",
+        csl_json=json.dumps({"title": "Test", "type": "article-journal"}),
+    )
+    return db_path
+
+
+def test_hook_blocks_unverified_quote_on_edit(tmp_path):
+    """Regression #220: Edit auf kapitel/*.md mit unverifiziertem Zitat -> Block (exit 2)."""
+    db_path = _empty_vault(tmp_path)
+    payload = {
+        "tool_name": "Edit",
+        "tool_input": {
+            "file_path": "kapitel/kap1.md",
+            "old_string": "Platzhalter",
+            "new_string": 'Laut dem Autor "Dies ist ein sehr wichtiger Satz aus dem Buch" stimmt das.',
+        },
+    }
+    result = run_hook_raw(payload, env_overrides={"VAULT_DB_PATH": db_path})
+    assert result.returncode == 2, (
+        f"Edit umgeht verbatim-guard: erwartet exit 2 (block), got {result.returncode}. "
+        f"stderr: {result.stderr}"
+    )
+
+
+def test_hook_blocks_unverified_quote_on_multiedit(tmp_path):
+    """Regression #220: MultiEdit auf *.tex mit unverifiziertem Zitat -> Block (exit 2)."""
+    db_path = _empty_vault(tmp_path, "empty_vault2.db")
+    payload = {
+        "tool_name": "MultiEdit",
+        "tool_input": {
+            "file_path": "kapitel/kap1.tex",
+            "edits": [
+                {"old_string": "x", "new_string": "Harmloser Text ohne Zitat."},
+                {
+                    "old_string": "y",
+                    "new_string": 'Er schrieb "Dies ist ein sehr wichtiger Satz aus dem Buch" woertlich.',
+                },
+            ],
+        },
+    }
+    result = run_hook_raw(payload, env_overrides={"VAULT_DB_PATH": db_path})
+    assert result.returncode == 2, (
+        f"MultiEdit umgeht verbatim-guard: erwartet exit 2 (block), got {result.returncode}. "
+        f"stderr: {result.stderr}"
+    )
+
+
+def test_hook_allows_clean_edit(tmp_path):
+    """Edit ohne Zitat/Figure-Referenz wird durchgelassen (exit 0)."""
+    db_path = _empty_vault(tmp_path, "empty_vault3.db")
+    payload = {
+        "tool_name": "Edit",
+        "tool_input": {
+            "file_path": "kapitel/kap1.md",
+            "old_string": "alt",
+            "new_string": "Ein voellig unauffaelliger Absatz ohne Zitate.",
+        },
+    }
+    result = run_hook_raw(payload, env_overrides={"VAULT_DB_PATH": db_path})
+    assert result.returncode == 0, f"Erwartet 0, got {result.returncode}. stderr: {result.stderr}"


### PR DESCRIPTION
## Problem

`hooks/hooks.json` matchte für `PreToolUse` (verbatim-guard) und `PostToolUse` (decision-log) nur das Tool `Write`. Da `Edit` (und `MultiEdit`) eigenständige Tool-Namen sind und ebenfalls Dateiinhalte schreiben, umging jeder `Edit`-Aufruf auf `kapitel/*.md` oder `*.tex` den Verbatim-Guard vollständig (unbelegte Zitate wurden nicht geblockt) und wurde nicht im `decisions.log` erfasst. Das hebelte die zentrale Halluzinationsschutz-Garantie aus.

Zusätzlich hätte eine reine Matcher-Erweiterung nicht gereicht: beide `.mjs`-Skripte filterten intern hart auf `toolName !== 'Write'` und kennen das `Edit`/`MultiEdit`-Input-Schema (`new_string` statt `content`) nicht.

## Fix

- `hooks/hooks.json`: Matcher beider Hooks von `"Write"` auf `"Write|Edit|MultiEdit"` erweitert.
- `hooks/verbatim-guard.mjs` und `hooks/post-tool-use-decisions.mjs`: akzeptieren nun `Write`, `Edit` und `MultiEdit` und extrahieren den geprüften Inhalt aus dem jeweiligen `tool_input` (`content` / `new_string` / `edits[].new_string`).
- `decisions.log` protokolliert jetzt den tatsächlichen Tool-Namen statt hartkodiert `Write`.

## TDD-Belege

Neue Regressionstests in `tests/test_hook_decisions_log.py` und `tests/test_verbatim_figure_guard.py`:

- `test_hook_logs_md_edit`, `test_hook_logs_md_multiedit` (decision-log)
- `test_hook_blocks_unverified_quote_on_edit`, `test_hook_blocks_unverified_quote_on_multiedit`, `test_hook_allows_clean_edit` (verbatim-guard)

Vor dem Fix (Write-only-Code): 4 der 5 neuen Tests **rot** — Edit/MultiEdit lieferten `exit 0` statt `exit 2` (Guard umgangen) bzw. schrieben keine Log-Zeile.

Nach dem Fix: gesamte Hook-Suite **grün** — `tests/test_hook_decisions_log.py` + `tests/test_verbatim_figure_guard.py` → 17 passed; `tests/test_hook_midsession.py` + `tests/test_hook_snapshot.py` → 12 passed.

Validierung: `jq empty hooks/hooks.json` OK, `node --check` für beide `.mjs` OK.

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)