### PR TITLE
fix(security): Symlink-Path-Traversal in restore_snapshot schliessen (#192)

### DIFF
--- a/academic_vault/server.py
+++ b/academic_vault/server.py
@@ -681,10 +681,32 @@ def restore_snapshot(
     target_path.mkdir(parents=True, exist_ok=True)
 
     try:
+        dest = target_path.resolve()
         with tarfile.open(str(tar_path), "r:gz") as tar:
-            # Nur sichere Mitglieder extrahieren (kein path-traversal)
-            members = [m for m in tar.getmembers() if not m.name.startswith('/') and '..' not in m.name]
-            tar.extractall(str(target_path), members=members)
+            # Sicher extrahieren (CVE-2007-4559 / CWE-22, Issue #192).
+            # Schicht 1: Symlink-/Hardlink-Member und Path-Traversal pro
+            # Member explizit ablehnen — funktioniert auch auf Python < 3.12
+            # ohne PEP-706-Filter.
+            safe_members = []
+            for m in tar.getmembers():
+                if m.issym() or m.islnk():
+                    # Symlinks/Hardlinks erlauben Escapes aus dem Zielverzeichnis.
+                    raise ValueError(f"symlink/hardlink not allowed: {m.name}")
+                if m.name.startswith("/"):
+                    raise ValueError(f"absolute path not allowed: {m.name}")
+                resolved = (dest / m.name).resolve()
+                if resolved != dest and dest not in resolved.parents:
+                    raise ValueError(f"path traversal: {m.name}")
+                safe_members.append(m)
+            # Schicht 2: PEP-706-data-Filter (Python 3.12+, backportiert auf
+            # 3.9.17+/3.10.12+/3.11.4+). Blockiert Symlink-Escape und
+            # Path-Traversal zusaetzlich auf C-Ebene. Wenn nicht verfuegbar,
+            # greift nur Schicht 1.
+            try:
+                tar.extractall(str(target_path), members=safe_members, filter="data")
+            except TypeError:
+                # filter-Argument auf aelteren Pythons nicht vorhanden
+                tar.extractall(str(target_path), members=safe_members)
         return True
     except Exception:
         return False

--- a/tests/test_history_restore.py
+++ b/tests/test_history_restore.py
@@ -176,3 +176,128 @@ def test_restore_snapshot_extracts_files(tmp_path, vault_db):
     # Datei muss wiederhergestellt sein
     restored = (project_dir / "academic_context.md").read_text()
     assert "Original" in restored, f"Restore fehlgeschlagen: {restored!r}"
+
+
+# ---------------------------------------------------------------------------
+# Security: Path-Traversal / Symlink-Escape (Issue #192, CVE-2007-4559)
+# ---------------------------------------------------------------------------
+
+def _build_malicious_tar(tar_path: Path, build_members) -> None:
+    """Hilfsfunktion: erstellt einen .tgz mit den von build_members(tar)
+    hinzugefuegten Mitgliedern (umgeht den export_snapshot-Pfad, um boese
+    Member injizieren zu koennen)."""
+    tar_path.parent.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(str(tar_path), "w:gz") as tar:
+        build_members(tar)
+
+
+def test_restore_snapshot_rejects_symlink_escape(tmp_path):
+    """restore_snapshot extrahiert KEINE Symlink-Member, die aus dem
+    Zielverzeichnis herauszeigen (Symlink-Path-Traversal, CVE-2007-4559)."""
+    import io
+    from academic_vault.server import restore_snapshot
+
+    # Ziel ausserhalb des Extraktionsverzeichnisses, das angegriffen wird
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    secret = outside / "secret.txt"
+    secret.write_text("ORIGINAL-SECRET")
+
+    snapshots_dir = tmp_path / "snapshots"
+    tar_path = snapshots_dir / "evil" / "20990101-0000.tgz"
+
+    def build(tar):
+        # 1) Symlink, der aus dem Zielverzeichnis auf die Geheimdatei zeigt
+        link = tarfile.TarInfo(name="evil_link")
+        link.type = tarfile.SYMTYPE
+        link.linkname = str(secret)
+        tar.addfile(link)
+        # 2) Schreibversuch durch den Symlink hindurch (ueberschreibt secret)
+        payload = b"PWNED"
+        data = tarfile.TarInfo(name="evil_link")
+        data.size = len(payload)
+        tar.addfile(data, io.BytesIO(payload))
+
+    _build_malicious_tar(tar_path, build)
+
+    target = tmp_path / "target"
+    target.mkdir()
+
+    # Restore darf das Geheimnis ausserhalb von target NICHT veraendern
+    restore_snapshot(
+        slug="evil",
+        ts="20990101-0000",
+        snapshots_dir=str(snapshots_dir),
+        target_dir=str(target),
+    )
+
+    assert secret.read_text() == "ORIGINAL-SECRET", (
+        "Symlink-Escape erfolgreich — Datei ausserhalb von target wurde veraendert!"
+    )
+
+
+def test_restore_snapshot_rejects_absolute_and_dotdot_paths(tmp_path):
+    """restore_snapshot extrahiert KEINE Member mit '..'-Komponenten,
+    die aus dem Zielverzeichnis herauszeigen (klassischer Path-Traversal)."""
+    import io
+    from academic_vault.server import restore_snapshot
+
+    snapshots_dir = tmp_path / "snapshots"
+    tar_path = snapshots_dir / "evil2" / "20990101-0001.tgz"
+
+    escape_target = tmp_path / "escaped.txt"
+
+    def build(tar):
+        payload = b"PWNED-TRAVERSAL"
+        info = tarfile.TarInfo(name="../escaped.txt")
+        info.size = len(payload)
+        tar.addfile(info, io.BytesIO(payload))
+
+    _build_malicious_tar(tar_path, build)
+
+    target = tmp_path / "target2"
+    target.mkdir()
+
+    restore_snapshot(
+        slug="evil2",
+        ts="20990101-0001",
+        snapshots_dir=str(snapshots_dir),
+        target_dir=str(target),
+    )
+
+    assert not escape_target.exists(), (
+        f"Path-Traversal erfolgreich — Datei wurde ausserhalb von target "
+        f"geschrieben: {escape_target}"
+    )
+
+
+def test_restore_snapshot_still_extracts_benign_files(tmp_path):
+    """Sanity-Check: harmlose, regulaere Dateien werden weiterhin extrahiert."""
+    import io
+    from academic_vault.server import restore_snapshot
+
+    snapshots_dir = tmp_path / "snapshots"
+    tar_path = snapshots_dir / "good" / "20990101-0002.tgz"
+
+    def build(tar):
+        payload = b"# Kontext\n"
+        info = tarfile.TarInfo(name="academic_context.md")
+        info.size = len(payload)
+        tar.addfile(info, io.BytesIO(payload))
+
+    _build_malicious_tar(tar_path, build)
+
+    target = tmp_path / "target3"
+    target.mkdir()
+
+    result = restore_snapshot(
+        slug="good",
+        ts="20990101-0002",
+        snapshots_dir=str(snapshots_dir),
+        target_dir=str(target),
+    )
+
+    assert result is True
+    extracted = target / "academic_context.md"
+    assert extracted.exists(), "Harmlose Datei wurde nicht extrahiert"
+    assert extracted.read_text() == "# Kontext\n"


### PR DESCRIPTION
## Problem

`restore_snapshot` in `academic_vault/server.py` entpackte Snapshot-Tarballs mit
`tarfile.extractall`. Der vorgeschaltete Filter prüfte lediglich auf einen
`/`-Präfix und `..`-Substrings im Member-Namen, ließ aber Symlink- und
Hardlink-Member ungeprüft durch. Ein präparierter Tarball konnte so über einen
Symlink mit harmlos aussehendem Namen aus dem Zielverzeichnis heraus schreiben
(Path-Traversal via Symlink, CWE-22 / CVE-2007-4559, Security-Audit Round-2
Finding H3).

## Fix

Das Entpacken wurde in zwei Schichten abgesichert:

- **Schicht 1 (versionsunabhängig):** Pro Member werden Symlinks/Hardlinks und
  absolute Pfade abgelehnt. Der aufgelöste Zielpfad (`(dest / m.name).resolve()`)
  muss innerhalb des aufgelösten Zielverzeichnisses liegen, sonst wird
  abgebrochen. Funktioniert auch auf Python < 3.12 ohne PEP-706-Filter.
- **Schicht 2:** Zusätzlich wird der PEP-706-Filter `filter='data'`
  (Python 3.12+, backportiert auf 3.9.17+/3.10.12+/3.11.4+) aktiviert, der
  Symlink-Escape und Path-Traversal auf Bibliotheksebene blockiert. Fehlt das
  `filter`-Argument (ältere Pythons), fällt der Code per `except TypeError`
  sauber auf Schicht 1 zurück.

Harmlose reguläre Dateien werden weiterhin extrahiert; das Verhalten von
`restore_snapshot` für legitime Snapshots bleibt unverändert.

## TDD-Belege

Neue Regressionstests in `tests/test_history_restore.py`:

- `test_restore_snapshot_rejects_symlink_escape` — präparierter Tarball mit
  Symlink aus dem Zielverzeichnis heraus + Schreibversuch durch den Symlink.
  Vor dem Fix **rot**: `AssertionError: Symlink-Escape erfolgreich` /
  `'PWNED' == 'ORIGINAL-SECRET'`. Nach dem Fix **grün**.
- `test_restore_snapshot_rejects_absolute_and_dotdot_paths` — `../`-Traversal.
- `test_restore_snapshot_still_extracts_benign_files` — Sanity-Check, dass
  legitime Dateien weiterhin entpackt werden.

Belege:
- Vorher: `1 failed, 8 passed` (Symlink-Escape-Test rot).
- Nachher: `tests/test_history_restore.py` → `9 passed`.
- Volle Suite: `966 passed, 148 skipped` (Baseline 963 passed + 3 neue Tests,
  0 failed, 0 errors).

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)
