### PR TITLE
fix(agents): Space-Syntax-Permission Bash(browser-use *) fuer 4 OA-Fetcher (#222)

### DIFF
--- a/agents/doabooks-fetcher.md
+++ b/agents/doabooks-fetcher.md
@@ -7,6 +7,7 @@ description: |
   liegen auf externen Providern. Liefert PDF-Pfad oder metadata_only.
 tools:
   - Bash(browser-use:*)
+  - Bash(browser-use *)
   - Read
   - Write
 maxTurns: 12

--- a/agents/kvk-fetcher.md
+++ b/agents/kvk-fetcher.md
@@ -7,6 +7,7 @@ description: |
   fuer Pickup zurueck. Kein eigener Volltext-Host.
 tools:
   - Bash(browser-use:*)
+  - Bash(browser-use *)
   - Read
   - Write
 maxTurns: 12

--- a/agents/oapen-fetcher.md
+++ b/agents/oapen-fetcher.md
@@ -7,6 +7,7 @@ description: |
   PDF-Pfad oder metadata_only-Status zurueck.
 tools:
   - Bash(browser-use:*)
+  - Bash(browser-use *)
   - Read
   - Write
 maxTurns: 12

--- a/agents/tib-fetcher.md
+++ b/agents/tib-fetcher.md
@@ -7,6 +7,7 @@ description: |
   strukturierten metadata_only-Status zurueck.
 tools:
   - Bash(browser-use:*)
+  - Bash(browser-use *)
   - Read
   - Write
 maxTurns: 15

--- a/tests/test_oa_fetchers.py
+++ b/tests/test_oa_fetchers.py
@@ -94,6 +94,23 @@ class TestAgentFrontmatter:
             f"'browser-use' fehlt im tools-Frontmatter von {agent_name}.md"
         )
 
+    @pytest.mark.parametrize("agent_name", AGENT_NAMES)
+    def test_frontmatter_tools_has_space_syntax_permission(self, agent_name):
+        """Regression #222: tools muss die Space-Syntax 'Bash(browser-use *)'
+        deklarieren, sonst matchen die im Workflow genutzten Space-Befehle
+        (browser-use open/state/click/download) nicht → Permission-Denied.
+        Die reine Colon-Variante 'Bash(browser-use:*)' reicht nicht aus.
+        """
+        path = AGENTS_DIR / f"{agent_name}.md"
+        content = path.read_text(encoding="utf-8")
+        fm_match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
+        assert fm_match, f"Kein Frontmatter in {agent_name}.md"
+        fm_raw = fm_match.group(1)
+        assert "Bash(browser-use *)" in fm_raw, (
+            f"Space-Syntax-Permission 'Bash(browser-use *)' fehlt im tools-Frontmatter "
+            f"von {agent_name}.md — Space-Befehle werden geblockt (Issue #222)"
+        )
+
     @pytest.mark.parametrize("agent_name, expected_guide", [
         ("tib-fetcher", "config/browser_guides/tib.md"),
         ("oapen-fetcher", "config/browser_guides/oapen.md"),


### PR DESCRIPTION
## Problem

Die vier OA-Fetcher-Agenten `doabooks-fetcher.md`, `kvk-fetcher.md`, `oapen-fetcher.md` und `tib-fetcher.md` deklarierten in ihrem `tools`-Frontmatter ausschliesslich die Colon-Variante `Bash(browser-use:*)`. Im Workflow nutzen sie jedoch durchgehend die Space-Syntax (`browser-use open`, `browser-use state`, `browser-use click`, `browser-use download`). Die Colon-Permission matcht Space-Befehle nicht — Folge: Permission-Denied, die Fetcher waren faktisch blockiert.

Die funktionierenden Vergleichsagenten (`auth-helper.md`, `degruyter.md`, `springer-book.md`) deklarieren beide Varianten: `Bash(browser-use:*)` UND `Bash(browser-use *)`.

## Fix

In allen vier Fetcher-Dateien wurde die Zeile `- Bash(browser-use *)` im `tools`-Block ergaenzt (zusaetzlich zur bestehenden Colon-Variante). Damit ist die browser-use-Permission-Konvention konsistent ueber alle browser-use-Agenten. Scope bewusst eng gehalten — nur die vier betroffenen Dateien, keine unverwandten Aenderungen.

## TDD-Belege

Neuer parametrisierter Regressionstest `test_frontmatter_tools_has_space_syntax_permission` in `tests/test_oa_fetchers.py`, der fuer jeden der vier Agenten asserted, dass `Bash(browser-use *)` im Frontmatter vorhanden ist.

- Rot (vor Fix): `4 failed` — `AssertionError: Space-Syntax-Permission 'Bash(browser-use *)' fehlt im tools-Frontmatter von <agent>.md`
- Gruen (nach Fix): `tests/test_oa_fetchers.py` → `58 passed`
- Volle Suite: `967 passed, 148 skipped, 0 failed` (Baseline 963 passed + 4 neue parametrisierte Faelle)
- CI-relevante Checks: `tests/test_skills_manifest.py tests/test_skill_naming.py` → `159 passed`; Frontmatter-Coverage der vier Dateien (`---` + nicht-leeres `description:`) bestaetigt.

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)
