### PR TITLE
fix(skill): ASCII-Substitution in reading-list-import + material-passport (und 5 weitere) SKILL.md restaurieren (#175)

### DIFF
--- a/skills/book-handler/SKILL.md
+++ b/skills/book-handler/SKILL.md
@@ -8,20 +8,20 @@ license: MIT
 # Buch-Handler
 
 > **Gemeinsames Preamble laden:** Lies `skills/_common/preamble.md`
-> und befolge alle dort definierten Bloecke (Vorbedingungen, Keine Fabrikation,
+> und befolge alle dort definierten Blöcke (Vorbedingungen, Keine Fabrikation,
 > Aktivierung, Abgrenzung), bevor du mit diesem Skill-spezifischen Inhalt
-> fortfaehrst.
+> fortfährst.
 
-## Uebersicht
+## Übersicht
 
-Indexiert Buecher und Kapitel erstklassig -- analog zu Artikeln. Liefert
+Indexiert Bücher und Kapitel erstklassig -- analog zu Artikeln. Liefert
 CSL-JSON mit `type: book | chapter`, Herausgeber-Array und Seitenangaben.
-Prueft DOAB/OAPEN auf Open-Access-Verfuegbarkeit.
+Prüft DOAB/OAPEN auf Open-Access-Verfügbarkeit.
 
 ## Abgrenzung
 
-Loest Metadaten auf und legt Vault-Eintraege an. Schneidet keine Kapitel aus
-PDFs (F2.2), berechnet kein Seitenmapping (F2.3), fuehrt keine OCR durch (F2.4).
+Löst Metadaten auf und legt Vault-Einträge an. Schneidet keine Kapitel aus
+PDFs (F2.2), berechnet kein Seitenmapping (F2.3), führt keine OCR durch (F2.4).
 Zitationsformatierung: `citation-extraction`.
 
 ## Trigger-Erkennung
@@ -33,7 +33,7 @@ Aktiviert sich bei:
 
 ## Workflow
 
-### 1. Metadaten aufloesen
+### 1. Metadaten auflösen
 
 ```bash
 python scripts/book_resolve.py --isbn {isbn}
@@ -72,22 +72,22 @@ Ergebnis via `vault.set_page_offset({citekey}, {offset})` speichern.
 
 Falls `book_resolve.py` ein `URL`-Feld liefert (DOAB/OAPEN):
 - Setze `pdf_path` im Vault-Eintrag
-- Informiere User: "OA-PDF verfuegbar unter {url}"
+- Informiere User: "OA-PDF verfügbar unter {url}"
 
 ### 4. Nachfolge-Hinweise
 
 Nach erfolgreichem Vault-Eintrag dem User anbieten:
 - Kapitel extrahieren? -> F2.2: `chunk_pdf.py`
-- Scan-PDF (kein Text)? -> Schritt 5 ausfuehren
+- Scan-PDF (kein Text)? -> Schritt 5 ausführen
 
-### 5. OCR-Pruefung (bei pdf_path vorhanden)
+### 5. OCR-Prüfung (bei pdf_path vorhanden)
 
 ```python
 from pdf import detect_needs_ocr
 if detect_needs_ocr(pdf_path):
     # User fragen:
     # "Scan-PDF erkannt: wenig Text auf Stichproben-Seiten.
-    #  OCR ausfuehren? (~30 s/Seite, lokal via ocrmypdf) [j/n]"
+    #  OCR ausführen? (~30 s/Seite, lokal via ocrmypdf) [j/n]"
     # Bei Zustimmung:
     from ocr import run_ocrmypdf
     run_ocrmypdf(pdf_path, pdf_path_ocr)
@@ -109,8 +109,8 @@ Buch indexiert: {titel} ({year})
 ## Beispiel
 
 **Gut:** User gibt ISBN 978-3-446-46103-1 an.
-book-handler fuehrt `book_resolve.py --isbn 9783446461031` aus,
-erhaelt CSL-JSON (type=book, title, author, publisher, year),
-legt Vault-Eintrag an, bestaetigt dem User.
+book-handler führt `book_resolve.py --isbn 9783446461031` aus,
+erhält CSL-JSON (type=book, title, author, publisher, year),
+legt Vault-Eintrag an, bestätigt dem User.
 
 **Schlecht:** Metadaten ohne API-Aufruf erfinden -- VERBOTEN.

--- a/skills/citation-style-import/SKILL.md
+++ b/skills/citation-style-import/SKILL.md
@@ -2,7 +2,7 @@
 name: citation-style-import
 description: >
   Verwende diesen Skill wenn der User einen Zitierstil aus dem CSL-Repository
-  importieren moechte und eine neue custom-Variante generieren will.
+  importieren möchte und eine neue custom-Variante generieren will.
   Trigger-Phrasen: "Zitierstil importieren", "CSL importieren", "neuer Stil",
   "custom citation style", "Stil aus GitHub laden".
   Parst .csl-Dateien ("Stilübernahme / Import" via xml.etree.ElementTree) und generiert
@@ -25,9 +25,9 @@ references:
 # CSL-Import Skill
 
 > **Gemeinsames Preamble laden:** Lies `skills/_common/preamble.md`
-> und befolge alle dort definierten Bloecke (Vorbedingungen, Keine Fabrikation,
+> und befolge alle dort definierten Blöcke (Vorbedingungen, Keine Fabrikation,
 > Aktivierung, Abgrenzung), bevor du mit diesem Skill-spezifischen Inhalt
-> fortfaehrst.
+> fortfährst.
 
 ## Zweck
 
@@ -40,7 +40,7 @@ CSL 1.0.2) und generiert eine neue Prompt-Regel-Variante analog zu
 ## Voraussetzungen
 
 Python 3.10+ mit `lxml>=4.9.0` (in `scripts/requirements.txt` enthalten).
-Internetverbindung fuer den Download aus GitHub (optional — lokales .csl geht auch).
+Internetverbindung für den Download aus GitHub (optional — lokales .csl geht auch).
 
 ## Verwendung
 
@@ -58,14 +58,14 @@ Beispiele:
 ### 2. CSL-Datei herunterladen (remote)
 
 ```bash
-# Raw-URL fuer direkten Download:
+# Raw-URL für direkten Download:
 # https://raw.githubusercontent.com/citation-style-language/styles/master/<dateiname>.csl
 
 curl -o /tmp/<dateiname>.csl \
   "https://raw.githubusercontent.com/citation-style-language/styles/master/<dateiname>.csl"
 ```
 
-### 3. Parser ausfuehren
+### 3. Parser ausführen
 
 ```bash
 python skills/citation-style-import/scripts/csl_import.py \
@@ -73,7 +73,7 @@ python skills/citation-style-import/scripts/csl_import.py \
   -o skills/citation-extraction/references/custom-<dateiname>.md
 ```
 
-Beispiel fuer Springer Author-Date:
+Beispiel für Springer Author-Date:
 
 ```bash
 curl -o /tmp/springer-basic-author-date.csl \
@@ -122,7 +122,7 @@ Die generierte Datei `custom-<style>.md` hat folgende Struktur:
 ...
 ```
 
-## Unterstuetzte Quellentypen (Eval: 5 Typen)
+## Unterstützte Quellentypen (Eval: 5 Typen)
 
 | CSL-Typ | DE-Bezeichnung |
 |---|---|
@@ -140,15 +140,15 @@ auf die neue Variante hinweisen:
 
 > "Zitiere im Stil springer-basic-author-date (custom-Variante)"
 
-## Bekannte Einschraenkungen
+## Bekannte Einschränkungen
 
 - Komplexe CSL-Macros mit bedingten Regeln werden vereinfacht dargestellt
-- Abkuerzungsregeln (`abbreviation` Felder) werden nicht uebertragen
+- Abkürzungsregeln (`abbreviation` Felder) werden nicht übertragen
 - Sprachspezifische Lokalisierungen (`<locale>`) werden ignoriert
-- Nur bibliographische Stile werden unterstuetzt (kein `class="note"`)
+- Nur bibliographische Stile werden unterstützt (kein `class="note"`)
 
 ## CSL-Spezifikation
 
-Vollstaendige Kurzreferenz: `skills/citation-style-import/references/csl-spec.md`
+Vollständige Kurzreferenz: `skills/citation-style-import/references/csl-spec.md`
 
 Offizielle Doku: https://docs.citationstyles.org/en/stable/specification.html

--- a/skills/cluster-visualizer/SKILL.md
+++ b/skills/cluster-visualizer/SKILL.md
@@ -2,11 +2,11 @@
 name: cluster-visualizer
 description: >
   Verwende diesen Skill wenn der User einen Literaturcluster visualisieren
-  moechte. Trigger-Phrasen: "zeige Cluster", "visualisiere", "Mindmap",
+  möchte. Trigger-Phrasen: "zeige Cluster", "visualisiere", "Mindmap",
   "Cluster-Diagramm", "Netzwerk der Quellen", "zeige Verbindungen".
   Nimmt ein Cluster-JSON (5D-Scoring-Output) als Input und erzeugt ein
-  Mermaid-graph-LR-Diagramm. Erzeugt Knoten fuer Paper (Titel + Jahr)
-  und Kanten fuer geteilte Zitationsverbindungen ("Kantenstärke / Gewicht" via linkStyle).
+  Mermaid-graph-LR-Diagramm. Erzeugt Knoten für Paper (Titel + Jahr)
+  und Kanten für geteilte Zitationsverbindungen ("Kantenstärke / Gewicht" via linkStyle).
   Optional wird das Diagramm per Mermaid-CLI (mmdc) als PNG exportiert.
 compatibility: Claude Code
 license: MIT
@@ -15,14 +15,14 @@ license: MIT
 # Cluster-Visualizer
 
 > **Gemeinsames Preamble laden:** Lies `skills/_common/preamble.md`
-> und befolge alle dort definierten Bloecke (Vorbedingungen, Keine Fabrikation,
+> und befolge alle dort definierten Blöcke (Vorbedingungen, Keine Fabrikation,
 > Aktivierung, Abgrenzung), bevor du mit diesem Skill-spezifischen Inhalt
-> fortfaehrst.
+> fortfährst.
 
-## Uebersicht
+## Übersicht
 
 Visualisiert einen Literaturcluster als Mermaid-`graph LR`-Diagramm.
-Knoten repraesentieren Paper (Titel + Jahr), Kanten repraesentieren
+Knoten repräsentieren Paper (Titel + Jahr), Kanten repräsentieren
 gemeinsame Zitationsverbindungen (Kantengewicht via Strichdicke).
 
 ## Trigger-Erkennung
@@ -63,7 +63,7 @@ Erwartetes Schema:
 python skills/cluster-visualizer/scripts/render_mermaid.py <cluster.json> [output_dir]
 ```
 
-Der Quelltext wird als `.mmd`-Datei gespeichert und als Pfad zurueckgegeben.
+Der Quelltext wird als `.mmd`-Datei gespeichert und als Pfad zurückgegeben.
 
 ### 3. PNG-Rendering (optional)
 
@@ -81,7 +81,7 @@ Ausgabe:
 
 ### 5. Einbettung in Literatur-Kapitel (optional)
 
-Falls der User das Diagramm in `kapitel/literatur.md` einbetten moechte:
+Falls der User das Diagramm in `kapitel/literatur.md` einbetten möchte:
 
 ````markdown
 ```mermaid

--- a/skills/material-passport/SKILL.md
+++ b/skills/material-passport/SKILL.md
@@ -2,13 +2,13 @@
 name: material-passport
 description: >
   Verwende diesen Skill wenn der User ein Reproduzierbarkeits-Manifest erstellen
-  oder das Projekt fuer die Abgabe finalisieren moechte.
+  oder das Projekt für die Abgabe finalisieren möchte.
   Trigger-Phrasen: "Reproduzierbarkeits-Manifest / Material-Passport erstellen",
   "Abgabe vorbereiten", "Vault sperren", "Repro-Lock", "material-passport.json".
   Exporttyp: "Prüfung / Validation" via JSON-Schema.
   Exportiert alle relevanten Metadaten (paper_ids, DOIs, Scores, Algo-Version,
   Modellversionen, PDF-Hashes, Decision-Snapshot) als material-passport.json
-  und ergaenzt kapitel/methodik.md automatisch um einen Reproduzierbarkeits-Block.
+  und ergänzt kapitel/methodik.md automatisch um einen Reproduzierbarkeits-Block.
 triggers:
   - "Reproduzierbarkeits-Manifest"
   - "Material-Passport erstellen"
@@ -24,21 +24,21 @@ tools:
 # Material-Passport Skill
 
 > **Gemeinsames Preamble laden:** Lies `skills/_common/preamble.md`
-> und befolge alle dort definierten Bloecke (Vorbedingungen, Keine Fabrikation,
+> und befolge alle dort definierten Blöcke (Vorbedingungen, Keine Fabrikation,
 > Aktivierung, Abgrenzung), bevor du mit diesem Skill-spezifischen Inhalt
-> fortfaehrst.
+> fortfährst.
 
 ---
 
 ## Zweck
 
-Erstellt einen vollstaendigen Material-Passport fuer das Forschungsprojekt:
+Erstellt einen vollständigen Material-Passport für das Forschungsprojekt:
 
 - **material-passport.json** — maschinenlesbares Manifest mit allen Metadaten
-- **kapitel/methodik.md** — erhaelt automatisch einen `## Reproduzierbarkeit`-Block
+- **kapitel/methodik.md** — erhält automatisch einen `## Reproduzierbarkeit`-Block
 - **Repro-Lock** (optional) — sperrt den Vault nach Abgabe read-only
 
-Der Passport ermoeglicht vollstaendige Reproduzierbarkeit: Dritte koennen nachvollziehen,
+Der Passport ermöglicht vollständige Reproduzierbarkeit: Dritte können nachvollziehen,
 welche Paper, Scores, Algorithmus-Version und Modellversionen verwendet wurden.
 
 ---
@@ -49,7 +49,7 @@ Aktiviert bei:
 - "Reproduzierbarkeits-Manifest erstellen"
 - "Material-Passport"
 - "Abgabe vorbereiten"
-- "Vault fuer Abgabe sperren" / "Repro-Lock"
+- "Vault für Abgabe sperren" / "Repro-Lock"
 - "material-passport.json generieren"
 - "Reproduzierbarkeit dokumentieren"
 
@@ -60,7 +60,7 @@ Aktiviert bei:
 1. **Vault-DB** vorhanden (Standard: `vault.db` im CWD oder via `VAULT_DB_PATH`)
 2. **Paper im Vault** eingetragen (via `vault.add_paper`)
 3. **kapitel/methodik.md** existiert (wird ggf. angelegt)
-4. Python-Abhaengigkeiten installiert: `pip install -r scripts/requirements.txt`
+4. Python-Abhängigkeiten installiert: `pip install -r scripts/requirements.txt`
 
 ---
 
@@ -68,12 +68,12 @@ Aktiviert bei:
 
 ### Schritt 1: User-Anfrage verstehen
 
-Klaere bei Bedarf:
+Kläre bei Bedarf:
 - Soll der Vault nach dem Export **gesperrt** werden? (Repro-Lock — irreversibel)
   Wenn unklar: **immer nachfragen** bevor `--lock` gesetzt wird.
 - Projekt-Slug (Standard: aus Vault-DB oder aktuelles Verzeichnis)
 
-### Schritt 2: build_passport.py ausfuehren
+### Schritt 2: build_passport.py ausführen
 
 **Ohne Repro-Lock** (normaler Export):
 ```bash
@@ -95,8 +95,8 @@ python skills/material-passport/scripts/build_passport.py \
 ```
 
 > **Achtung:** Der Repro-Lock ist **irreversibel**. Sobald `--lock` gesetzt wurde,
-> koennen keine weiteren Paper oder Decisions in den Vault geschrieben werden.
-> Den User **explizit bestaetigen lassen**, bevor `--lock` ausgefuehrt wird.
+> können keine weiteren Paper oder Decisions in den Vault geschrieben werden.
+> Den User **explizit bestätigen lassen**, bevor `--lock` ausgeführt wird.
 
 ### Schritt 3: Ergebnis an User melden
 
@@ -106,7 +106,7 @@ Material-Passport exportiert: ./material-passport.json
 methodik.md aktualisiert: kapitel/methodik.md
 ```
 
-Vollstaendige Meldung an User:
+Vollständige Meldung an User:
 ```
 Material-Passport erstellt:
   Datei:   ./material-passport.json
@@ -115,30 +115,30 @@ Material-Passport erstellt:
   DOIs:    <M> mit DOI
   Decisions: <K> aktive Entscheidungen
 
-kapitel/methodik.md wurde um '## Reproduzierbarkeit' ergaenzt.
+kapitel/methodik.md wurde um '## Reproduzierbarkeit' ergänzt.
 ```
 
-Bei aktivem Repro-Lock zusaetzlich:
+Bei aktivem Repro-Lock zusätzlich:
 ```
 Vault gesperrt (Repro-Lock aktiv).
-Keine weiteren Aenderungen am Vault moeglich.
+Keine weiteren Aenderungen am Vault möglich.
 ```
 
 ---
 
-## Fehlerfaelle
+## Fehlerfälle
 
-| Situation | Meldung | Massnahme |
+| Situation | Meldung | Maßnahme |
 |-----------|---------|-----------|
-| Vault bereits gesperrt | `FEHLER: Vault fuer Slug '...' ist gesperrt` | Kein erneuter Export — Vault ist read-only |
-| Vault-DB nicht gefunden | `FEHLER: ...` | Pfad pruefen oder `VAULT_DB_PATH` setzen |
-| methodik.md nicht schreibbar | `WARNUNG: methodik.md konnte nicht aktualisiert werden` | Berechtigungen pruefen; Passport wurde trotzdem erstellt |
+| Vault bereits gesperrt | `FEHLER: Vault für Slug '...' ist gesperrt` | Kein erneuter Export — Vault ist read-only |
+| Vault-DB nicht gefunden | `FEHLER: ...` | Pfad prüfen oder `VAULT_DB_PATH` setzen |
+| methodik.md nicht schreibbar | `WARNUNG: methodik.md konnte nicht aktualisiert werden` | Berechtigungen prüfen; Passport wurde trotzdem erstellt |
 
 ---
 
 ## material-passport.json — Inhalt
 
-Das JSON-Dokument enthaelt:
+Das JSON-Dokument enthält:
 
 | Feld | Beschreibung |
 |------|-------------|
@@ -154,7 +154,7 @@ Das JSON-Dokument enthaelt:
 | `decisions_snapshot` | Snapshot aller aktiven Decisions |
 | `pdf_sha256_hashes` | SHA-256-Hashes aller vorhandenen PDFs |
 | `created_at` | Unix-Timestamp des Exports |
-| `passport_hash` | SHA-256 ueber alle uebrigen Felder |
+| `passport_hash` | SHA-256 über alle übrigen Felder |
 
 Das Dokument wird gegen das JSON-Schema in
 `academic_vault/material-passport.schema.json` validiert.
@@ -165,6 +165,6 @@ Das Dokument wird gegen das JSON-Schema in
 
 - Kein automatisches Backup oder Archivierung — nur Export
 - Kein Hochladen in externe Systeme
-- Repro-Lock nur mit expliziter User-Bestaetigung
-- Kein Loeschen vorhandener Vault-Daten
+- Repro-Lock nur mit expliziter User-Bestätigung
+- Kein Löschen vorhandener Vault-Daten
 - JSON-Schema-Validierung erfolgt intern; bei Validierungsfehler wird kein File geschrieben

--- a/skills/notebook-bundle/SKILL.md
+++ b/skills/notebook-bundle/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: notebook-bundle
 description: >
-  Verwende diesen Skill wenn der User ein NotebookLM-Bundle erstellen moechte.
-  Trigger-Phrasen: "NotebookLM Bundle", "PDF-Bundle exportieren", "Bundle fuer Upload",
-  "Bücher / grosse Dokumente aufteilen", "Riesen-PDF aufteilen", "NotebookLM vorbereiten".
-  Erzeugt ein konkateniertes PDF aller ausgewaehlten Paper (mit Cover + TOC)
-  fuer manuellen Upload in Google NotebookLM.
+  Verwende diesen Skill wenn der User ein NotebookLM-Bundle erstellen möchte.
+  Trigger-Phrasen: "NotebookLM Bundle", "PDF-Bundle exportieren", "Bundle für Upload",
+  "Bücher / große Dokumente aufteilen", "Riesen-PDF aufteilen", "NotebookLM vorbereiten".
+  Erzeugt ein konkateniertes PDF aller ausgewählten Paper (mit Cover + TOC)
+  für manuellen Upload in Google NotebookLM.
 compatibility: Claude Code
 license: MIT
 ---
@@ -13,9 +13,9 @@ license: MIT
 # NotebookLM-Bundle Skill
 
 > **Gemeinsames Preamble laden:** Lies `skills/_common/preamble.md`
-> und befolge alle dort definierten Bloecke (Vorbedingungen, Keine Fabrikation,
+> und befolge alle dort definierten Blöcke (Vorbedingungen, Keine Fabrikation,
 > Aktivierung, Abgrenzung), bevor du mit diesem Skill-spezifischen Inhalt
-> fortfaehrst.
+> fortfährst.
 
 ---
 
@@ -24,18 +24,18 @@ license: MIT
 **NotebookLM (Gemini) ist ein Triage-Tool, KEIN Zitat-Pfad.**
 
 Antworten aus NotebookLM sind NICHT verbatim aus den Quellen zitiert und
-duerfen NICHT als zitierfahige Quellen in wissenschaftlichen Arbeiten
+dürfen NICHT als zitierfahige Quellen in wissenschaftlichen Arbeiten
 verwendet werden.
 
-- Fuer verbatim-gesicherte Zitate: **Vault-Zitat-Pfad** (`vault.add_quote`) nutzen.
-- Dieses Bundle dient der **Orientierung und Uebersicht** — nicht als Belegen.
-- NotebookLM-Antworten koennen sinngemass korrekt, aber verbatim falsch sein.
+- Für verbatim-gesicherte Zitate: **Vault-Zitat-Pfad** (`vault.add_quote`) nutzen.
+- Dieses Bundle dient der **Orientierung und Übersicht** — nicht als Belegen.
+- NotebookLM-Antworten können sinngemäß korrekt, aber verbatim falsch sein.
 
 Diese Warnung muss dem User bei jeder Bundle-Erstellung explizit mitgeteilt werden.
 
 ---
 
-## Uebersicht
+## Übersicht
 
 Erzeugt aus einer Paper-Selektion ein Bundle-PDF:
 - Bibliographie-Cover als erste Seite(n)
@@ -52,10 +52,10 @@ Output: `notebook-bundle-<ts>.pdf` — manuell in NotebookLM hochladen.
 Aktiviert bei:
 - "NotebookLM Bundle"
 - "PDF-Bundle exportieren"
-- "Bundle fuer Upload"
-- "Buecher zu gross" / "Riesen-PDF aufteilen"
+- "Bundle für Upload"
+- "Bücher zu groß" / "Riesen-PDF aufteilen"
 - "NotebookLM vorbereiten"
-- "Paper fuer NotebookLM zusammenstellen"
+- "Paper für NotebookLM zusammenstellen"
 
 ---
 
@@ -85,7 +85,7 @@ Erwartetes Schema der `selection.json`:
 }
 ```
 
-Fehlende `pdf_path`-Eintraege: Skill meldet diese Paper als "uebersprungen".
+Fehlende `pdf_path`-Einträge: Skill meldet diese Paper als "übersprungen".
 
 ### Schritt 2: Bundle bauen
 
@@ -111,17 +111,17 @@ python skills/notebook-bundle/scripts/bundle.py <selection.json> \
 Ausgabe:
 - Pfad(e) zur Bundle-PDF
 - Anzahl Seiten + Dateigröße
-- Liste uebersprungener Paper (fehlende PDFs)
+- Liste übersprungener Paper (fehlende PDFs)
 - **Wiederholung der Verbatim-Warning**
 
 Beispiel:
 ```
 Bundle erzeugt: /projekt/notebook-bundle-20260518T123456.pdf
-Seiten: 152  |  Groesse: 18.4 MB
+Seiten: 152  |  Größe: 18.4 MB
 Uebersprungen (0): —
 
 WARNUNG: NotebookLM-Antworten sind NICHT verbatim-garantiert.
-Fuer Zitate: Vault-Zitat-Pfad (vault.add_quote) nutzen.
+Für Zitate: Vault-Zitat-Pfad (vault.add_quote) nutzen.
 ```
 
 Bei Split (mehrere Dateien):
@@ -138,5 +138,5 @@ notebook-bundle-20260518T123456-part2.pdf  (120 MB, 88 Seiten)
 - Kein automatischer Upload nach NotebookLM — manuell durch User.
 - Ersetzt nicht den Vault-Zitat-Pfad (verbatim-gesichert).
 - Keine Konvertierung von non-PDF-Formaten.
-- Keine Vault-DB-Eintraege — Bundle ist reine Export-Funktion.
-- Maximale NotebookLM-Source-Groesse: 500MB. Bei Split mehrere Quellen hochladen.
+- Keine Vault-DB-Einträge — Bundle ist reine Export-Funktion.
+- Maximale NotebookLM-Source-Größe: 500MB. Bei Split mehrere Quellen hochladen.

--- a/skills/reading-list-import/SKILL.md
+++ b/skills/reading-list-import/SKILL.md
@@ -2,7 +2,7 @@
 name: reading-list-import
 description: >
   Verwende diesen Skill wenn der User eine Leseliste, Bibliographie oder
-  Quellenliste (PDF, Markdown, Plaintext) in den Vault importieren moechte.
+  Quellenliste (PDF, Markdown, Plaintext) in den Vault importieren möchte.
   Trigger-Phrasen: "Importiere Reading List", "Prof-Liste einlesen",
   "Bibliographie importieren", "Literaturliste einlesen",
   "Reading List importieren".
@@ -32,25 +32,25 @@ security:
 # Reading-List-Import Skill
 
 > **Gemeinsames Preamble laden:** Lies `skills/_common/preamble.md`
-> und befolge alle dort definierten Bloecke (Vorbedingungen, Keine Fabrikation,
+> und befolge alle dort definierten Blöcke (Vorbedingungen, Keine Fabrikation,
 > Aktivierung, Abgrenzung), bevor du mit diesem Skill-spezifischen Inhalt
-> fortfaehrst.
+> fortfährst.
 
 ## Zweck
 
 Importiert eine Referenzliste (Literaturliste, Reading List, Bibliographie)
 eines Professors oder aus einem Paper in den academic-research Vault.
-Unterstuetzt PDF, Markdown und Plaintext. Dedupliziert via DOI/ISBN.
+Unterstützt PDF, Markdown und Plaintext. Dedupliziert via DOI/ISBN.
 
 ## Voraussetzungen
 
-### 1. Abhaengigkeiten
+### 1. Abhängigkeiten
 
 ```bash
 pip install anthropic requests lxml
-# Optional fuer PDF:
+# Optional für PDF:
 pip install PyPDF2
-# Optional: anystyle (Ruby-Gem) fuer strukturiertes Parsen
+# Optional: anystyle (Ruby-Gem) für strukturiertes Parsen
 gem install anystyle-cli
 ```
 
@@ -83,7 +83,7 @@ python skills/reading-list-import/scripts/parse_list.py \
   --db ~/.academic-research/projects/meine-arbeit/vault.db
 ```
 
-### Unterstuetzte Formate
+### Unterstützte Formate
 
 - `.pdf` — Text wird via PyPDF2 oder pdfminer.six extrahiert
 - `.md` / `.markdown` — direkt eingelesen
@@ -97,7 +97,7 @@ Detaillierte Format-Hinweise: `skills/reading-list-import/references/format-hint
 ```
 Datei-Eingabe
     ↓
-Text-Extraktion (PyPDF2 fuer PDF, direkt fuer md/txt)
+Text-Extraktion (PyPDF2 für PDF, direkt für md/txt)
     ↓
 LLM-Parser (Sonnet): Text → [{author, title, year, doi, isbn, ...}]
     ↓  (optional: anystyle-Fallback)
@@ -107,37 +107,37 @@ ISBN-Resolution: DNB SRU + OpenLibrary + GoogleBooks → CSL-JSON
     ↓
 Fallback: minimales CSL-JSON aus geparsten Daten
     ↓
-Vault.add_paper() fuer jeden Eintrag (Dedup via DOI/ISBN)
+Vault.add_paper() für jeden Eintrag (Dedup via DOI/ISBN)
     ↓
-Ergebnis: N importiert, M uebersprungen, Fehler
+Ergebnis: N importiert, M übersprungen, Fehler
 ```
 
 ### Anystyle (optional)
 
 Falls `anystyle` installiert ist, kann es als vorgelagerter Parser
-verwendet werden. Claude prueft automatisch ob das Tool verfuegbar ist:
+verwendet werden. Claude prüft automatisch ob das Tool verfügbar ist:
 
 ```bash
-# Pruefe ob anystyle verfuegbar
-anystyle --version 2>/dev/null && echo "verfuegbar" || echo "nicht installiert"
+# Prüfe ob anystyle verfügbar
+anystyle --version 2>/dev/null && echo "verfügbar" || echo "nicht installiert"
 ```
 
-Bei Verfuegbarkeit wird anystyle fuer initiales Parsen genutzt;
-der LLM-Parser ueberprueft und vervollstaendigt das Ergebnis.
+Bei Verfügbarkeit wird anystyle für initiales Parsen genutzt;
+der LLM-Parser überprüft und vervollständigt das Ergebnis.
 
 ## Verhalten
 
 1. Datei-Pfad entgegennehmen (Argument oder via User-Frage)
 2. Format erkennen und Text extrahieren
 3. LLM-Parser aufrufen (Sonnet) — extrahiert strukturierte Liste
-4. Fuer jeden Eintrag: DOI/ISBN resolven → CSL-JSON
+4. Für jeden Eintrag: DOI/ISBN resolven → CSL-JSON
 5. `vault.add_paper()` aufrufen (idempotent: Dedup via DOI/ISBN)
 6. Bei Mehrdeutigkeit (_ambiguous: true): AskUserQuestion-Tool nutzen
-7. Ergebnis melden: N importiert, M uebersprungen
+7. Ergebnis melden: N importiert, M übersprungen
 
 ## Mehrdeutigkeiten
 
-Wenn der LLM-Parser mehrere moegliche Quellen fuer einen Eintrag findet
+Wenn der LLM-Parser mehrere mögliche Quellen für einen Eintrag findet
 (z.B. gleichnamige Arbeiten verschiedener Autoren), wird der User via
 `AskUserQuestion` gefragt:
 
@@ -156,12 +156,12 @@ Auswahl (Nummer):
 - **Credentials**: Anthropic-Key nur aus `~/.academic-research/config.yaml` (0600)
 - **Keine PDFs heruntergeladen**: Nur Metadaten werden im Vault gespeichert
 
-## Bekannte Einschraenkungen
+## Bekannte Einschränkungen
 
-- Eintraege ohne DOI und ISBN koennen nicht dedupliziert werden;
+- Einträge ohne DOI und ISBN können nicht dedupliziert werden;
   sie werden bei erneutem Import neu angelegt
 - PDF-Extraktion erfordert PyPDF2 oder pdfminer.six
-- Scan-PDFs (keine Textschicht) koennen nicht verarbeitet werden;
+- Scan-PDFs (keine Textschicht) können nicht verarbeitet werden;
   OCR muss vorgelagert werden
 - anystyle erfordert Ruby-Umgebung (optional, kein Pflicht-Dep)
-- Netz-Ausfaelle fuehren zu Fallback auf LLM-generiertes CSL-JSON
+- Netz-Ausfälle führen zu Fallback auf LLM-generiertes CSL-JSON

--- a/skills/zotero-import/SKILL.md
+++ b/skills/zotero-import/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: zotero-import
 description: >
-  Verwende diesen Skill wenn der User Zotero-Items in den Vault importieren moechte.
+  Verwende diesen Skill wenn der User Zotero-Items in den Vault importieren möchte.
   Trigger-Phrasen: "Zotero importieren", "Bibliothek synchronisieren", "Zotero sync".
   Holt Items und PDF-Attachments aus einer Zotero-Library via pyzotero.
   Dedupliziert via DOI/ISBN ("Prüfung / Deduplication" via normalisierten Identifikatoren).
-  Laedt PDFs in die Files-API hoch und cached file_ids. Read-only — kein Push zurueck.
+  Lädt PDFs in die Files-API hoch und cached file_ids. Read-only — kein Push zurück.
 triggers:
   - "Zotero importieren"
   - "Bibliothek synchronisieren"
@@ -22,15 +22,15 @@ security:
 # Zotero-Import Skill
 
 > **Gemeinsames Preamble laden:** Lies `skills/_common/preamble.md`
-> und befolge alle dort definierten Bloecke (Vorbedingungen, Keine Fabrikation,
+> und befolge alle dort definierten Blöcke (Vorbedingungen, Keine Fabrikation,
 > Aktivierung, Abgrenzung), bevor du mit diesem Skill-spezifischen Inhalt
-> fortfaehrst.
+> fortfährst.
 
 ## Zweck
 
 Holt alle Items und PDF-Attachments aus einer Zotero-Library (user oder group)
 und importiert sie in den academic-research Vault. Idempotent: wiederholter
-Aufruf erstellt keine Duplikate (fuer Items mit DOI oder ISBN).
+Aufruf erstellt keine Duplikate (für Items mit DOI oder ISBN).
 
 ## Voraussetzungen
 
@@ -56,20 +56,20 @@ Permissions setzen (Pflicht):
 chmod 0600 ~/.academic-research/config.yaml
 ```
 
-**Hinweis:** Der API-Key ist ein persoenliches Credential. Er wird niemals geloggt,
+**Hinweis:** Der API-Key ist ein persönliches Credential. Er wird niemals geloggt,
 in den Vault geschrieben oder im PR-Diff sichtbar.
 
 ### 3. Zotero API-Key erstellen
 
 1. https://www.zotero.org/settings/keys aufrufen
-2. "Create new private key" → Read-only fuer die gewuenschte Library
+2. "Create new private key" → Read-only für die gewünschte Library
 3. Key in config.yaml eintragen
 
 ## Verwendung
 
 ### Automatisch (Skill-Trigger)
 
-Claude erkennt folgende Phrasen und fuehrt den Import aus:
+Claude erkennt folgende Phrasen und führt den Import aus:
 - "Zotero importieren"
 - "Bibliothek synchronisieren"
 - "Zotero sync"
@@ -84,22 +84,22 @@ python skills/zotero-import/scripts/zotero_pull.py \
 
 ## Verhalten
 
-1. Config laden und 0600-Permissions pruefen
+1. Config laden und 0600-Permissions prüfen
 2. Alle Items aus Zotero holen (paginiert via `zot.everything()`)
-3. Fuer jedes Item: DOI/ISBN-Dedup gegen Vault
+3. Für jedes Item: DOI/ISBN-Dedup gegen Vault
 4. Neue Items: `vault.add_paper()` + ggf. PDF-Attachment herunterladen
 5. PDFs: `vault.ensure_file()` → Files-API-Upload + file_id cachen
-6. Ergebnis ausgeben: N importiert, M uebersprungen, Fehler
+6. Ergebnis ausgeben: N importiert, M übersprungen, Fehler
 
 ## Sicherheitshinweise
 
-- **Read-only**: Kein Schreiben zurueck nach Zotero
-- **Netz-Allowlist**: Ausschliesslich `api.zotero.org` (via pyzotero)
+- **Read-only**: Kein Schreiben zurück nach Zotero
+- **Netz-Allowlist**: Ausschließlich `api.zotero.org` (via pyzotero)
 - **Credentials**: Nur in `~/.academic-research/config.yaml` mit 0600-Permissions
 
-## Bekannte Einschraenkungen
+## Bekannte Einschränkungen
 
-- Items ohne DOI und ISBN koennen nicht dedupliziert werden — sie werden bei
+- Items ohne DOI und ISBN können nicht dedupliziert werden — sie werden bei
   jedem Import neu angelegt
 - Nur das erste PDF-Attachment pro Item wird verarbeitet
 - Annotations, Notes und verschachtelte Attachments werden nicht importiert

--- a/tests/test_issue_175_skill_orthography.py
+++ b/tests/test_issue_175_skill_orthography.py
@@ -1,0 +1,97 @@
+"""Regression-Guard fuer Issue #175 — ASCII-Substitution in SKILL.md restaurieren.
+
+Die globale CLAUDE.md verlangt volle Orthografie (ue->ü, ae->ä, oe->ö, ss->ß).
+Mehrere v6.5-Skills enthielten ASCII-Ersatz statt korrekter Umlaute. Dieser Test
+kodiert die Akzeptanzkriterien:
+
+1. Keine der bekannten ASCII-substituierten deutschen Woerter darf in den
+   betroffenen SKILL.md-Dateien (Body + Frontmatter) mehr auftauchen.
+   Kein blindes sed — eine explizite Wortliste, damit legitime Sequenzen wie
+   "Quelle", "neue", "bauen", "manuell", "issued", "true" erhalten bleiben.
+2. Trigger-Phrasen in der description bieten weiterhin beide Schreibweisen an
+   (vorhandenes "X / Y"-Umlaut-Paar-Muster bleibt erhalten).
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+SKILLS_DIR = Path(__file__).parent.parent / "skills"
+
+AFFECTED_SKILLS = [
+    "reading-list-import",
+    "material-passport",
+    "book-handler",
+    "cluster-visualizer",
+    "citation-style-import",
+    "zotero-import",
+    "notebook-bundle",
+]
+
+# Exakte ASCII-substituierte Woerter, die NICHT mehr vorkommen duerfen.
+# Bewusst keine Regex-Heuristik: nur diese konkreten Tokens werden verboten,
+# damit legitime ue/oe/ae-Sequenzen (Quelle, neue, bauen, manuell, ...) bleiben.
+FORBIDDEN_ASCII_WORDS = {
+    # ue -> ü
+    "Abhaengigkeiten", "Ausfaelle", "Einschraenkungen", "Eintraege",
+    "fortfaehrst", "fuehren", "fuehrt", "Fuer", "fuer", "koennen",
+    "moechte", "moegliche", "moeglich", "Pruefe", "prueft", "Pruefung",
+    "Prueft", "ueber", "ueberprueft", "uebersprungen", "uebersprungener",
+    "uebertragen", "uebrigen", "Unterstuetzt", "Unterstuetzte",
+    "unterstuetzt", "verfuegbar", "Verfuegbarkeit", "vervollstaendigt",
+    "Buecher", "ausfuehren", "ausgefuehrt", "duerfen", "gewuenschte",
+    "Groesse", "Abkuerzungsregeln", "zurueck", "zurueckgegeben",
+    "ausgewaehlten", "Quelltext",  # Quelltext -> Quelltext bleibt, s. unten
+    # ae -> ä
+    "Fehlerfaelle", "ergaenzt", "enthaelt", "erhaelt", "Klaere",
+    "bestaetigen", "Bestaetigung", "bestaetigt", "repraesentieren",
+    "Vollstaendige", "vollstaendige", "vollstaendigen", "persoenliches",
+    # oe -> ö
+    "Bloecke", "ermoeglicht", "Loeschen", "Loest", "aufloesen",
+    "zusaetzlich", "Aufloesung",
+    "Uebersicht", "Ueberblick",
+    "Laedt",
+}
+# "Quelltext" enthaelt KEIN Substitut (Quell+text). Wieder entfernen:
+FORBIDDEN_ASCII_WORDS.discard("Quelltext")
+
+# Token-weise pruefen: Worttrenner = alles ausser Buchstaben.
+WORD_RE = re.compile(r"[A-Za-zÄÖÜäöüß]+")
+
+# Umlaut-Paar in description: "...ä.../..." analog test_skills_manifest.
+DESC_PAIR_RE = re.compile(r'"[^"]*[äöüß][^"]*\s*/\s*[a-zA-Z][^"]*"')
+
+
+def _read(skill: str) -> str:
+    return (SKILLS_DIR / skill / "SKILL.md").read_text(encoding="utf-8")
+
+
+def _description(text: str) -> str:
+    m = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
+    if not m:
+        return ""
+    fm = m.group(1)
+    # description kann mehrzeilig sein (>- Block oder gequotet)
+    dm = re.search(r"^description:\s*(.*(?:\n[ \t]+.*)*)", fm, re.MULTILINE)
+    return dm.group(1) if dm else ""
+
+
+@pytest.mark.parametrize("skill", AFFECTED_SKILLS)
+def test_no_ascii_substituted_words(skill: str) -> None:
+    text = _read(skill)
+    found = sorted({w for w in WORD_RE.findall(text) if w in FORBIDDEN_ASCII_WORDS})
+    assert not found, (
+        f"skills/{skill}/SKILL.md enthaelt ASCII-substituierte Woerter "
+        f"(Umlaute restaurieren): {found}"
+    )
+
+
+@pytest.mark.parametrize("skill", AFFECTED_SKILLS)
+def test_description_offers_umlaut_variant(skill: str) -> None:
+    """Trigger-Phrasen mit Umlaut bieten weiterhin beide Schreibweisen an."""
+    desc = _description(_read(skill))
+    pairs = DESC_PAIR_RE.findall(desc)
+    assert pairs, (
+        f"skills/{skill}/SKILL.md: description bietet kein 'mit/ohne Umlaut'-Paar "
+        f'("X / Y") mehr an'
+    )


### PR DESCRIPTION
## Problem

Die globale CLAUDE.md verlangt volle Orthografie (Umlaute, ß — nie ASCII-Ersatz). Mehrere v6.5-Skills verstießen durchgehend dagegen und verwendeten ASCII-Substitution (`ue`, `ae`, `oe`, `ss`) statt korrekter Umlaute — sowohl im Body als auch in den `description`-Trigger-Phrasen, was die Trigger-Erkennungsrate senken kann.

Betroffene Dateien (Issue-Body + Audit-Erweiterung):

- `skills/reading-list-import/SKILL.md`
- `skills/material-passport/SKILL.md`
- `skills/book-handler/SKILL.md`
- `skills/cluster-visualizer/SKILL.md`
- `skills/citation-style-import/SKILL.md`
- `skills/zotero-import/SKILL.md`
- `skills/notebook-bundle/SKILL.md`

## Fix

Wort-für-Wort-Restauration über eine explizite Token-Map (`ue→ü`, `ae→ä`, `oe→ö`, `ss→ß`) in Body **und** `description`. **Kein blindes `sed s/ue/ü/g`**: nur exakt aufgelistete ASCII-Tokens werden ersetzt, damit legitime Sequenzen wie `Quelle`, `neue`, `bauen`, `manuell`, `issued`, `Crossref`, `Voraussetzungen`, `wissenschaftlichen` unangetastet bleiben.

Die `description`-Trigger-Phrasen behalten ihre vorhandenen "mit/ohne Umlaut"-Paare (z.B. `"Auflösung / Resolution"`, `"Bücher / große Dokumente"`) analog zu grant-proposal/topic-brainstorm.

## TDD-Belege

Neuer Regressionstest `tests/test_issue_175_skill_orthography.py` kodiert beide Akzeptanzkriterien:

1. `test_no_ascii_substituted_words` — keine der bekannten ASCII-substituierten deutschen Wörter mehr in den 7 Dateien.
2. `test_description_offers_umlaut_variant` — `description` bietet weiterhin ein "X / Y"-Umlaut-Paar an.

- **Rot (vorher):** `7 failed, 7 passed` — alle 7 `test_no_ascii_substituted_words`-Fälle scheiterten (z.B. `notebook-bundle: ['Bloecke', 'Buecher', 'Eintraege', 'Fuer', 'Groesse', 'Uebersicht', ...]`).
- **Grün (nachher):** `14 passed`.
- **Volle Suite:** `977 passed, 148 skipped` (Baseline 963 + 14 neue Tests, 0 Failures, keine Regression).

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)
