### PR TITLE
fix(skill): Tippfehler 'Konferenz create' in conference-poster korrigieren (#179)

### DIFF
--- a/skills/conference-poster/SKILL.md
+++ b/skills/conference-poster/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: conference-poster
-description: Use this skill when the user needs to create a conference poster / Konferenz-Poster. Triggers on "Poster für Konferenz erstellen / Poster fuer Konferenz create", "A0-Poster", "tikzposter", "conference poster", or when a visual research summary for a conference is needed. Erstellt A0-Poster aus Kapiteln + Top-Figures; für vollständige Kapitel → `chapter-writer`.
+description: Use this skill when the user needs to create a conference poster / Konferenz-Poster. Triggers on "Poster für Konferenz erstellen / create conference poster", "A0-Poster", "tikzposter", "conference poster", or when a visual research summary for a conference is needed. Erstellt A0-Poster aus Kapiteln + Top-Figures; für vollständige Kapitel → `chapter-writer`.
 license: MIT
 ---
 

--- a/tests/test_issue_179_conference_poster_typo.py
+++ b/tests/test_issue_179_conference_poster_typo.py
@@ -1,0 +1,62 @@
+"""Regressionstest fuer Issue #179.
+
+skills/conference-poster/SKILL.md:3 enthielt einen Tippfehler in der
+Description: "Poster fuer Konferenz create" (englisches Wort + ASCII-Ersatz
+mitten im deutschen Trigger-String).
+
+Akzeptanzkriterien (Issue #179):
+- "create" -> "erstellen"
+- Umlaut-Restoration "fuer" -> "für"
+"""
+
+import re
+from pathlib import Path
+
+SKILL_MD = (
+    Path(__file__).parent.parent
+    / "skills"
+    / "conference-poster"
+    / "SKILL.md"
+)
+
+
+def _description() -> str:
+    text = SKILL_MD.read_text(encoding="utf-8")
+    m = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
+    assert m, "kein YAML-Frontmatter in conference-poster/SKILL.md"
+    fm = m.group(1)
+    desc_lines: list[str] = []
+    capturing = False
+    for line in fm.splitlines():
+        if line.startswith("description:"):
+            capturing = True
+            desc_lines.append(line.partition(":")[2].strip())
+        elif capturing and line.startswith("  "):
+            desc_lines.append(line.strip())
+        elif capturing:
+            break
+    return " ".join(desc_lines)
+
+
+def test_no_konferenz_create_typo() -> None:
+    """Der englische Tippfehler 'Konferenz create' darf nicht mehr vorkommen."""
+    desc = _description()
+    assert "Konferenz create" not in desc, (
+        "Tippfehler 'Konferenz create' weiterhin in der Description vorhanden"
+    )
+
+
+def test_korrekter_deutscher_trigger() -> None:
+    """Der Trigger lautet korrekt 'Poster für Konferenz erstellen'."""
+    desc = _description()
+    assert "Poster für Konferenz erstellen" in desc, (
+        "korrekter Trigger 'Poster für Konferenz erstellen' fehlt"
+    )
+
+
+def test_keine_fuer_ascii_ersatz_im_trigger() -> None:
+    """Die ASCII-Ersatzform 'fuer Konferenz' darf nicht mehr vorkommen."""
+    desc = _description()
+    assert "fuer Konferenz" not in desc, (
+        "ASCII-Ersatz 'fuer Konferenz' weiterhin vorhanden — 'für' erwartet"
+    )


### PR DESCRIPTION
## Problem

`skills/conference-poster/SKILL.md:3` enthielt in der Description einen
fehlerhaften Trigger: `"Poster fuer Konferenz create"`. Das englische Wort
`create` stand mitten im deutschen Trigger-String und `fuer` nutzte den
ASCII-Ersatz statt `für`.

## Fix

Der bilinguale Slash-Trigger lautet nun korrekt
`"Poster für Konferenz erstellen / create conference poster"`.

- `create` → `erstellen` (deutsche Seite)
- `fuer` → `für` (Umlaut-Restoration)

Die Slash-getrennte Zweisprachen-Konvention (deutsch/englisch innerhalb des
Quotes) bleibt erhalten, sodass
`tests/test_skills_manifest.py::test_umlaut_variants_in_description` weiterhin
grün ist.

## TDD-Belege

Neuer Regressionstest `tests/test_issue_179_conference_poster_typo.py` kodiert
die Akzeptanzkriterien:

- `test_no_konferenz_create_typo` — kein `"Konferenz create"` mehr
- `test_korrekter_deutscher_trigger` — `"Poster für Konferenz erstellen"` vorhanden
- `test_keine_fuer_ascii_ersatz_im_trigger` — kein `"fuer Konferenz"` mehr

Rot → Grün:

- Vor dem Fix: 2 von 3 Tests rot (`AssertionError: ... 'fuer Konferenz' weiterhin vorhanden`).
- Nach dem Fix: alle 3 grün; zusätzlich `test_umlaut_variants_in_description[conference-poster]` grün.
- Volle Suite lokal (`/tmp/v652-venv/bin/pytest tests/`): **966 passed, 148 skipped** (Baseline 963/148 — die 3 neuen Tests addiert, keine Regression).

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)
