### PR TITLE
fix(doc): alle 28 Vault-MCP-Tools im README dokumentieren (#207)

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,25 +479,72 @@ Der **Vault** (`academic_vault/`) ist die Kernkomponente seit v6.0. Er ersetzt d
 
 **Datenbank:** `~/.academic-research/projects/<slug>/vault.db`
 
-### MCP-Tools (Auswahl)
+### MCP-Tools (alle 28)
 
-| Tool | Beschreibung |
-|------|-------------|
-| `vault.search(query, type?, top_k?)` | Hybrid-Suche (BM25 + vec0 + RRF) |
-| `vault.get_paper(paper_id)` | Metadaten + PDF-Status |
-| `vault.add_paper(csl_json)` | Paper einpflegen |
-| `vault.add_quote(paper_id, quote)` | Verbatim-Zitat mit Provenance |
-| `vault.find_quotes(paper_id, query, k?)` | Ähnlichkeitssuche über Zitate |
-| `vault.search_quote_text(text)` | Volltext-Suche Zitate |
-| `vault.add_decision(text, category)` | Entscheidung ins Decision-Log |
-| `vault.list_decisions(category?)` | Entscheidungen abrufen |
-| `vault.add_risk_of_bias(paper_id, data)` | RoB-Bewertung speichern |
-| `vault.add_score_snapshot(paper_id, scores)` | Score-Historie |
-| `vault.export_material_passport(paper_id)` | Material-Passport generieren |
-| `vault.lock_passport(paper_id)` | Passport unveränderlich sperren |
-| `vault.ensure_file(pdf_path)` | PDF → Anthropic Files-API (`file_id`) |
-| `vault.export_snapshot()` / `vault.restore_snapshot(ts)` | Backup/Restore |
-| `vault.stats()` | DB-Statistiken |
+Der Server registriert **28 MCP-Tools** (`@mcp.tool`). Maßgebliche Code-Referenz: [`academic_vault/server.py`](academic_vault/server.py) (Funktion `_build_mcp_server`). Die folgenden Tabellen sind nach Kategorie geordnet; Signatur mit Default-Werten, Beschreibung und Beispiel-Call.
+
+**Suche & Papers**
+
+| Tool (Signatur mit Defaults) | Beschreibung | Beispiel-Call |
+|------|-------------|------|
+| `vault.search(query, type=None, k=5, rerank=False)` | Hybrid-Suche (BM25 + vec0 + RRF); `rerank=True` aktiviert Voyage/Cohere | `vault.search("transformer attention", k=10)` |
+| `vault.get_paper(paper_id)` | Paper-Metadaten + `pdf_status` | `vault.get_paper("vaswani2017")` |
+| `vault.add_paper(paper_id, csl_json, pdf_path=None, doi=None, isbn=None, page_offset=0, editor=None, chapter=None, page_first=None, page_last=None, container_title=None, parent_paper_id=None)` | Upsert eines Papers; `type` aus `csl_json` | `vault.add_paper("vaswani2017", csl_json, doi="10.5555/...")` |
+| `vault.add_chapter(parent_paper_id, chapter_number, csl_json, paper_id=None, pdf_path=None, page_first=None, page_last=None)` | Legt Kapitel als Kind-Paper an; gibt `paper_id` zurück | `vault.add_chapter("book2020", 3, csl_json, page_first=45)` |
+| `vault.ensure_file(paper_id)` | PDF → Anthropic Files-API; gibt gecachte `file_id` zurück | `vault.ensure_file("vaswani2017")` |
+| `vault.stats()` | DB-Counts + Token-Ersparnis-Schätzung | `vault.stats()` |
+
+**Zitate (Quotes)**
+
+| Tool (Signatur mit Defaults) | Beschreibung | Beispiel-Call |
+|------|-------------|------|
+| `vault.add_quote(paper_id, verbatim, extraction_method, api_response_id=None, pdf_page=None, printed_page=None, section=None, context_before=None, context_after=None)` | Fügt Verbatim-Zitat mit Provenance ein; `extraction_method="citations-api"` erfordert `api_response_id` | `vault.add_quote("vaswani2017", "Attention is all you need", "citations-api", api_response_id="resp_1")` |
+| `vault.search_quote_text(verbatim, k=5)` | LIKE-Volltextsuche in `quotes.verbatim` (prüft, ob ein Zitat existiert) | `vault.search_quote_text("Attention is all", k=3)` |
+| `vault.find_quotes(paper_id, query=None, k=10)` | Gibt Quotes für ein Paper zurück (optional Ähnlichkeitssuche) | `vault.find_quotes("vaswani2017", query="self-attention")` |
+| `vault.get_quote(quote_id)` | Vollständiger Quote-Record | `vault.get_quote("q_42")` |
+
+**Figures & Tabellen** (v6.1 Figure-Verifier)
+
+| Tool (Signatur mit Defaults) | Beschreibung | Beispiel-Call |
+|------|-------------|------|
+| `vault.add_figure(paper_id, page=None, caption=None, vlm_description=None, data_extracted_json=None)` | Fügt Figure/Tabelle ein; gibt `figure_id` zurück | `vault.add_figure("vaswani2017", page=3, caption="Fig. 1: Architecture")` |
+| `vault.get_figure(figure_id)` | Gibt Figure-Record zurück oder `None` | `vault.get_figure("fig_7")` |
+| `vault.list_figures(paper_id)` | Alle Figures eines Papers, nach `page` sortiert | `vault.list_figures("vaswani2017")` |
+
+**OCR-Pipeline & Seitenzählung** (v6.1)
+
+| Tool (Signatur mit Defaults) | Beschreibung | Beispiel-Call |
+|------|-------------|------|
+| `vault.set_ocr_done(paper_id, value=1)` | Setzt `ocr_done`-Flag (`1`=OCR durchgeführt) | `vault.set_ocr_done("scan2019")` |
+| `vault.update_pdf_path(paper_id, new_path)` | Aktualisiert den PDF-Pfad nach OCR | `vault.update_pdf_path("scan2019", "/data/scan2019_ocr.pdf")` |
+| `vault.set_page_offset(paper_id, offset)` | Setzt `page_offset` (Bücher mit Vorseiten/Vorwort) | `vault.set_page_offset("book2020", 12)` |
+| `vault.get_printed_page(paper_id, pdf_page)` | Berechnet gedruckte Seite: `pdf_page - page_offset` | `vault.get_printed_page("book2020", 25)` |
+
+**Decision-Log & Ausschlüsse**
+
+| Tool (Signatur mit Defaults) | Beschreibung | Beispiel-Call |
+|------|-------------|------|
+| `vault.add_decision(category=None, text="", rationale=None)` | Fügt Entscheidung ins Decision-Log ein; gibt `decision_id` zurück | `vault.add_decision(category="scope", text="Nur Studien ab 2015", rationale="Aktualität")` |
+| `vault.list_decisions(category=None, active_only=True)` | Gibt Decisions zurück (optionaler `category`-Filter) | `vault.list_decisions(category="scope")` |
+| `vault.add_excluded_source(paper_id, reason=None)` | Fügt `paper_id` zu `excluded_sources` (verhindert Re-Vorschlag) | `vault.add_excluded_source("smith2010", reason="off-topic")` |
+| `vault.is_excluded(paper_id)` | Prüft, ob `paper_id` ausgeschlossen ist | `vault.is_excluded("smith2010")` |
+
+**Risk-of-Bias & Score-Historie** (v6.4)
+
+| Tool (Signatur mit Defaults) | Beschreibung | Beispiel-Call |
+|------|-------------|------|
+| `vault.add_risk_of_bias(paper_id, study_type, domain_scores)` | Fügt RoB-Assessment ein (`domain_scores` als JSON-String); gibt `assessment_id` zurück | `vault.add_risk_of_bias("rct2018", "RCT", '{"randomization":"low"}')` |
+| `vault.list_risk_of_bias(paper_id=None)` | Gibt RoB-Assessments zurück (optional nach `paper_id` gefiltert) | `vault.list_risk_of_bias("rct2018")` |
+| `vault.add_score_snapshot(paper_id, session_id, scores)` | Fügt Score-Snapshot ein (`scores` als JSON-String); gibt `snapshot_id` zurück | `vault.add_score_snapshot("rct2018", "sess_1", '{"relevance":0.8}')` |
+| `vault.get_score_history(paper_id, k=None)` | Score-History eines Papers (neueste zuerst) | `vault.get_score_history("rct2018", k=5)` |
+
+**Material-Passport & Lock** (v6.4)
+
+| Tool (Signatur mit Defaults) | Beschreibung | Beispiel-Call |
+|------|-------------|------|
+| `vault.export_material_passport(slug, output_dir=".", score_algo_version="1.0", plugin_version="6.4")` | Exportiert `material-passport.json`; gibt Dateipfad zurück | `vault.export_material_passport("mein-projekt")` |
+| `vault.lock_passport(slug)` | Setzt Vault-Lock für `slug` (macht Vault read-only) | `vault.lock_passport("mein-projekt")` |
+| `vault.is_locked(slug)` | Prüft, ob der Vault für `slug` gelockt ist | `vault.is_locked("mein-projekt")` |
 
 ### Halluzinationsschutz
 

--- a/tests/test_issue_207_readme_mcp_tools.py
+++ b/tests/test_issue_207_readme_mcp_tools.py
@@ -1,0 +1,65 @@
+"""Regressionstest fuer Issue #207 — README dokumentiert alle MCP-Tools.
+
+Befund (Doku-Drift): Die README-MCP-Sektion listete nur eine "Auswahl" der
+Tools, obwohl `academic_vault/server.py` 28 Tools via `@mcp.tool(name=...)`
+registriert. Dieser Test koppelt README und Code: jeder registrierte
+Tool-Name muss in der README dokumentiert sein, und die README muss auf die
+Code-Referenz `academic_vault/server.py` verlinken.
+"""
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+SERVER_PY = REPO_ROOT / "academic_vault" / "server.py"
+README = REPO_ROOT / "README.md"
+
+# Vom Code registrierte Tools sind die autoritative Quelle.
+TOOL_NAME_RE = re.compile(r'@mcp\.tool\(name="(vault\.[a-z_]+)"\)')
+
+
+def _registered_tools() -> list[str]:
+    return TOOL_NAME_RE.findall(SERVER_PY.read_text())
+
+
+def _readme_text() -> str:
+    return README.read_text()
+
+
+def test_all_28_tools_are_registered_in_server() -> None:
+    """Sanity-Check: server.py registriert genau 28 MCP-Tools (Drift-Anker)."""
+    tools = _registered_tools()
+    assert len(tools) == 28, (
+        f"Erwartet 28 registrierte @mcp.tool, gefunden {len(tools)}: {tools}"
+    )
+
+
+def test_every_registered_tool_documented_in_readme() -> None:
+    """Jeder in server.py registrierte vault.*-Tool steht in der README."""
+    readme = _readme_text()
+    tools = _registered_tools()
+    missing = [t for t in tools if t not in readme]
+    assert not missing, (
+        f"{len(missing)} registrierte MCP-Tools fehlen in der README: {missing}"
+    )
+
+
+def test_readme_links_to_server_code_reference() -> None:
+    """README MCP-Sektion verlinkt auf den Code (academic_vault/server.py)."""
+    readme = _readme_text()
+    assert "academic_vault/server.py" in readme, (
+        "README verlinkt nicht auf die Code-Referenz academic_vault/server.py"
+    )
+
+
+def test_readme_does_not_advertise_unregistered_snapshot_tools() -> None:
+    """export_snapshot/restore_snapshot sind KEINE @mcp.tool — duerfen nicht
+    als MCP-Tool-Signatur (vault.export_snapshot(...)) ausgegeben werden."""
+    readme = _readme_text()
+    tools = _registered_tools()
+    for ghost in ("vault.export_snapshot", "vault.restore_snapshot"):
+        if ghost not in tools:
+            assert ghost not in readme, (
+                f"README bewirbt nicht-registriertes Tool {ghost} "
+                f"(kein @mcp.tool in server.py)"
+            )


### PR DESCRIPTION
## Problem

Die README-MCP-Sektion (`## Vault-MCP-Server`) listete nur 16 Einträge — explizit als "Auswahl" deklariert —, obwohl `academic_vault/server.py` **28 Tools** via `@mcp.tool(name=...)` registriert. Damit fehlten 14 Kern-Tools in der Doku:

- `vault.add_chapter`
- `vault.add_figure`, `vault.get_figure`, `vault.list_figures` (v6.1 Figure-Verifier)
- `vault.set_ocr_done`, `vault.update_pdf_path`, `vault.set_page_offset`, `vault.get_printed_page` (v6.1 OCR-Pipeline)
- `vault.get_quote`
- `vault.add_excluded_source`, `vault.is_excluded`
- `vault.list_risk_of_bias`, `vault.get_score_history` (v6.4 Memory)
- `vault.is_locked`

Zusätzlich bewarb die README zwei Tools, die gar nicht als `@mcp.tool` registriert sind (`vault.export_snapshot()` / `vault.restore_snapshot(ts)` — das sind reine Python-Funktionen, keine MCP-Tools).

## Fix

Die MCP-Tools-Sektion wurde als kategorisierte Übersicht neu geschrieben (Suche & Papers / Zitate / Figures & Tabellen / OCR-Pipeline / Decision-Log & Ausschlüsse / Risk-of-Bias & Score-Historie / Material-Passport & Lock). Pro Tool sind nun **Signatur mit Default-Werten, Beschreibung und ein Beispiel-Call** dokumentiert — alle 28 registrierten Tools sind abgedeckt. Die irreführenden Snapshot-Tool-Signaturen wurden entfernt. Ergänzt wurde der Code-Referenz-Link auf [`academic_vault/server.py`](academic_vault/server.py).

## TDD-Belege

Neuer Regressionstest `tests/test_issue_207_readme_mcp_tools.py` parst die registrierten `@mcp.tool`-Namen aus `server.py` und koppelt README an Code (Doku-Vollständigkeit, Code-Link, keine Geister-Tools).

- **Rot (vor Fix):** `3 failed, 1 passed` — u.a. `AssertionError: 14 registrierte MCP-Tools fehlen in der README: ['vault.add_chapter', 'vault.get_quote', 'vault.set_ocr_done', ...]` sowie fehlender Code-Link und beworbenes `vault.export_snapshot`.
- **Grün (nach Fix):** `4 passed`.
- **Volle Suite:** `967 passed, 148 skipped` (Baseline `963 passed, 148 skipped` + 4 neue Tests, 0 failed/errors).

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)
