### PR TITLE
fix(skill): Trigger-Konflikt humanizer-de vs style-evaluator entschaerfen (#177)

### DIFF
--- a/skills/humanizer-de/SKILL.md
+++ b/skills/humanizer-de/SKILL.md
@@ -7,6 +7,9 @@ description: >
   normal (Sachlich) und deep (vollständiger Zwei-Pass-Durchlauf mit finalem
   Anti-KI-Audit). Optionale Voice-Kalibrierung via Schreibproben.
   Produziert humanisierten Text sowie Severity-gegliedertes Diff.
+  Inkludiert Korrektur (Eingriff am Text) — für reine Detektion/Score/Audit
+  ohne Eingriff → style-evaluator. Triggert auf: "humanisieren", "umschreiben",
+  "weniger KI-haft", "menschlicher klingen".
   Nicht triggern für: Zitation, Literaturrecherche, Kapitelplanung.
 version: 3.2.4-de.1-vendored
 vendored_from: "https://github.com/marmbiz/humanizer-de"

--- a/skills/style-evaluator/SKILL.md
+++ b/skills/style-evaluator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: style-evaluator
-description: Use this skill when the user wants to evaluate academic writing style (without source comparison). Triggers on "Stil prüfen / Stil pruefen", "Schreibstil", "Satzlänge / Satzlaenge", "Passiv-Quote", "Nominalstil", "style evaluation", or when a chapter draft needs stylistic review. Bewertet Stil-Qualität ohne Quellenbezug; Für Textähnlichkeit → `plagiarism-check`.
+description: Use this skill when the user wants to evaluate academic writing style (without source comparison). Triggers on "Stil prüfen / Stil pruefen", "Schreibstil", "Satzlänge / Satzlaenge", "Passiv-Quote", "Nominalstil", "style evaluation", "Score", "Audit". Detektion-only ohne Revision; für KI-Korrektur (humanisieren / umschreiben) → humanizer-de. Für Textähnlichkeit → plagiarism-check.
 license: MIT
 ---
 

--- a/tests/test_issue_177_ki_trigger_disambiguation.py
+++ b/tests/test_issue_177_ki_trigger_disambiguation.py
@@ -1,0 +1,66 @@
+"""Regression-Test fuer Issue #177.
+
+Trigger-Konflikt humanizer-de vs style-evaluator (KI-Erkennung):
+Die User-Phrase "Pruef den Text auf KI-Muster" koennte beide Skills aktivieren.
+Dieser Test fixiert die Disambiguierung in beiden SKILL.md-Descriptions:
+
+- style-evaluator: Detektion-only ohne Revision; fuer Korrektur -> humanizer-de;
+  triggert auf "Score" / "Audit".
+- humanizer-de: inkludiert Korrektur; fuer reine Detektion -> style-evaluator;
+  triggert auf "humanisieren" / "umschreiben" / "weniger KI-haft".
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+SKILLS_DIR = Path(__file__).parent.parent / "skills"
+
+
+def _description(skill: str) -> str:
+    """Liest das description-Feld aus dem YAML-Frontmatter (inkl. Block-Scalar)."""
+    text = (SKILLS_DIR / skill / "SKILL.md").read_text(encoding="utf-8")
+    m = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
+    assert m, f"{skill}: kein YAML-Frontmatter"
+    fm = m.group(1)
+    desc_m = re.search(
+        r"^description:\s*\|?>?\s*(.+?)(?=^[a-zA-Z_-]+:|\Z)", fm, re.M | re.S
+    )
+    assert desc_m, f"{skill}: kein description-Feld"
+    # Mehrzeilige Block-Scalars zu einer Zeile zusammenfuehren.
+    return re.sub(r"\s+", " ", desc_m.group(1)).strip()
+
+
+def test_style_evaluator_detektion_only_verweis_auf_humanizer() -> None:
+    desc = _description("style-evaluator").lower()
+    assert "detektion" in desc, "style-evaluator: 'Detektion' fehlt in description"
+    assert "humanizer-de" in desc, (
+        "style-evaluator: Verweis auf humanizer-de fuer Korrektur fehlt"
+    )
+
+
+def test_style_evaluator_score_und_audit_trigger() -> None:
+    desc = _description("style-evaluator").lower()
+    assert "score" in desc, "style-evaluator: Trigger 'Score' fehlt in description"
+    assert "audit" in desc, "style-evaluator: Trigger 'Audit' fehlt in description"
+
+
+def test_humanizer_inkludiert_korrektur_verweis_auf_style_evaluator() -> None:
+    desc = _description("humanizer-de").lower()
+    assert "korrektur" in desc, "humanizer-de: 'Korrektur' fehlt in description"
+    assert "style-evaluator" in desc, (
+        "humanizer-de: Verweis auf style-evaluator fuer reine Detektion fehlt"
+    )
+
+
+def test_humanizer_humanisieren_und_umschreiben_trigger() -> None:
+    desc = _description("humanizer-de").lower()
+    assert "humanisieren" in desc, (
+        "humanizer-de: Trigger 'humanisieren' fehlt in description"
+    )
+    assert "umschreiben" in desc, (
+        "humanizer-de: Trigger 'umschreiben' fehlt in description"
+    )
+    assert "weniger ki-haft" in desc, (
+        "humanizer-de: Trigger 'weniger KI-haft' fehlt in description"
+    )


### PR DESCRIPTION
## Problem

Die User-Phrase „Prüf den Text auf KI-Muster" konnte sowohl `style-evaluator`
(KI-Detektion als Feature, README:419) als auch `humanizer-de` (Anti-KI-Audit
+ Korrektur) aktivieren. Bislang gab es nur in `humanizer-de` einen expliziten
Negativ-Trigger, aber keine gegenseitige Abgrenzung zwischen Detektion und
Korrektur. Resultat: Trigger-Konflikt / Overtriggering.

## Fix

Beide SKILL.md-Descriptions disambiguieren jetzt explizit:

- **`skills/style-evaluator/SKILL.md`**: Description geschärft auf
  „Detektion-only ohne Revision; für KI-Korrektur (humanisieren / umschreiben)
  → humanizer-de". Trigger-Phrasen „Score" und „Audit" ergänzt.
- **`skills/humanizer-de/SKILL.md`**: Description ergänzt um „Inkludiert
  Korrektur (Eingriff am Text) — für reine Detektion/Score/Audit ohne Eingriff
  → style-evaluator". Trigger-Phrasen „humanisieren", „umschreiben",
  „weniger KI-haft", „menschlicher klingen" ergänzt.

Damit ist die Trennung eindeutig: „Score" / „Audit" → `style-evaluator`;
„humanisieren" / „umschreiben" / „weniger KI-haft" → `humanizer-de`.

Die `style-evaluator`-Description wurde dabei leicht gekürzt, damit die
`test_token_reduction`-Schwelle (≥ 1400 Zeichen unter Baseline) eingehalten
bleibt; das YAML-Frontmatter bleibt gültig (kein Inline-Doppelpunkt im
Plain-Scalar).

## TDD-Belege

Neuer Regressionstest `tests/test_issue_177_ki_trigger_disambiguation.py`
kodiert die drei Akzeptanzkriterien (4 Test-Funktionen).

- **Rot vor Fix:** `4 failed in 0.02s` — u.a. „Trigger 'Score' fehlt in
  description", „'Korrektur' fehlt in description", „Trigger 'humanisieren'
  fehlt in description".
- **Grün nach Fix:** `4 passed in 0.01s`.
- **Volle Suite:** `967 passed, 148 skipped` (Baseline war 963 passed /
  148 skipped — +4 durch die neuen Tests, keine Regression).
- Bestehende `tests/test_skills_manifest.py` und `tests/test_skill_naming.py`
  weiterhin grün (YAML-/Umlaut-/Token-Reduction-Guards eingehalten).

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)
