### PR TITLE
fix(doc): nicht existentes scripts/migrate_v5.py aus Migration-Guide entfernen (#224)

### DIFF
--- a/docs/MIGRATION-v5-to-v6.md
+++ b/docs/MIGRATION-v5-to-v6.md
@@ -50,15 +50,16 @@ PDFs registriert: 38/42 (4 ohne lokale PDF-Datei, nur Metadaten).
 literature_state.md bleibt als Backup erhalten.
 ```
 
-### Manuelle Migration (Fallback)
+### Migration klappt nicht?
 
-Falls die automatische Migration nicht klappt:
+Falls die automatische Migration scheitert, zuerst sicherstellen, dass der Vault initialisiert ist, und das Setup erneut starten:
 
-```bash
-~/.academic-research/venv/bin/python scripts/migrate_v5.py \
-  --literature-state ./literature_state.md \
-  --vault ~/.academic-research/projects/<slug>/vault.db
 ```
+/academic-research:setup
+/academic-research:setup --migrate-v5
+```
+
+Schlägt sie weiterhin fehl, hilft der Verbose-Modus bei der Fehleranalyse (siehe Abschnitt 8 — Troubleshooting). Häufigste Ursache sind unvollständige `## [paper_id]`-Blöcke in `literature_state.md`.
 
 ### Nach der Migration prüfen
 
@@ -314,15 +315,14 @@ Oder `/academic-research:setup` erneut ausführen — der Setup-Wizard fragt neu
 ```bash
 # Zeige die ersten 50 Zeilen zur Fehleranalyse
 head -50 ./literature_state.md
-
-# Migration mit Verbose-Logging
-~/.academic-research/venv/bin/python scripts/migrate_v5.py \
-  --literature-state ./literature_state.md \
-  --vault ~/.academic-research/projects/<slug>/vault.db \
-  --verbose
 ```
 
-Häufigste Ursache: Unvollständige `## [paper_id]`-Blöcke in der Datei. Im Verbose-Modus werden die fehlerhaften Einträge angezeigt.
+```
+# Migration erneut anstoßen — das Setup meldet fehlerhafte Einträge
+/academic-research:setup --migrate-v5
+```
+
+Häufigste Ursache: Unvollständige `## [paper_id]`-Blöcke in der Datei. Das Setup zeigt die fehlerhaften Einträge an und überspringt sie, statt abzubrechen.
 
 ### Vault nicht gefunden nach Update
 

--- a/tests/test_issue_224_migration_guide_scripts.py
+++ b/tests/test_issue_224_migration_guide_scripts.py
@@ -1,0 +1,42 @@
+"""Regression guard fuer Issue #224.
+
+Der Migration-Guide (docs/MIGRATION-v5-to-v6.md) darf nur auf Skripte
+verweisen, die tatsaechlich im Repo existieren. Ein frueherer Stand
+verwies auf das nicht existente ``scripts/migrate_v5.py``.
+
+Akzeptanzkriterium: Migration-Guide referenziert nur Befehle/Skripte,
+die existieren.
+"""
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+MIGRATION_GUIDE = REPO_ROOT / "docs" / "MIGRATION-v5-to-v6.md"
+
+# Erkennt Verweise wie ``scripts/migrate_v5.py`` oder ``scripts/foo/bar.py``
+# innerhalb des Doku-Texts (auch in Code-Bloecken).
+SCRIPT_REF_PATTERN = re.compile(r"scripts/[\w./-]+\.py")
+
+
+def test_migration_guide_exists():
+    assert MIGRATION_GUIDE.exists(), f"{MIGRATION_GUIDE} fehlt"
+
+
+def test_migration_guide_references_only_existing_scripts():
+    text = MIGRATION_GUIDE.read_text(encoding="utf-8")
+    referenced = set(SCRIPT_REF_PATTERN.findall(text))
+    missing = sorted(ref for ref in referenced if not (REPO_ROOT / ref).exists())
+    assert not missing, (
+        "Migration-Guide referenziert nicht existente Skripte:\n"
+        + "\n".join(missing)
+    )
+
+
+def test_migration_guide_does_not_mention_migrate_v5_script():
+    """``migrate_v5.py`` wurde nie ausgeliefert und darf nicht referenziert werden."""
+    text = MIGRATION_GUIDE.read_text(encoding="utf-8")
+    assert "migrate_v5.py" not in text, (
+        "Migration-Guide verweist auf das nicht existente Skript migrate_v5.py. "
+        "Stattdessen die automatische Migration "
+        "(/academic-research:setup --migrate-v5) dokumentieren."
+    )


### PR DESCRIPTION
## Problem

`docs/MIGRATION-v5-to-v6.md` verwies an zwei Stellen (Zeile 58 und 319) auf einen manuellen Migrations-Fallback via `scripts/migrate_v5.py`. Dieses Skript existiert nicht im Repo. Nutzer, die dem Fallback folgten, erhielten `No such file or directory`.

## Fix

Beide Verweise auf das nicht existente `scripts/migrate_v5.py` entfernt. Statt eines selbst aufzurufenden Skripts zeigt der Guide jetzt auf die bereits dokumentierte und unterstützte automatische Migration `/academic-research:setup --migrate-v5` (so auch in `README.md` und `CHANGELOG.md` referenziert).

- Abschnitt "Manuelle Migration (Fallback)" → "Migration klappt nicht?" mit Verweis auf `/academic-research:setup` + `--migrate-v5`.
- Troubleshooting-Block "Migration schlägt fehl" verweist statt auf den Skript-Aufruf mit `--verbose` ebenfalls auf `/academic-research:setup --migrate-v5`.

Keine Manifest-, Hook- oder Command-/Agent-Dateien angefasst — CI-relevante Checks (jq, node --check, Frontmatter-Coverage) sind unberührt.

## TDD-Belege

Neuer Regressionstest `tests/test_issue_224_migration_guide_scripts.py`:
- `test_migration_guide_references_only_existing_scripts` — scannt `scripts/*.py`-Verweise im Guide und prüft Existenz.
- `test_migration_guide_does_not_mention_migrate_v5_script` — sichert ab, dass `migrate_v5.py` nicht mehr referenziert wird.
- `test_migration_guide_exists` — Smoke-Check.

Rot → grün:
- Vor dem Fix: `2 failed, 1 passed` (Verweise auf `scripts/migrate_v5.py` an Zeile 58 + 319 erkannt).
- Nach dem Fix: `3 passed`.
- Volle Suite: `966 passed, 148 skipped` (Baseline 963/148 + 3 neue Tests, keine Regression).

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)
