### PR TITLE
fix(skill): Trigger-Konflikt chapter-writer vs advisor aufloesen (#178)

### DIFF
--- a/evals/advisor/trigger_evals.json
+++ b/evals/advisor/trigger_evals.json
@@ -1,5 +1,5 @@
 {
   "component": "advisor",
-  "should_trigger": ["Pruefe meine Gliederung", "Gliederung pruefen, bitte", "Ist meine Argumentation schluessig?", "Schau dir mein Exposee an", "Expose feedback", "outline review", "Hilf mir, die Kapitel zu strukturieren", "Review meiner Argumentationskette", "Pruefe, ob meine Unterkapitel sinnvoll sind", "Bewerte meinen Gliederungsentwurf"],
-  "should_not_trigger": ["Schärfe meine Forschungsfrage", "Welche Methodik passt?", "Schreib das Theorie-Kapitel", "Finde Paper zu meinem Thema", "Erzeuge Abstract", "Pruefe Formatierung", "Bewerte meinen Stil", "Welche Quellen fehlen?", "Gib mir einen Titel", "Pruefe Plagiat"]
+  "should_trigger": ["Pruefe meine Gliederung", "Gliederung pruefen, bitte", "Ist meine Argumentation schluessig?", "Schau dir mein Exposee an", "Expose feedback", "Argumentations-Outline review", "Mein Diskussionskapitel braucht Feedback zur Struktur", "Review meiner Argumentationskette", "Pruefe, ob meine Unterkapitel sinnvoll sind", "Bewerte meinen Gliederungsentwurf"],
+  "should_not_trigger": ["Schärfe meine Forschungsfrage", "Welche Methodik passt?", "Schreib das Theorie-Kapitel", "Diskussionsteil ausformulieren", "Finde Paper zu meinem Thema", "Erzeuge Abstract", "Pruefe Formatierung", "Welche Quellen fehlen?", "Gib mir einen Titel", "Pruefe Plagiat"]
 }

--- a/evals/chapter-writer/trigger_evals.json
+++ b/evals/chapter-writer/trigger_evals.json
@@ -1,5 +1,5 @@
 {
   "component": "chapter-writer",
-  "should_trigger": ["Schreib das Einleitungskapitel", "Kapitel 3 verfassen, bitte", "Text zum Grundlagen-Abschnitt", "Ein Absatz zu DevOps Governance", "Einleitung schreiben", "Uebergang zwischen Kapiteln", "Diskussions-Absatz zu Ergebnis X", "Chapter prose generieren", "Schreib die Zusammenfassung", "200 Woerter zu Theorie Y"],
-  "should_not_trigger": ["Zitat nach APA formatieren", "Forschungsfrage schaerfen", "Gliederung pruefen", "Paper suchen", "Abstract erzeugen", "Titel vorschlagen", "Stilbewertung", "Methodik waehlen", "Plagiat pruefen", "FH-Leibniz-Formalia pruefen"]
+  "should_trigger": ["Schreib das Einleitungskapitel", "Kapitel 3 verfassen, bitte", "Theorieteil ausformulieren", "Diskussionsteil drafted, bitte", "Einleitung schreiben", "Uebergang zwischen Kapiteln", "Diskussions-Absatz zu Ergebnis X schreiben", "Chapter prose generieren", "Schreib die Zusammenfassung", "200 Woerter zu Theorie Y schreiben"],
+  "should_not_trigger": ["Zitat nach APA formatieren", "Forschungsfrage schaerfen", "Gliederung pruefen", "Mein Diskussionskapitel braucht Feedback zur Struktur", "Paper suchen", "Abstract erzeugen", "Titel vorschlagen", "Methodik waehlen", "Plagiat pruefen", "FH-Leibniz-Formalia pruefen"]
 }

--- a/skills/advisor/SKILL.md
+++ b/skills/advisor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: advisor
-description: Use this skill when the user needs structural feedback on their outline, argumentation flow, or exposé. Triggers on "Gliederung prüfen / Gliederung pruefen", "Argumentationskette", "Kapitel-Feedback", "Exposé feedback", "Exposee-Bewertung", "outline review", or when another skill detects structural weaknesses. Baut die Gliederung und den Argumentations-Fluss; Für Schärfung der Forschungsfrage → `research-question-refiner`. Für Methodenwahl → `methodology-advisor`.
+description: Use this skill for structural feedback on outline, argumentation flow, or exposé — Review ohne Neuschrieb. Triggers on "Gliederung prüfen / Gliederung pruefen", "Argumentations-Outline review", "Exposé feedback / Expose feedback", "Exposee-Bewertung", or when another skill detects structural weaknesses. Für das tatsächliche SCHREIBEN eines Kapitels → `chapter-writer`. Für Schärfung der Forschungsfrage → `research-question-refiner`. Für Methodenwahl → `methodology-advisor`.
 license: MIT
 ---
 
@@ -13,20 +13,20 @@ license: MIT
 
 ## Übersicht
 
-Supervisor-Agent für die Gesamt-Gliederung einer Arbeit. Bewertet Struktur,
-schlägt Kapitel-Reorganisation vor, liefert Expose-Templates. Orchestriert
-andere Skills, wenn spezifische Themenbereiche vertieft werden müssen.
+Supervisor-Agent für die Gesamt-Gliederung. Bewertet Struktur, schlägt
+Kapitel-Reorganisation vor und liefert Expose-Templates.
 
 ## Abgrenzung
 
-Baut die Gliederung und das Exposé.
+Liefert Review/Feedback zu Struktur, Gliederung und Exposé — **ohne
+Neuschrieb** von Kapitel-Prosa.
+Für das tatsächliche Schreiben von Kapitel-Text (Text-Output) → `chapter-writer`.
 Für Schärfung der Forschungsfrage selbst → `research-question-refiner`.
 Für Methodenwahl und Scoring-Matrix → `methodology-advisor`.
 
 ## Bewertungskriterien (PASS/FAIL)
 
-Prüfe die Outline gegen diese 7 Kriterien. Jedes ist PASS oder FAIL — kein
-Zwischenstufen-Urteil:
+Prüfe die Outline gegen diese 7 Kriterien (je PASS oder FAIL):
 
 1. **Forschungsfrage formuliert** — ≤ 25 Wörter, eine W-Frage (Was/Wie/Warum/Inwiefern)
 2. **Outline mit ≥ 3 Kapiteln** — Haupt-Kapitel, nicht nur Gliederungspunkte
@@ -36,7 +36,7 @@ Zwischenstufen-Urteil:
 6. **Supervisor identifiziert** — Name in `./academic_context.md`
 7. **Abgabetermin fixiert** — konkretes Datum in `./academic_context.md`
 
-Ausgabe: Tabelle mit Kriterium + PASS/FAIL + Begründung bei FAIL.
+Ausgabe: Tabelle mit Kriterium + Status + Begründung bei FAIL.
 
 ## Kontext-Dateien
 

--- a/skills/chapter-writer/SKILL.md
+++ b/skills/chapter-writer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: chapter-writer
-description: Use this skill when the user writes a chapter of an academic work. Triggers on "Einleitung schreiben", "Theorieteil / Theoretischer Rahmen", "Methodik-Kapitel / Methodenteil", "Empirie / Ergebnisse darstellen", "Diskussion schreiben", "Fazit / Schlussteil", "Übergänge formulieren / Uebergaenge formulieren", or when a chapter body with proper citations is needed. Schreibt vollständige Kapitelentwürfe; Für Abstract/Keywords → `abstract-generator`; für Zitations-Formatierung → `citation-extraction`.
+description: Use this skill when the user wants a chapter SCHREIBEN (Text-Output, kein Review). Triggers on "Kapitel SCHREIBEN", "Einleitung schreiben", "Theorieteil ausformulieren / Theoretischer Rahmen", "Methodik-Kapitel / Methodenteil", "Diskussionsteil drafted", "Fazit / Schlussteil", "Übergänge formulieren / Uebergaenge formulieren". Für reines Struktur-/Gliederungs-Feedback ohne Neuschrieb → `advisor`. Für Abstract/Keywords → `abstract-generator`. Für Zitations-Formatierung → `citation-extraction`.
 compatibility: Claude API mit documents[] und citations.enabled
 license: MIT
 ---
@@ -15,12 +15,14 @@ license: MIT
 ## Übersicht
 
 Schreibt konkrete Kapitel (Einleitung, Theorieteil, Methodik, Empirie,
-Diskussion, Fazit) für akademische Arbeiten. Zieht Zitate via
-`vault.search()` + `vault.find_quotes()` und folgt dem Disziplin-Register.
+Diskussion, Fazit). Zieht Zitate via `vault.search()` +
+`vault.find_quotes()` und folgt dem Disziplin-Register.
 
 ## Abgrenzung
 
-Schreibt Kapitel-Prosa und baut Zitate in die Argumentation ein.
+Erzeugt Kapitel-Prosa als **Text-Output** und baut Zitate in die
+Argumentation ein.
+Für reines Struktur-/Gliederungs-Feedback ohne Neuschrieb → `advisor`.
 Für reines Extrahieren wörtlicher Zitate aus einem PDF → `citation-extraction`.
 
 ## Few-Shot-Beispiele (pro Kapiteltyp)
@@ -95,7 +97,7 @@ nicht die komplette Literaturliste.
 
 ### 2. Ziel-Kapitel bestimmen
 
-Frage den User, welches Kapitel oder welcher Abschnitt geschrieben werden soll, falls nicht klar. Kläre:
+Frage den User, welches Kapitel geschrieben werden soll, falls unklar. Kläre:
 
 - Kapitelnummer und -titel aus der Gliederung
 - Scope — Was soll das Kapitel leisten?
@@ -140,21 +142,21 @@ Plan dem User zur Freigabe vorlegen, bevor gedraftet wird.
 
 ### 4. Draften
 
-Schreibe das Kapitel Abschnitt für Abschnitt. Für jeden Abschnitt:
+Schreibe das Kapitel Abschnitt für Abschnitt. Je Abschnitt:
 
 1. Text in der Sprache der Arbeit entwerfen (Default: Deutsch)
 2. In-Text-Zitate im konfigurierten Zitationsstil einbauen (Default: APA7)
-3. Formales akademisches Register nutzen — keine Umgangssprache, keine Ich-Form, außer die Methodik verlangt es
+3. Formales akademisches Register — keine Umgangssprache, keine Ich-Form (außer die Methodik verlangt es)
 4. Wo sinnvoll, explizit an die Forschungsfrage anknüpfen
 5. Entwurf dem User zur Durchsicht vorlegen
 
 #### Schreibrichtlinien
 
 - **Absatzstruktur** — Topic Sentence, Ausarbeitung, Evidenz, Synthese
-- **Zitationsdichte** — In Theoriekapiteln mindestens ein Zitat pro substanzieller Aussage; weniger in Methodik/Analyse
+- **Zitationsdichte** — In Theoriekapiteln min. ein Zitat pro substanzieller Aussage; weniger in Methodik/Analyse
 - **Übergänge** — Jeder Abschnitt endet mit einer Brücke zum nächsten
-- **Hedging-Sprache** — Angemessene Abschwächung bei Aussagen ("deutet darauf hin", "weist darauf hin", "laut")
-- **Keine Füllwörter** — Jeder Satz muss zur Argumentation beitragen
+- **Hedging-Sprache** — Angemessene Abschwächung ("deutet darauf hin", "weist darauf hin", "laut")
+- **Keine Füllwörter** — Jeder Satz trägt zur Argumentation bei
 
 #### Quellenintegration
 

--- a/tests/test_issue_178_trigger_conflict.py
+++ b/tests/test_issue_178_trigger_conflict.py
@@ -1,0 +1,124 @@
+"""Regression-Guard fuer Issue #178 — Trigger-Konflikt chapter-writer vs advisor.
+
+User-Phrase "Mein Diskussionskapitel braucht Feedback" durfte frueher BEIDE
+Skills triggern. Dieser Test kodiert die Akzeptanzkriterien aus #178 offline
+(kein Netzwerk noetig): er asserted die geforderten Trigger-Abgrenzungen und
+die wechselseitige Abgrenzungs-Section direkt im SKILL.md-Text.
+
+Akzeptanzkriterien (#178):
+- advisor: Trigger auf strukturelle Feedback-Phrasen beschraenken
+  ("Gliederung pruefen", "Argumentations-Outline review", "Expose feedback");
+  die mehrdeutige Phrase "Kapitel-Feedback" entfaellt.
+- chapter-writer: Trigger auf Schreib-Aktion fokussieren
+  ("Kapitel SCHREIBEN", "Diskussionsteil drafted", "Theorieteil ausformulieren").
+- Beide SKILL.md: Abgrenzungs-Section, die chapter-writer = Text-Output und
+  advisor = Review/Feedback ohne Neuschrieb klar trennt.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+SKILLS_DIR = Path(__file__).parent.parent / "skills"
+ADVISOR_MD = SKILLS_DIR / "advisor" / "SKILL.md"
+CHAPTER_WRITER_MD = SKILLS_DIR / "chapter-writer" / "SKILL.md"
+
+
+def _frontmatter_description(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    m = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
+    assert m, f"{path}: kein Frontmatter gefunden"
+    fm = m.group(1)
+    desc_m = re.search(r"^description:\s*\|?\s*(.+?)(?=^[a-zA-Z_-]+:|\Z)", fm, re.M | re.S)
+    assert desc_m, f"{path}: keine description im Frontmatter"
+    return " ".join(desc_m.group(1).split())
+
+
+def _abgrenzung_section(path: Path) -> str:
+    """Extrahiert den Text der '## Abgrenzung'-Section (bis zur naechsten H2)."""
+    text = path.read_text(encoding="utf-8")
+    m = re.search(r"^## Abgrenzung\s*\n(.*?)(?=^## |\Z)", text, re.M | re.S)
+    assert m, f"{path}: keine '## Abgrenzung'-Section gefunden"
+    return m.group(1)
+
+
+# --- advisor: Trigger auf strukturelles Feedback beschraenken --------------
+
+
+def test_advisor_no_kapitel_feedback_trigger() -> None:
+    """Die mehrdeutige Phrase 'Kapitel-Feedback' darf advisor NICHT mehr triggern."""
+    desc = _frontmatter_description(ADVISOR_MD)
+    assert "Kapitel-Feedback" not in desc, (
+        "advisor description enthaelt noch die mehrdeutige Phrase 'Kapitel-Feedback' "
+        "— sie kollidiert mit chapter-writer (#178)."
+    )
+
+
+def test_advisor_has_structural_feedback_triggers() -> None:
+    """advisor muss strukturelle Feedback-Phrasen als Trigger fuehren."""
+    desc = _frontmatter_description(ADVISOR_MD)
+    assert "Gliederung prüfen" in desc or "Gliederung pruefen" in desc, (
+        "advisor description fehlt der strukturelle Trigger 'Gliederung pruefen'."
+    )
+    assert "Argumentations-Outline review" in desc, (
+        "advisor description fehlt der strukturelle Trigger 'Argumentations-Outline review'."
+    )
+    assert "Exposé feedback" in desc or "Expose feedback" in desc, (
+        "advisor description fehlt der strukturelle Trigger 'Expose feedback'."
+    )
+
+
+# --- chapter-writer: Trigger auf Schreib-Aktion fokussieren -----------------
+
+
+def test_chapter_writer_has_write_action_triggers() -> None:
+    """chapter-writer muss explizite Schreib-Aktions-Phrasen als Trigger fuehren."""
+    desc = _frontmatter_description(CHAPTER_WRITER_MD)
+    assert "Kapitel SCHREIBEN" in desc, (
+        "chapter-writer description fehlt der Schreib-Trigger 'Kapitel SCHREIBEN'."
+    )
+    assert "Diskussionsteil drafted" in desc, (
+        "chapter-writer description fehlt der Schreib-Trigger 'Diskussionsteil drafted'."
+    )
+    assert "Theorieteil ausformulieren" in desc, (
+        "chapter-writer description fehlt der Schreib-Trigger 'Theorieteil ausformulieren'."
+    )
+
+
+def test_chapter_writer_no_bare_feedback_trigger() -> None:
+    """chapter-writer darf keine reinen Feedback-Phrasen als Trigger fuehren."""
+    desc = _frontmatter_description(CHAPTER_WRITER_MD)
+    assert "Kapitel-Feedback" not in desc, (
+        "chapter-writer description enthaelt 'Kapitel-Feedback' — gehoert zu advisor (#178)."
+    )
+
+
+# --- Wechselseitige Abgrenzungs-Section -------------------------------------
+
+
+def test_chapter_writer_abgrenzung_marks_text_output() -> None:
+    """chapter-writer Abgrenzung muss sich als Text-Output gegen advisor abgrenzen."""
+    section = _abgrenzung_section(CHAPTER_WRITER_MD)
+    assert "advisor" in section, (
+        "chapter-writer Abgrenzung verweist nicht auf 'advisor' (#178)."
+    )
+    assert "Text" in section or "Output" in section, (
+        "chapter-writer Abgrenzung beschreibt nicht den Text-Output-Charakter (#178)."
+    )
+
+
+def test_advisor_abgrenzung_marks_review_no_rewrite() -> None:
+    """advisor Abgrenzung muss Review/Feedback ohne Neuschrieb betonen."""
+    section = _abgrenzung_section(ADVISOR_MD)
+    assert "chapter-writer" in section, (
+        "advisor Abgrenzung verweist nicht auf 'chapter-writer' (#178)."
+    )
+    assert "Neuschrieb" in section or "Neuschrieb" in section.replace("ß", "ss"), (
+        "advisor Abgrenzung erwaehnt nicht den fehlenden Neuschrieb (#178)."
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## Problem

Die Trigger-Descriptions von `chapter-writer` und `advisor` überlappten sich.
`advisor` listete die mehrdeutige Phrase „Kapitel-Feedback" als Trigger, während
`chapter-writer` mit „Diskussion schreiben" auf Schreib-Aktionen reagierte. Eine
User-Phrase wie „Mein Diskussionskapitel braucht Feedback" konnte dadurch beide
Skills triggern (Pre-Release-Audit MAJOR, skill-reviewer Cross-Skill-Konflikt #1).

## Fix

- `advisor/SKILL.md`: Trigger auf strukturelle Feedback-Phrasen beschränkt
  („Gliederung prüfen", „Argumentations-Outline review", „Exposé feedback");
  die mehrdeutige Phrase „Kapitel-Feedback" entfernt. Die description signalisiert
  jetzt explizit „Review ohne Neuschrieb".
- `chapter-writer/SKILL.md`: Trigger auf die Schreib-Aktion fokussiert
  („Kapitel SCHREIBEN", „Diskussionsteil drafted", „Theorieteil ausformulieren")
  und als „Text-Output, kein Review" gekennzeichnet.
- Beide `## Abgrenzung`-Sections trennen nun wechselseitig: chapter-writer =
  Text-Output, advisor = Review/Feedback ohne Neuschrieb, jeweils mit Verweis
  auf den anderen Skill.
- Trigger-Eval-Fixtures (`evals/*/trigger_evals.json`) an die neuen Trigger
  angeglichen; die Abgrenzungs-Phrase „Mein Diskussionskapitel braucht Feedback
  zur Struktur" routet jetzt nach advisor (should_trigger advisor /
  should_not_trigger chapter-writer).

Beide SKILL.md wurden netto verkleinert, damit der `token_reduction`-Regression-
Guard (>= 1400 Zeichen unter Baseline) erhalten bleibt.

## TDD-Belege

Neuer Offline-Regressionstest `tests/test_issue_178_trigger_conflict.py` kodiert
die drei Akzeptanzkriterien direkt gegen den SKILL.md-Text (kein Netzwerk).

- ROT vor dem Fix: `5 failed, 1 passed` — u.a.
  `test_advisor_no_kapitel_feedback_trigger`,
  `test_chapter_writer_has_write_action_triggers` (`assert 'Kapitel SCHREIBEN' in desc` schlug fehl),
  `test_advisor_abgrenzung_marks_review_no_rewrite` (`assert 'chapter-writer' in section` schlug fehl).
- GRÜN nach dem Fix: `165 passed` für
  `tests/test_issue_178_trigger_conflict.py tests/test_skills_manifest.py tests/test_skill_naming.py`.
- Volle Suite: `969 passed, 148 skipped` (Baseline `963 passed, 148 skipped` +
  6 neue Tests; keine Regression).

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)
