### PR TITLE
fix(skill): Scoring-Tabellen-Duplikat in topic-brainstorm entfernen (#180)

### DIFF
--- a/skills/topic-brainstorm/SKILL.md
+++ b/skills/topic-brainstorm/SKILL.md
@@ -130,35 +130,14 @@ Nächster Schritt: Forschungsfrage präzisieren
 
 ## Scoring-Dimensionen
 
-Details: `skills/topic-brainstorm/references/scoring-criteria.md`
+Drei Scores (je 0-10), Summe ergibt den Gesamtscore (0-30):
 
-### Feasibility (0-10)
-Gewichtung: Datenverfügbarkeit (3 Punkte) + Zeitaufwand (3 Punkte) + Methoden-Match (4 Punkte)
+- **Feasibility**: Datenverfügbarkeit + Zeitaufwand + Methoden-Match
+- **Novelty**: Forschungslücken-Heuristik (Stichwort-Überschneidung mit Interessensgebieten)
+- **Career-Fit**: Schlagwort-Überschneidung mit Studienrichtung
 
-| Datenzugang | Basismodifikator |
-|-------------|-----------------|
-| Public Datasets | +1.0 |
-| Literatur-Only | +0.5 |
-| Interview-fähig | 0.0 |
-| Unternehmensdaten | -1.0 |
-
-| Zeitbudget | Basismodifikator |
-|------------|-----------------|
-| 3 Monate | -1.0 |
-| 6 Monate | 0.0 |
-| 12 Monate | +1.0 |
-
-### Novelty (0-10)
-Pilotsuche-Gap-Indikator: Stichwort-Überschneidung mit Interessensgebieten erhöht Relevanz-Score.
-
-### Career-Fit (0-10)
-Schlagwort-Überschneidung mit Studienrichtung.
-
-| Studienrichtung | Modifier-Referenz |
-|-----------------|-------------------|
-| Wirtschaftsinformatik | hoch für IT+BWL-Kombithemen |
-| BWL | hoch für Management/Finance-Themen |
-| Informatik | hoch für rein technische Themen |
+Scoring-Kriterien (alle Modifikator-Tabellen für Datenverfügbarkeit, Zeitbudget
+und Studienrichtung) siehe `skills/topic-brainstorm/references/scoring-criteria.md`.
 
 ## Wichtige Regeln
 

--- a/tests/test_topic_brainstorm.py
+++ b/tests/test_topic_brainstorm.py
@@ -296,6 +296,77 @@ class TestAcademicContextWrite:
 
 
 # ---------------------------------------------------------------------------
+# Test 6b: SKILL.md dupliziert KEINE Scoring-Tabellen (Issue #180)
+# ---------------------------------------------------------------------------
+
+class TestNoScoringTableDuplication:
+    """SKILL.md darf die Scoring-Tabellen nicht duplizieren (Progressive Disclosure).
+
+    Die Modifikator-Tabellen (Datenverfuegbarkeit, Zeitbudget, Studienrichtung)
+    leben kanonisch in references/scoring-criteria.md. SKILL.md verweist nur darauf.
+    """
+
+    _SKILL_MD = _WORKTREE_ROOT / "skills" / "topic-brainstorm" / "SKILL.md"
+    _SCORING_REF = (
+        _WORKTREE_ROOT
+        / "skills"
+        / "topic-brainstorm"
+        / "references"
+        / "scoring-criteria.md"
+    )
+
+    def test_skill_md_has_no_data_access_table_rows(self):
+        """SKILL.md enthaelt keine Datenverfuegbarkeit-Modifikator-Tabellenzeilen."""
+        text = self._SKILL_MD.read_text(encoding="utf-8")
+        for forbidden in (
+            "| Public Datasets | +1.0 |",
+            "| Literatur-Only | +0.5 |",
+            "| Unternehmensdaten | -1.0 |",
+        ):
+            assert forbidden not in text, (
+                f"SKILL.md dupliziert Scoring-Tabelle (gefunden: {forbidden!r}) "
+                "— gehoert nach references/scoring-criteria.md"
+            )
+
+    def test_skill_md_has_no_time_budget_table_rows(self):
+        """SKILL.md enthaelt keine Zeitbudget-Modifikator-Tabellenzeilen."""
+        text = self._SKILL_MD.read_text(encoding="utf-8")
+        for forbidden in (
+            "| 3 Monate | -1.0 |",
+            "| 6 Monate | 0.0 |",
+            "| 12 Monate | +1.0 |",
+        ):
+            assert forbidden not in text, (
+                f"SKILL.md dupliziert Zeitbudget-Tabelle (gefunden: {forbidden!r})"
+            )
+
+    def test_skill_md_has_no_field_modifier_table(self):
+        """SKILL.md enthaelt keine Studienrichtung-Modifier-Referenz-Tabelle."""
+        text = self._SKILL_MD.read_text(encoding="utf-8")
+        assert "| Modifier-Referenz |" not in text, (
+            "SKILL.md dupliziert Studienrichtung-Modifier-Tabelle "
+            "— gehoert nach references/scoring-criteria.md"
+        )
+
+    def test_skill_md_references_scoring_criteria(self):
+        """SKILL.md verweist explizit auf references/scoring-criteria.md."""
+        text = self._SKILL_MD.read_text(encoding="utf-8")
+        assert "references/scoring-criteria.md" in text, (
+            "SKILL.md muss auf references/scoring-criteria.md verweisen"
+        )
+
+    def test_scoring_tables_remain_in_reference(self):
+        """Die Scoring-Tabellen bleiben kanonisch in der Referenz erhalten."""
+        ref = self._SCORING_REF.read_text(encoding="utf-8")
+        assert "| Public Datasets | +1.0 |" in ref, (
+            "Datenverfuegbarkeit-Tabelle fehlt in scoring-criteria.md"
+        )
+        assert "| 3 Monate | -1.0 |" in ref, (
+            "Zeitbudget-Tabelle fehlt in scoring-criteria.md"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Test 6: skill_sizes.json enthaelt 'topic-brainstorm'
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

`skills/topic-brainstorm/SKILL.md` duplizierte die Scoring-Tabellen
(Datenverfügbarkeit-, Zeitbudget- und Studienrichtung-Modifikatoren), die
kanonisch bereits in `skills/topic-brainstorm/references/scoring-criteria.md`
stehen. Das verstößt gegen das Progressive-Disclosure-Prinzip: SKILL.md soll
kurz bleiben, Detail-Referenzen gehören nach `references/`.

## Fix

Die `## Scoring-Dimensionen`-Section in SKILL.md wird durch eine knappe
Dimensions-Übersicht (eine Zeile pro Score) plus expliziten Verweis ersetzt:
"Scoring-Kriterien ... siehe `skills/topic-brainstorm/references/scoring-criteria.md`."
Die drei Modifikator-Tabellen bleiben kanonisch und unverändert in der Referenz.

SKILL.md schrumpft von 5648 auf 5191 Zeichen. Die Token-Reduktion gegenüber der
Baseline (7200) wächst damit auf 2009 Zeichen — `test_token_reduction` (Minimum
1400) bleibt erfüllt.

## TDD-Belege

Neue Regressionstests in `tests/test_topic_brainstorm.py` (Klasse
`TestNoScoringTableDuplication`):

- `test_skill_md_has_no_data_access_table_rows`
- `test_skill_md_has_no_time_budget_table_rows`
- `test_skill_md_has_no_field_modifier_table`
- `test_skill_md_references_scoring_criteria`
- `test_scoring_tables_remain_in_reference`

Vor dem Fix: 3 failed (Tabellenzeilen noch in SKILL.md vorhanden), 2 passed.
Nach dem Fix: 5 passed.

Volle Suite: `968 passed, 148 skipped` (Baseline 963 passed + 5 neue Tests,
Skips unverändert) — keine Regression. JSON-Manifeste, Hooks und
Command-/Agent-Markdown wurden nicht angefasst; SKILL.md-Frontmatter mit
`description:` bleibt intakt.

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)
