### PR TITLE
fix(security): auth-helper Credentials via ENV-Var statt browser-use-Prompt (#193)

### DIFF
--- a/agents/auth-helper.md
+++ b/agents/auth-helper.md
@@ -86,7 +86,40 @@ except Exception as e:
 PYEOF
 ```
 
-Die tatsaechlichen Credential-Werte (Passwort, Benutzername) werden direkt beim browser-use-Aufruf aus dem Profil gelesen, aber NICHT in diesen Output geschrieben.
+Die tatsaechlichen Credential-Werte (Passwort, Benutzername) werden NICHT in diesen Output geschrieben.
+
+#### Credentials in ENV-Variablen laden (NICHT in den Prompt)
+
+**Sicherheits-Kern (Fix #193):** Credential-Werte duerfen NIEMALS als Text in den
+browser-use-Prompt (Reasoning-Stream des LLM) gelangen — sonst leaken sie via
+Trace-Logs, Hook-Captures oder Error-Messages. Stattdessen werden sie in lokale
+Shell-ENV-Variablen geladen und ueber den deterministischen `browser-use input`-Befehl
+direkt in die Formular-Felder getippt. Der Wert wird von der Shell expandiert und
+erreicht das LLM nie.
+
+```bash
+# Benutzername/Passwort aus dem Profil in ENV-Variablen laden — KEIN echo/print der Werte.
+# Der erste Eintrag in credentials_keys ist der User-Schluessel, der zweite der Pass-Schluessel.
+export BROWSER_USE_USER="$(python3 - <<'PYEOF'
+import yaml, os
+with open(os.path.expanduser("~/.academic-research/library-profiles/active.yaml")) as f:
+    d = yaml.safe_load(f) or {}
+keys = d.get("credentials_keys", [])
+print(d.get(keys[0], "") if len(keys) > 0 else "", end="")
+PYEOF
+)"
+export BROWSER_USE_PASS="$(python3 - <<'PYEOF'
+import yaml, os
+with open(os.path.expanduser("~/.academic-research/library-profiles/active.yaml")) as f:
+    d = yaml.safe_load(f) or {}
+keys = d.get("credentials_keys", [])
+print(d.get(keys[1], "") if len(keys) > 1 else "", end="")
+PYEOF
+)"
+```
+
+Diese Variablen leben nur in der aktuellen Shell-Session, werden NIE per `echo`/`print`
+ausgegeben und nach dem Login mit `unset BROWSER_USE_USER BROWSER_USE_PASS` geloescht.
 
 ### Schritt 2: Auth-Typ bestimmen
 
@@ -120,14 +153,28 @@ Wenn NICHT enthalten:
 
 Baue die HAN-Proxy-URL aus `proxy_pattern` und dem Ziel-Hostnamen.
 
+Voraussetzung: `BROWSER_USE_USER` / `BROWSER_USE_PASS` sind bereits in der Shell gesetzt
+(siehe "Credentials in ENV-Variablen laden"). Die Werte werden NICHT in den Prompt geschrieben.
+
 ```bash
+# 1. Seite oeffnen und Formular-Struktur lesen (KEINE Credentials im Prompt).
+browser-use open "<proxy_url aus proxy_pattern>"
+browser-use state    # liefert die Element-Indizes der Login-Felder
+```
+
+```bash
+# 2. Credentials deterministisch in die Felder tippen — Wert kommt aus der ENV-Var,
+#    von der Shell expandiert, NICHT ueber das LLM. <user_idx>/<pass_idx>/<submit_idx>
+#    stammen aus dem vorigen `state`-Output.
+browser-use input <user_idx> "$BROWSER_USE_USER" \
+  && browser-use input <pass_idx> "$BROWSER_USE_PASS" \
+  && browser-use click <submit_idx>
+```
+
+```bash
+# 3. Ergebnis pruefen — der Prompt enthaelt KEINE Credentials.
 browser-use "
-Navigiere zur HAN-Proxy-URL: <proxy_url aus proxy_pattern>
-Falls eine Login-Seite erscheint:
-  - Fuelle Benutzername-Feld mit dem Wert aus dem Profil-Feld <credentials_keys[0]>
-  - Fuelle Passwort-Feld mit dem Wert aus dem Profil-Feld <credentials_keys[1]>
-  - Klicke Submit
-Pruefe: Wurde zur Ziel-Site weitergeleitet?
+Pruefe den aktuellen browser-use state: Wurde zur Ziel-Site weitergeleitet?
 Antworte NUR mit einem dieser Strings (ohne Credentials):
   LOGIN_SUCCESS
   LOGIN_FAILED: <Fehlertext, keine Zugangsdaten>
@@ -137,15 +184,31 @@ Antworte NUR mit einem dieser Strings (ohne Credentials):
 
 #### Shibboleth-Login (inkl. DFN-AAI)
 
+Voraussetzung: `BROWSER_USE_USER` / `BROWSER_USE_PASS` sind in der Shell gesetzt.
+
 ```bash
+# 1. Navigieren + ggf. WAYF-Einrichtung waehlen. <uni> ist KEIN Credential und
+#    darf im Prompt stehen. Danach das Login-Formular per state lesen.
+browser-use open "<auth_url aus Profil>"
 browser-use "
-Navigiere zu: <auth_url aus Profil>
-Falls WAYF-Seite erscheint: Waehle Einrichtung mit Namen/Schluessel '<uni>' aus.
-Fuelle Shibboleth-Login-Formular:
-  - Benutzername: <Wert aus credentials_keys[0] im Profil>
-  - Passwort: <Wert aus credentials_keys[1] im Profil>
-Klicke Anmelden / Login.
-Warte auf Redirect zur Ziel-Site.
+Falls eine WAYF-/Einrichtungs-Auswahlseite erscheint: Waehle die Einrichtung mit
+Namen/Schluessel '<uni>' aus und folge zum Login-Formular.
+Antworte NUR mit: WAYF_DONE oder NO_WAYF
+"
+browser-use state    # Element-Indizes der Shibboleth-Login-Felder lesen
+```
+
+```bash
+# 2. Credentials deterministisch eingeben — Werte aus ENV-Vars, nie im Prompt.
+browser-use input <user_idx> "$BROWSER_USE_USER" \
+  && browser-use input <pass_idx> "$BROWSER_USE_PASS" \
+  && browser-use click <submit_idx>
+```
+
+```bash
+# 3. Ergebnis pruefen (kein Credential im Prompt).
+browser-use "
+Pruefe den browser-use state: Wurde nach dem Login zur Ziel-Site weitergeleitet?
 Antworte NUR:
   LOGIN_SUCCESS
   LOGIN_FAILED: <Fehlermeldung ohne Zugangsdaten>
@@ -155,13 +218,25 @@ Antworte NUR:
 
 #### EZproxy-Login
 
+Voraussetzung: `BROWSER_USE_USER` / `BROWSER_USE_PASS` sind in der Shell gesetzt.
+
 ```bash
+# 1. Login-Seite oeffnen und Formular-Struktur lesen.
+browser-use open "<auth_url aus Profil>"
+browser-use state    # Element-Indizes der Login-Felder lesen
+```
+
+```bash
+# 2. Credentials deterministisch eingeben — Werte aus ENV-Vars, nie im Prompt.
+browser-use input <user_idx> "$BROWSER_USE_USER" \
+  && browser-use input <pass_idx> "$BROWSER_USE_PASS" \
+  && browser-use click <submit_idx>
+```
+
+```bash
+# 3. Ergebnis pruefen (kein Credential im Prompt).
 browser-use "
-Navigiere zu: <auth_url aus Profil>
-Fuelle Login-Formular:
-  - Benutzername: <Wert aus credentials_keys[0]>
-  - Passwort: <Wert aus credentials_keys[1]>
-Submit → warte auf Redirect.
+Pruefe den browser-use state: Wurde zur Ziel-Site weitergeleitet?
 Antworte NUR:
   LOGIN_SUCCESS
   LOGIN_FAILED: <Fehlermeldung>
@@ -214,6 +289,9 @@ Wenn `browser-use` meldet, dass eine Session abgelaufen ist oder ein erneuter Lo
 
 ## Sicherheits-Checkliste (vor jedem Output pruefen)
 
+- [ ] Credentials NUR via ENV-Var (`BROWSER_USE_USER`/`BROWSER_USE_PASS`) + `browser-use input` — NIE im browser-use-Prompt-Text
+- [ ] Kein `echo`/`print` der Credential-ENV-Variablen
+- [ ] Nach dem Login: `unset BROWSER_USE_USER BROWSER_USE_PASS`
 - [ ] Kein Passwort-String im Output
 - [ ] Kein Cookie-Inhalt im Output
 - [ ] `session_context` = nur opaker Bezeichner (Format: `browser-use:active:<uni>`)

--- a/tests/test_auth_helper.py
+++ b/tests/test_auth_helper.py
@@ -323,3 +323,74 @@ class TestNoLoginForOASites:
         profile = {}
         result = detect_auth_type(profile, "https://www.oapen.org/book/12345")
         assert result == "oa-only"
+
+
+class TestAuthHelperPromptNoCredentialLeak:
+    """Regression #193 — auth-helper.md darf Credentials NICHT im browser-use-Prompt
+    uebergeben (sonst landen sie im LLM-Reasoning-Stream → Leak via Trace-Logs,
+    Hook-Captures, Error-Messages).
+
+    Akzeptanzkriterium: Credentials werden ueber ENV-Variablen (z.B. BROWSER_USE_USER /
+    BROWSER_USE_PASS) und deterministische Eingabe (browser-use input <idx> "$VAR")
+    behandelt — der Prompt-Text enthaelt keine Credential-Platzhalter mehr.
+    """
+
+    @pytest.fixture
+    def doc_path(self) -> Path:
+        return Path(__file__).parent.parent / "agents" / "auth-helper.md"
+
+    @pytest.fixture
+    def doc_text(self, doc_path) -> str:
+        assert doc_path.exists(), f"auth-helper.md fehlt: {doc_path}"
+        return doc_path.read_text(encoding="utf-8")
+
+    # Muster, die einen Credential-Wert in den LLM-Prompt schreiben wuerden.
+    # Beispiele aus dem alten Template:
+    #   "Fuelle Passwort-Feld mit dem Wert aus dem Profil-Feld <credentials_keys[1]>"
+    #   "Benutzername: <Wert aus credentials_keys[0] im Profil>"
+    LEAK_PATTERNS = [
+        "credentials_keys[0]",
+        "credentials_keys[1]",
+        "Wert aus dem Profil-Feld",
+        "Wert aus credentials_keys",
+    ]
+
+    def test_no_credential_placeholder_in_prompt(self, doc_text):
+        """Kein Credential-Platzhalter im Prompt-Text (sonst LLM-Stream-Leak)."""
+        found = [p for p in self.LEAK_PATTERNS if p in doc_text]
+        assert not found, (
+            "auth-helper.md uebergibt Credentials im browser-use-Prompt — "
+            f"verbotene Muster gefunden: {found}. "
+            "Credentials muessen via ENV-Var + 'browser-use input' eingegeben werden, "
+            "nicht als Prompt-Platzhalter."
+        )
+
+    def test_uses_env_variables_for_credentials(self, doc_text):
+        """Credentials werden ueber ENV-Variablen referenziert."""
+        assert "BROWSER_USE_USER" in doc_text and "BROWSER_USE_PASS" in doc_text, (
+            "auth-helper.md muss Credentials ueber ENV-Variablen "
+            "(BROWSER_USE_USER / BROWSER_USE_PASS) ansprechen statt im Prompt."
+        )
+
+    def test_uses_deterministic_input_for_credentials(self, doc_text):
+        """Credential-Eingabe erfolgt deterministisch via 'browser-use input'."""
+        assert "browser-use input" in doc_text, (
+            "auth-helper.md muss 'browser-use input <idx> \"$VAR\"' nutzen, "
+            "damit der Credential-Wert nicht in den LLM-Prompt gelangt."
+        )
+
+    def test_env_vars_not_echoed(self, doc_text):
+        """Die Credential-ENV-Variablen duerfen nicht via echo/print ausgegeben werden."""
+        import re
+        # echo/print, das eine Credential-ENV-Var ausgibt → Leak in stdout/Logs
+        leak_echo = re.findall(
+            r"(?:echo|print[^\n]*)\$?\{?BROWSER_USE_(?:USER|PASS)",
+            doc_text,
+        )
+        assert not leak_echo, (
+            f"Credential-ENV-Var wird ausgegeben (Leak): {leak_echo}"
+        )
+
+    def test_security_policy_still_documented(self, doc_text):
+        """Die Sicherheits-Policy (Credentials nie in Outputs) bleibt dokumentiert."""
+        assert "NIEMALS" in doc_text, "Sicherheits-Policy-Abschnitt fehlt"


### PR DESCRIPTION
## Problem

`agents/auth-helper.md` uebergab Credentials direkt als Platzhalter im browser-use-Prompt-String, z.B.:

```
- Fuelle Passwort-Feld mit dem Wert aus dem Profil-Feld <credentials_keys[1]>
- Benutzername: <Wert aus credentials_keys[0] im Profil>
```

Dadurch gelangten die Credential-Werte in den LLM-Reasoning-Stream und konnten leaken via:
- LLM-Trace-Logs (Anthropic API)
- Hook-Captures (post-tool-use, pre-compact)
- Error-Messages bei fehlgeschlagenem Login

Das widersprach dem dokumentierten Auth-Helper-Vertrag ("Credentials NIEMALS in Outputs, JSON-Antworten oder Zwischenmeldungen").

## Fix

Credentials werden nicht mehr im Prompt uebergeben, sondern:
1. In lokale Shell-ENV-Variablen `BROWSER_USE_USER` / `BROWSER_USE_PASS` geladen (per Python-Heredoc aus dem Profil, ohne `echo`/`print` der Werte).
2. Ueber den deterministischen `browser-use input <idx> "$BROWSER_USE_PASS"`-Befehl direkt ins Formular getippt — der Wert wird von der Shell expandiert und erreicht das LLM nie.
3. Der browser-use-Prompt liest nur noch die Feld-Indizes (`browser-use state`) und prueft den Login-Status; er enthaelt keine Credential-Werte.

Umgestellt fuer alle drei Login-Flows (HAN, Shibboleth inkl. DFN-AAI, EZproxy). Die Sicherheits-Checkliste wurde erweitert (kein `echo`/`print` der ENV-Vars, `unset` nach dem Login). Die WAYF-Einrichtungsauswahl (`<uni>`) bleibt im Prompt, da der Uni-Schluessel kein Credential ist.

## TDD-Belege

Neue Test-Klasse `TestAuthHelperPromptNoCredentialLeak` in `tests/test_auth_helper.py` (assertiert Eigenschaften des Dokuments `agents/auth-helper.md`):
- `test_no_credential_placeholder_in_prompt` — keine `credentials_keys[N]` / "Wert aus ..."-Platzhalter mehr im Prompt.
- `test_uses_env_variables_for_credentials` — `BROWSER_USE_USER` / `BROWSER_USE_PASS` vorhanden.
- `test_uses_deterministic_input_for_credentials` — `browser-use input` wird genutzt.
- `test_env_vars_not_echoed` — keine `echo`/`print`-Ausgabe der Credential-ENV-Vars.
- `test_security_policy_still_documented` — Sicherheits-Policy bleibt dokumentiert.

Rot -> Gruen:
- Vor dem Fix: `3 failed, 2 passed` (verbotene Muster `['credentials_keys[0]', 'credentials_keys[1]', 'Wert aus dem Profil-Feld', 'Wert aus credentials_keys']` gefunden; ENV-Vars und `browser-use input` fehlten).
- Nach dem Fix: `5 passed`.
- Volle Suite: `968 passed, 148 skipped` (Baseline 963 passed + 5 neue Tests; 0 failed, 0 errors).

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)
