### PR TITLE
fix(skill): BibTeX-Trigger-Konflikt latex-export vs citation-extraction abgrenzen (#176)

### DIFF
--- a/skills/citation-extraction/SKILL.md
+++ b/skills/citation-extraction/SKILL.md
@@ -25,6 +25,12 @@ Extrahiert und formatiert wörtliche Zitate aus PDFs für einzelne Belege.
 Für Kapitel-Prosa, die Belege in Argumentation einbaut → `chapter-writer`
 (ruft `citation-extraction` bei Bedarf auf).
 
+**BibTeX-Abgrenzung:** Der BibTeX-Output dieses Skills = einzelne Zitate aus
+PDF-Extraktion (one-shot, aus dem aktuell betrachteten Quellmaterial). Für den
+vollständigen Vault→`.bib`-Export aller Papers (Bibliography-Dump zur
+LaTeX-Kompilation) → `latex-export --bib`. Phrasen wie „BibTeX aus Vault" oder
+„komplette Bibliographie als .bib" gehören zu `latex-export`, nicht hierher.
+
 ## Variant-Selector
 
 Lies `./academic_context.md`, Feld `Zitationsstil`. Lade die entsprechende Variant-Datei:
@@ -192,7 +198,8 @@ Bei erkannten Lücken `/search` mit gezielten Queries anbieten oder den Skill `l
 
 Diese Output-Formate werden unterstützt (inline generiert, kein externes Skript):
 
-- **BibTeX** — für LaTeX-Integration
+- **BibTeX** — für LaTeX-Integration einzelner extrahierter Zitate (one-shot).
+  Für den vollständigen Vault→`.bib`-Dump aller Papers → `latex-export --bib`.
 - **Markdown** — für Review und manuelles Editieren
 - **JSON** — für die programmatische Nutzung durch andere Skills
 

--- a/skills/latex-export/SKILL.md
+++ b/skills/latex-export/SKILL.md
@@ -34,6 +34,11 @@ description: Use this skill for LaTeX-Output / .tex-Export. Triggers on "Kapitel
 | `book` | `@book` | author, title, publisher, year |
 | `chapter` | `@incollection` | author, title, booktitle, year |
 
+## BibTeX-Abgrenzung
+
+BibTeX hier = Vault-weiter Bibliography-Dump (alle Papers).
+Einzelzitat aus PDF (one-shot) → `citation-extraction`.
+
 ## Verbatim-Guard
 
 Hook `hooks/verbatim-guard.mjs` schützt `*.tex`-Writes (wie `kapitel/*.md`).

--- a/tests/test_issue_176_bibtex_trigger.py
+++ b/tests/test_issue_176_bibtex_trigger.py
@@ -1,0 +1,76 @@
+"""Regression-Test fuer Issue #176.
+
+Trigger-Konflikt latex-export vs citation-extraction beim BibTeX-Output:
+Die User-Phrase "Erstelle mir eine BibTeX-Datei" triggerte beide Skills.
+Beide SKILL.md muessen einen Abgrenzungs-Block enthalten, der den
+BibTeX-Scope klar zuordnet:
+
+- citation-extraction = Einzelzitat-Extraktion aus PDF (one-shot)
+- latex-export        = vollstaendiger Vault-Bibliography-Dump
+
+Offline-hermetisch: prueft ausschliesslich Datei-Inhalte, kein Netzwerk.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+SKILLS_DIR = Path(__file__).parent.parent / "skills"
+CITATION_SKILL = SKILLS_DIR / "citation-extraction" / "SKILL.md"
+LATEX_SKILL = SKILLS_DIR / "latex-export" / "SKILL.md"
+
+
+def _read(path: Path) -> str:
+    assert path.exists(), f"SKILL.md fehlt: {path}"
+    return path.read_text(encoding="utf-8")
+
+
+def test_citation_extraction_grenzt_vault_bibtex_ab() -> None:
+    """citation-extraction muss Vault-weiten .bib-Export an latex-export delegieren."""
+    text = _read(CITATION_SKILL)
+    assert "latex-export" in text, (
+        "citation-extraction/SKILL.md verweist nicht auf latex-export fuer "
+        "den vollstaendigen Vault->.bib-Export (Issue #176)"
+    )
+    # Der Verweis muss im BibTeX-/Export-Kontext stehen, nicht irgendwo.
+    bibtex_section = re.search(
+        r"BibTeX[^\n]*\n(?:.*\n){0,12}", text, re.IGNORECASE
+    )
+    assert bibtex_section is not None, "Kein BibTeX-Abschnitt in citation-extraction"
+    assert "latex-export" in bibtex_section.group(0), (
+        "Der Verweis auf latex-export steht nicht im BibTeX-Kontext "
+        "(Issue #176: Abgrenzung des one-shot-Einzelzitats vom Vault-Dump)"
+    )
+
+
+def test_latex_export_grenzt_einzelzitat_ab() -> None:
+    """latex-export muss Einzelzitat-Extraktion an citation-extraction delegieren."""
+    text = _read(LATEX_SKILL)
+    assert "citation-extraction" in text, (
+        "latex-export/SKILL.md verweist nicht auf citation-extraction fuer "
+        "die Einzelzitat-Extraktion aus PDFs (Issue #176)"
+    )
+
+
+def test_latex_export_behaelt_vault_bibtex_trigger() -> None:
+    """Routing-Signal: 'BibTeX aus Vault' bleibt latex-export zugeordnet.
+
+    Akzeptanzkriterium #3: User-Phrase 'BibTeX aus Vault' trifft latex-export.
+    """
+    text = _read(LATEX_SKILL)
+    m = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
+    assert m is not None, "Kein Frontmatter in latex-export/SKILL.md"
+    frontmatter = m.group(1)
+    assert "BibTeX aus Vault" in frontmatter, (
+        "latex-export-Description nennt 'BibTeX aus Vault' nicht mehr als Trigger "
+        "(Issue #176, Akzeptanzkriterium #3)"
+    )
+    # citation-extraction darf diesen Vault-weiten Trigger gerade NICHT fuer sich
+    # beanspruchen.
+    cite = _read(CITATION_SKILL)
+    cite_fm = re.match(r"^---\n(.*?)\n---", cite, re.DOTALL)
+    assert cite_fm is not None
+    assert "BibTeX aus Vault" not in cite_fm.group(1), (
+        "citation-extraction-Description beansprucht den Vault-weiten "
+        "'BibTeX aus Vault'-Trigger (Overtriggering, Issue #176)"
+    )


### PR DESCRIPTION
## Problem

Zwei Skills produzierten BibTeX-Output ohne klare Abgrenzung:

- `skills/latex-export/SKILL.md`: `.bib`-Output via `--bib refs.bib` (Vault-weiter Dump)
- `skills/citation-extraction/SKILL.md`: „BibTeX — für LaTeX-Integration" (Einzelzitat aus PDF)

Die User-Phrase „Erstelle mir eine BibTeX-Datei" konnte beide Skills triggern → Race / inkonsistentes Verhalten (Pre-Release-Audit MAJOR, skill-reviewer Cross-Skill-Konflikt #2).

## Fix

Beide SKILL.md erhalten einen expliziten BibTeX-Abgrenzungs-Block:

- `citation-extraction`: BibTeX = einzelne Zitate aus PDF-Extraktion (one-shot). Vollständiger Vault→`.bib`-Export aller Papers → `latex-export --bib`. Auch in den Export-Formaten ergänzt.
- `latex-export`: BibTeX = Vault-weiter Bibliography-Dump (alle Papers). Einzelzitat-Extraktion aus PDF → `citation-extraction`.

Der Trigger „BibTeX aus Vault" bleibt damit eindeutig `latex-export` zugeordnet; `citation-extraction` beansprucht ihn nicht. Der Eingriff ist minimal und hält die `test_token_reduction`-Budgets beider Skills ein.

## TDD-Belege

Neuer offline-hermetischer Regressionstest `tests/test_issue_176_bibtex_trigger.py` (3 Cases):

- `test_citation_extraction_grenzt_vault_bibtex_ab` — Verweis auf `latex-export` im BibTeX-Kontext
- `test_latex_export_grenzt_einzelzitat_ab` — Verweis auf `citation-extraction`
- `test_latex_export_behaelt_vault_bibtex_trigger` — „BibTeX aus Vault" bleibt latex-export-Trigger, citation-extraction beansprucht ihn nicht

Rot → Grün: Vor dem Fix schlugen die ersten beiden Cases fehl (`AssertionError: ... verweist nicht auf latex-export/citation-extraction`). Nach dem Fix: 3 passed.

Volle Suite lokal (`/tmp/v652-venv/bin/pytest tests/ -p no:cacheprovider -q`): 966 passed, 148 skipped, 0 failed (Baseline 963 + 3 neue Tests). CI-Checks (jq/node/Frontmatter) unberührt — keine JSON-/Hook-/Command-Änderungen.

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)
