### PR TITLE
fix(evals): Eval-Coverage fuer 14 fehlende Skills + CI-Guard (#198)

### DIFF
--- a/evals/book-handler/evals.json
+++ b/evals/book-handler/evals.json
@@ -1,6 +1,11 @@
 {
   "component": "book-handler",
   "component_type": "skill",
+  "prompts": [
+    {"id": "bh-p01", "input": "Validiere die ISBN-13 978-3-16-148410-0 und sage mir, ob die Pruefziffer korrekt ist.", "expected": {"type": "regex", "value": "(978-3-16-148410-0|9783161484100|ISBN|Pruefziffer|gueltig)"}, "mode": "with_skill"},
+    {"id": "bh-p02", "input": "Wie unterscheidet die Verarbeitung zwischen einer Monografie und einem Sammelband?", "expected": {"type": "regex", "value": "(Monografie|Sammelband|Herausgeber|Kapitel|Editor)"}, "mode": "with_skill"},
+    {"id": "bh-p03", "input": "Welche Dienste nutzt du, um ein Buch ueber ISBN oder DOI aufzuloesen?", "expected": {"type": "regex", "value": "(DNB|OpenLibrary|DOAB|ISBN|DOI)"}, "mode": "with_skill"}
+  ],
   "cases": [
     {
       "id": "bh-01",

--- a/evals/book-handler/trigger_evals.json
+++ b/evals/book-handler/trigger_evals.json
@@ -1,0 +1,27 @@
+{
+  "component": "book-handler",
+  "should_trigger": [
+    "Verarbeite dieses Buch fuer meine Arbeit.",
+    "Ich habe eine Monografie, leg sie im Vault an.",
+    "Verarbeite diesen Sammelband.",
+    "Loese die ISBN 978-3-16-148410-0 auf.",
+    "Ein Kapitel von Schmidt aus einem Sammelband bitte.",
+    "Importiere dieses Springer-Buch (DOI 10.1007/978-3-...).",
+    "Leg dieses Fachbuch als CSL-JSON im Vault an.",
+    "Kannst du diese Monografie ueber DNB aufloesen?",
+    "Buch via OpenLibrary suchen und anlegen.",
+    "Verarbeite den Sammelband mit drei Herausgebern."
+  ],
+  "should_not_trigger": [
+    "Extrahiere Zitate aus diesem Paper.",
+    "Suche Open-Access-Artikel zu Microservices.",
+    "Schreibe Kapitel 2 meiner Arbeit.",
+    "Welches Thema soll ich nehmen?",
+    "Exportiere nach LaTeX.",
+    "Importiere meine Zotero-Bibliothek.",
+    "Pruefe meinen Text auf Plagiate.",
+    "Erstelle ein Poster.",
+    "Schaerfe meine Forschungsfrage.",
+    "Generiere einen Titel."
+  ]
+}

--- a/evals/citation-style-import/evals.json
+++ b/evals/citation-style-import/evals.json
@@ -1,0 +1,9 @@
+{
+  "component": "citation-style-import",
+  "component_type": "skill",
+  "prompts": [
+    {"id": "csi-01", "input": "Beschreibe Schritt fuer Schritt, wie du einen .csl-Stil aus dem CSL-Repository importierst und in eine custom-Prompt-Regel umwandelst.", "expected": {"type": "regex", "value": "(CSL|\\.csl|Stil|Import)"}, "mode": "with_skill"},
+    {"id": "csi-02", "input": "Welche XML-Elemente einer .csl-Datei sind relevant, um eine Zitierregel abzuleiten?", "expected": {"type": "regex", "value": "(citation|bibliography|macro|XML|csl)"}, "mode": "with_skill"},
+    {"id": "csi-03", "input": "Wohin schreibst du die generierte custom-Variante eines importierten Zitierstils?", "expected": {"type": "regex", "value": "(custom|references|citation-extraction|skills/)"}, "mode": "with_skill"}
+  ]
+}

--- a/evals/citation-style-import/trigger_evals.json
+++ b/evals/citation-style-import/trigger_evals.json
@@ -1,0 +1,27 @@
+{
+  "component": "citation-style-import",
+  "should_trigger": [
+    "Importiere einen Zitierstil aus dem CSL-Repository.",
+    "Kannst du CSL importieren?",
+    "Ich brauche einen neuen Zitierstil.",
+    "Lade mir einen custom citation style.",
+    "Hol den Stil aus GitHub und mach eine Variante.",
+    "Importiere den Chicago-CSL-Stil.",
+    "CSL-Stil laden und als Prompt-Regel generieren.",
+    "Ich moechte einen eigenen Zitierstil aus einer .csl-Datei.",
+    "Citation Style Language importieren.",
+    "Neuer Stil aus dem CSL-Repo bitte."
+  ],
+  "should_not_trigger": [
+    "Extrahiere Zitate aus diesem PDF.",
+    "Formatiere diese Quelle nach APA.",
+    "Schreibe Kapitel 2.",
+    "Welches Thema soll ich nehmen?",
+    "Importiere meine Zotero-Bibliothek.",
+    "Importiere meine Reading List.",
+    "Pruefe meinen Text auf Plagiate.",
+    "Exportiere nach LaTeX.",
+    "Erstelle ein Poster.",
+    "Schaerfe meine Forschungsfrage."
+  ]
+}

--- a/evals/cluster-visualizer/evals.json
+++ b/evals/cluster-visualizer/evals.json
@@ -1,0 +1,9 @@
+{
+  "component": "cluster-visualizer",
+  "component_type": "skill",
+  "prompts": [
+    {"id": "cv-01", "input": "Erzeuge aus diesem Cluster-JSON ein Mermaid-graph-LR-Diagramm:\n{\"nodes\":[{\"id\":\"p1\",\"title\":\"DevOps Governance\",\"year\":2022},{\"id\":\"p2\",\"title\":\"Zero Trust\",\"year\":2024}],\"edges\":[{\"from\":\"p1\",\"to\":\"p2\",\"weight\":0.6}]}", "expected": {"type": "regex", "value": "(graph LR|-->|mermaid)"}, "mode": "with_skill"},
+    {"id": "cv-02", "input": "Wie kodierst du die Kantenstaerke (Gewicht) zwischen zwei Papern in einem Mermaid-Diagramm?", "expected": {"type": "regex", "value": "(linkStyle|Gewicht|Kante|stroke)"}, "mode": "with_skill"},
+    {"id": "cv-03", "input": "Welche Information gehoert in einen Paper-Knoten eines Literaturcluster-Diagramms?", "expected": {"type": "regex", "value": "(Titel|Jahr|year|title|Knoten)"}, "mode": "with_skill"}
+  ]
+}

--- a/evals/cluster-visualizer/trigger_evals.json
+++ b/evals/cluster-visualizer/trigger_evals.json
@@ -1,0 +1,27 @@
+{
+  "component": "cluster-visualizer",
+  "should_trigger": [
+    "Zeige mir den Literaturcluster.",
+    "Visualisiere meine Quellen.",
+    "Erstelle eine Mindmap der Paper.",
+    "Ich brauche ein Cluster-Diagramm.",
+    "Zeige das Netzwerk der Quellen.",
+    "Zeige die Verbindungen zwischen den Papern.",
+    "Mach mir ein Mermaid-Diagramm aus dem Cluster-JSON.",
+    "Visualisiere die Zitationsverbindungen.",
+    "Erzeuge einen Graphen meiner Literatur.",
+    "Cluster als Diagramm darstellen bitte."
+  ],
+  "should_not_trigger": [
+    "Suche Paper zu Microservices.",
+    "Schreibe Kapitel 3.",
+    "Welches Thema soll ich nehmen?",
+    "Extrahiere Zitate aus dem PDF.",
+    "Pruefe meinen Text auf Plagiate.",
+    "Exportiere nach LaTeX.",
+    "Importiere meine Reading List.",
+    "Schreibe einen Foerderantrag.",
+    "Generiere einen Titel.",
+    "Schaerfe meine Forschungsfrage."
+  ]
+}

--- a/evals/conference-poster/evals.json
+++ b/evals/conference-poster/evals.json
@@ -1,0 +1,9 @@
+{
+  "component": "conference-poster",
+  "component_type": "skill",
+  "prompts": [
+    {"id": "cp-01", "input": "Erstelle das Grundgeruest eines A0-Konferenz-Posters (tikzposter) mit den Bloecken Titel, Motivation, Methode, Ergebnisse, Fazit fuer das Thema 'Zero Trust in Healthcare'.", "expected": {"type": "regex", "value": "(tikzposter|block|Titel|Motivation|Ergebnisse)"}, "mode": "with_skill"},
+    {"id": "cp-02", "input": "Welche Inhalte gehoeren in den Ergebnis-Block eines wissenschaftlichen A0-Posters und wie waehle ich die Top-Figures aus?", "expected": {"type": "regex", "value": "(Figure|Abbildung|Ergebnis|Block)"}, "mode": "with_skill"},
+    {"id": "cp-03", "input": "Fasse dieses Kapitel in fuenf praegnanten Stichpunkten fuer einen Poster-Methodenblock zusammen: Wir nutzen eine qualitative Inhaltsanalyse nach Mayring mit 24 Interviews.", "expected": {"type": "regex", "value": "(Inhaltsanalyse|Mayring|Interview|Methode|-)"}, "mode": "with_skill"}
+  ]
+}

--- a/evals/conference-poster/trigger_evals.json
+++ b/evals/conference-poster/trigger_evals.json
@@ -1,0 +1,27 @@
+{
+  "component": "conference-poster",
+  "should_trigger": [
+    "Erstelle ein Poster fuer die Konferenz.",
+    "Ich brauche ein A0-Poster fuer meine Praesentation.",
+    "Mach mir ein tikzposter aus meinen Ergebnissen.",
+    "Kannst du ein conference poster aus dem Kapitel bauen?",
+    "Ich moechte eine visuelle Zusammenfassung als Poster.",
+    "Erzeuge ein Konferenz-Poster mit den Top-Figures.",
+    "Poster fuer die Tagung erstellen bitte.",
+    "Wandle meine Forschungsergebnisse in ein A0-Poster um.",
+    "Layout fuer ein wissenschaftliches Poster generieren.",
+    "Brauche ein Poster im tikzposter-Format."
+  ],
+  "should_not_trigger": [
+    "Schreibe das vollstaendige Kapitel 4.",
+    "Welches Thema soll ich nehmen?",
+    "Schreibe einen Foerderantrag.",
+    "Exportiere mein Kapitel nach LaTeX.",
+    "Antworte auf die Reviewer.",
+    "Importiere meine Reading List.",
+    "Pruefe meinen Text auf Plagiate.",
+    "Generiere einen Titel.",
+    "Schaerfe meine Forschungsfrage.",
+    "Suche Open-Access-Paper."
+  ]
+}

--- a/evals/grant-proposal/evals.json
+++ b/evals/grant-proposal/evals.json
@@ -1,0 +1,9 @@
+{
+  "component": "grant-proposal",
+  "component_type": "skill",
+  "prompts": [
+    {"id": "gp-01", "input": "Skizziere die Gliederung eines DFG-Sachbeihilfe-Antrags zum Thema 'Erklaerbare KI in der Medizin'.", "expected": {"type": "regex", "value": "(Stand der Forschung|Arbeitsprogramm|Ziele|Gliederung|Antrag)"}, "mode": "with_skill"},
+    {"id": "gp-02", "input": "Formuliere einen Abschnitt 'Ziele und Arbeitshypothesen' fuer einen BMBF-Antrag zu nachhaltiger Logistik.", "expected": {"type": "regex", "value": "(Ziel|Hypothese|Arbeitshypothese)"}, "mode": "with_skill"},
+    {"id": "gp-03", "input": "Welche Pflichtbestandteile muss ein EU-Horizon-Antrag (Excellence, Impact, Implementation) enthalten?", "expected": {"type": "regex", "value": "(Excellence|Impact|Implementation|Bestandteile)"}, "mode": "with_skill"}
+  ]
+}

--- a/evals/grant-proposal/trigger_evals.json
+++ b/evals/grant-proposal/trigger_evals.json
@@ -1,0 +1,27 @@
+{
+  "component": "grant-proposal",
+  "should_trigger": [
+    "Hilf mir einen Foerderantrag zu schreiben.",
+    "Ich brauche einen DFG-Antrag.",
+    "Schreibe einen BMBF-Antrag fuer mein Projekt.",
+    "Wie formuliere ich einen EU-Horizon-Antrag?",
+    "Erstelle einen Drittmittelantrag.",
+    "Ich moechte einen grant proposal verfassen.",
+    "Unterstuetze mich bei der Foerderantragstellung.",
+    "Antrag fuer Forschungsfoerderung schreiben.",
+    "Hilf mir beim Antragstext fuer die DFG-Sachbeihilfe.",
+    "Kannst du einen Projektantrag fuer Drittmittel aufsetzen?"
+  ],
+  "should_not_trigger": [
+    "Schreibe Kapitel 2 meiner Dissertation.",
+    "Welches Thema soll ich waehlen?",
+    "Exportiere mein Kapitel nach LaTeX.",
+    "Erstelle ein Konferenz-Poster.",
+    "Antworte auf die Reviewer-Kommentare.",
+    "Pruefe meinen Text auf Plagiate.",
+    "Importiere meine Zotero-Bibliothek.",
+    "Schaerfe meine Forschungsfrage.",
+    "Generiere einen Titel fuer das Paper.",
+    "Visualisiere die Literaturcluster."
+  ]
+}

--- a/evals/humanizer-de/evals.json
+++ b/evals/humanizer-de/evals.json
@@ -1,0 +1,9 @@
+{
+  "component": "humanizer-de",
+  "component_type": "skill",
+  "prompts": [
+    {"id": "hd-01", "input": "Ueberarbeite diesen Satz, sodass er weniger nach KI klingt: 'In der heutigen schnelllebigen Welt ist es von entscheidender Bedeutung, dass wir die transformative Kraft der Digitalisierung nutzen.'", "expected": {"type": "regex", "value": "(\\w+)"}, "mode": "with_skill"},
+    {"id": "hd-02", "input": "Welche typischen Anzeichen fuer KI-generierte Texte pruefst du bei einem deutschen Kapitelentwurf?", "expected": {"type": "regex", "value": "(Werbesprache|Floskel|Symbolik|Trikolon|Parallelismus|KI)"}, "mode": "with_skill"},
+    {"id": "hd-03", "input": "Markiere die KI-typischen Stellen in: 'Es ist wichtig zu beachten, dass dieser innovative Ansatz nicht nur effizient, sondern auch nachhaltig und zukunftsweisend ist.'", "expected": {"type": "regex", "value": "(\\w+)"}, "mode": "with_skill"}
+  ]
+}

--- a/evals/humanizer-de/trigger_evals.json
+++ b/evals/humanizer-de/trigger_evals.json
@@ -1,0 +1,27 @@
+{
+  "component": "humanizer-de",
+  "should_trigger": [
+    "Pruefe diesen Text auf KI-typische Schreibmuster.",
+    "Mach diesen Kapitelentwurf weniger nach KI klingend.",
+    "Fuehre einen Anti-KI-Audit auf meinem Text durch.",
+    "Entferne KI-Floskeln aus diesem Absatz.",
+    "Humanisiere diesen deutschen Text.",
+    "Klingt das nach ChatGPT? Bitte ueberarbeiten.",
+    "Mach den Stil natuerlicher, weg vom KI-Sound.",
+    "Pruefe meinen Entwurf auf Anzeichen fuer KI-generierte Inhalte.",
+    "Deep-Pass: KI-Muster erkennen und ueberarbeiten.",
+    "Entferne aufgeblaehte Symbolik und Werbesprache aus dem Text."
+  ],
+  "should_not_trigger": [
+    "Extrahiere Zitate aus dem PDF.",
+    "Suche Literatur zu Microservices.",
+    "Plane mein naechstes Kapitel.",
+    "Formatiere meine Zitate nach APA.",
+    "Welches Thema soll ich nehmen?",
+    "Exportiere nach LaTeX.",
+    "Importiere meine Reading List.",
+    "Erstelle ein Poster.",
+    "Schreibe einen Foerderantrag.",
+    "Generiere einen Titel."
+  ]
+}

--- a/evals/latex-export/evals.json
+++ b/evals/latex-export/evals.json
@@ -1,0 +1,9 @@
+{
+  "component": "latex-export",
+  "component_type": "skill",
+  "prompts": [
+    {"id": "lx-01", "input": "Wandle dieses Markdown-Kapitel in LaTeX um:\n\n# Einleitung\n\nDiese Arbeit untersucht **DevOps Governance** in KMU.\n\n## Motivation\n\nText.", "expected": {"type": "regex", "value": "(\\\\section|\\\\textbf|\\\\chapter|documentclass|tex)"}, "mode": "with_skill"},
+    {"id": "lx-02", "input": "Erstelle einen biblatex-Eintrag im DIN-1505-Stil fuer: Smith, J. (2023). DevOps Governance. Journal of Software, 12(3), 45-60. DOI 10.1109/MS.2023.1234567", "expected": {"type": "regex", "value": "(@article|@book|@misc|author|title)"}, "mode": "with_skill"},
+    {"id": "lx-03", "input": "Konvertiere die Markdown-Tabelle in eine LaTeX-tabular-Umgebung:\n\n| Jahr | Wert |\n|---|---|\n| 2022 | 10 |\n| 2023 | 20 |", "expected": {"type": "regex", "value": "(tabular|\\\\begin|&)"}, "mode": "with_skill"}
+  ]
+}

--- a/evals/latex-export/trigger_evals.json
+++ b/evals/latex-export/trigger_evals.json
@@ -1,0 +1,27 @@
+{
+  "component": "latex-export",
+  "should_trigger": [
+    "Exportiere mein Kapitel als .tex.",
+    "Wandle meine Thesis nach LaTeX um.",
+    "Kapitel uebersetzen nach LaTeX bitte.",
+    "Erzeuge eine .bib-Datei aus dem Vault.",
+    "Ich brauche meinen Text als LaTeX-Output.",
+    "Konvertiere das Markdown-Kapitel in tex.",
+    "Baue mir die BibTeX aus den Quellen im Vault.",
+    "LaTeX-Export der gesamten Arbeit starten.",
+    "Generiere biblatex im DIN-1505-Stil.",
+    "Mach aus dem Kapitel eine tex-Datei mit Pandoc."
+  ],
+  "should_not_trigger": [
+    "Schreibe Kapitel 3 meiner Arbeit.",
+    "Welches Thema soll ich nehmen?",
+    "Pruefe meinen Text auf KI-Muster.",
+    "Erstelle ein Konferenz-Poster.",
+    "Importiere meine Reading List.",
+    "Schaerfe meine Forschungsfrage.",
+    "Suche Open-Access-Paper zu Microservices.",
+    "Generiere einen Arbeitstitel.",
+    "Schreibe einen Foerderantrag.",
+    "Visualisiere meinen Literaturcluster."
+  ]
+}

--- a/evals/material-passport/evals.json
+++ b/evals/material-passport/evals.json
@@ -1,0 +1,9 @@
+{
+  "component": "material-passport",
+  "component_type": "skill",
+  "prompts": [
+    {"id": "mp-01", "input": "Welche Felder muss eine material-passport.json fuer ein reproduzierbares Literaturprojekt enthalten? Antworte als JSON-Objekt mit Beispielfeldern.", "expected": {"type": "regex", "value": "(paper_ids|DOI|hash|version|Score)"}, "mode": "with_skill"},
+    {"id": "mp-02", "input": "Warum sind PDF-Hashes und Modellversionen Teil eines Reproduzierbarkeits-Manifests?", "expected": {"type": "regex", "value": "(Hash|Reproduzier|Version|Nachvollzieh)"}, "mode": "with_skill"},
+    {"id": "mp-03", "input": "Beschreibe, wie der Reproduzierbarkeits-Block in kapitel/methodik.md aussehen sollte.", "expected": {"type": "regex", "value": "(Reproduzier|Methodik|material-passport|Block)"}, "mode": "with_skill"}
+  ]
+}

--- a/evals/material-passport/trigger_evals.json
+++ b/evals/material-passport/trigger_evals.json
@@ -1,0 +1,27 @@
+{
+  "component": "material-passport",
+  "should_trigger": [
+    "Erstelle ein Reproduzierbarkeits-Manifest.",
+    "Ich moechte die Abgabe vorbereiten.",
+    "Sperre den Vault fuer die Abgabe.",
+    "Mach einen Repro-Lock.",
+    "Generiere die material-passport.json.",
+    "Dokumentiere die Reproduzierbarkeit meines Projekts.",
+    "Material-Passport fuer das Projekt erstellen.",
+    "Finalisiere das Projekt fuer die Einreichung.",
+    "Exportiere alle Metadaten als Repro-Manifest.",
+    "Erzeuge den Decision-Snapshot fuer die Abgabe."
+  ],
+  "should_not_trigger": [
+    "Schreibe Kapitel 4.",
+    "Welches Thema soll ich nehmen?",
+    "Extrahiere Zitate aus dem PDF.",
+    "Suche Open-Access-Paper.",
+    "Exportiere nach LaTeX.",
+    "Importiere meine Zotero-Bibliothek.",
+    "Pruefe meinen Text auf Plagiate.",
+    "Erstelle ein Poster.",
+    "Schaerfe meine Forschungsfrage.",
+    "Generiere einen Titel."
+  ]
+}

--- a/evals/notebook-bundle/evals.json
+++ b/evals/notebook-bundle/evals.json
@@ -1,0 +1,9 @@
+{
+  "component": "notebook-bundle",
+  "component_type": "skill",
+  "prompts": [
+    {"id": "nb-01", "input": "Welche Bestandteile gehoeren in ein NotebookLM-Bundle-PDF (Cover, TOC, Paper)?", "expected": {"type": "regex", "value": "(Cover|TOC|Inhaltsverzeichnis|Paper|PDF)"}, "mode": "with_skill"},
+    {"id": "nb-02", "input": "Warum muss ein sehr grosses Buch fuer den NotebookLM-Upload ggf. aufgeteilt werden?", "expected": {"type": "regex", "value": "(Limit|Groesse|aufteil|Upload|NotebookLM)"}, "mode": "with_skill"},
+    {"id": "nb-03", "input": "Beschreibe den Ablauf, um drei ausgewaehlte Paper zu einem hochladbaren NotebookLM-PDF zu konkatenieren.", "expected": {"type": "regex", "value": "(konkatenier|zusammenf|PDF|Bundle|merge)"}, "mode": "with_skill"}
+  ]
+}

--- a/evals/notebook-bundle/trigger_evals.json
+++ b/evals/notebook-bundle/trigger_evals.json
@@ -1,0 +1,27 @@
+{
+  "component": "notebook-bundle",
+  "should_trigger": [
+    "Erstelle ein NotebookLM-Bundle.",
+    "Exportiere ein PDF-Bundle fuer den Upload.",
+    "Mach mir ein Bundle fuer NotebookLM.",
+    "Bereite die Paper fuer NotebookLM vor.",
+    "Konkateniere die ausgewaehlten Paper zu einem PDF.",
+    "Teile dieses Riesen-PDF fuer NotebookLM auf.",
+    "Bundle fuer den NotebookLM-Upload erzeugen.",
+    "Fasse alle Paper zu einem PDF mit Cover und TOC zusammen.",
+    "Grosse Dokumente fuer NotebookLM aufteilen.",
+    "Erzeuge ein zusammengefuegtes PDF aller Quellen."
+  ],
+  "should_not_trigger": [
+    "Extrahiere Zitate aus dem PDF.",
+    "Schreibe Kapitel 2.",
+    "Welches Thema soll ich nehmen?",
+    "Suche Open-Access-Paper.",
+    "Exportiere nach LaTeX.",
+    "Importiere meine Reading List.",
+    "Pruefe meinen Text auf Plagiate.",
+    "Erstelle ein Poster.",
+    "Schaerfe meine Forschungsfrage.",
+    "Generiere einen Titel."
+  ]
+}

--- a/evals/prisma-flow/evals.json
+++ b/evals/prisma-flow/evals.json
@@ -1,0 +1,9 @@
+{
+  "component": "prisma-flow",
+  "component_type": "skill",
+  "prompts": [
+    {"id": "pf-01", "input": "Render ein PRISMA-2020-Flussdiagramm als Mermaid-Block fuer: n_identified=320, n_duplicates=80, n_screened=240, n_excluded=180, n_included=60.", "expected": {"type": "regex", "value": "(flowchart|graph|320|240|60|mermaid)"}, "mode": "with_skill"},
+    {"id": "pf-02", "input": "Welche Stufen (Identification, Screening, Eligibility, Included) gehoeren in ein PRISMA-2020-Flussdiagramm?", "expected": {"type": "regex", "value": "(Identification|Screening|Eligibility|Included)"}, "mode": "with_skill"},
+    {"id": "pf-03", "input": "Wie integrierst du das gerenderte PRISMA-Diagramm in kapitel/methodik.md?", "expected": {"type": "regex", "value": "(methodik|Mermaid|Diagramm|integrier)"}, "mode": "with_skill"}
+  ]
+}

--- a/evals/prisma-flow/trigger_evals.json
+++ b/evals/prisma-flow/trigger_evals.json
@@ -1,0 +1,27 @@
+{
+  "component": "prisma-flow",
+  "should_trigger": [
+    "Erstelle ein PRISMA-Flow-Diagramm.",
+    "Ich brauche ein PRISMA-Diagramm fuer meine Methodik.",
+    "Render das Flussdiagramm der Literatursuche.",
+    "Mach ein PRISMA-2020-Flussdiagramm.",
+    "Zeige die Einschluesse als PRISMA-Flow.",
+    "Erzeuge das PRISMA-Flowchart aus den Suchzaehlern.",
+    "Flussdiagramm fuer die Literaturauswahl erstellen.",
+    "Integriere ein PRISMA-Diagramm in kapitel/methodik.md.",
+    "PRISMA Flow mit n_identified und n_included rendern.",
+    "Visualisiere meinen Screening-Prozess als PRISMA-Diagramm."
+  ],
+  "should_not_trigger": [
+    "Visualisiere meinen Literaturcluster als Netzwerk.",
+    "Schreibe Kapitel 3.",
+    "Welches Thema soll ich nehmen?",
+    "Extrahiere Zitate aus dem PDF.",
+    "Exportiere nach LaTeX.",
+    "Importiere meine Reading List.",
+    "Pruefe meinen Text auf Plagiate.",
+    "Erstelle ein Poster.",
+    "Schaerfe meine Forschungsfrage.",
+    "Generiere einen Titel."
+  ]
+}

--- a/evals/reading-list-import/evals.json
+++ b/evals/reading-list-import/evals.json
@@ -1,0 +1,9 @@
+{
+  "component": "reading-list-import",
+  "component_type": "skill",
+  "prompts": [
+    {"id": "rli-01", "input": "Parse diese Reading-List-Zeile in Autor, Jahr und Titel: 'Mayring, P. (2022). Qualitative Inhaltsanalyse. Beltz.'", "expected": {"type": "regex", "value": "(Mayring|2022|Inhaltsanalyse|Titel|Autor)"}, "mode": "with_skill"},
+    {"id": "rli-02", "input": "Welche Dienste nutzt du, um DOI und ISBN einer importierten Quelle aufzuloesen?", "expected": {"type": "regex", "value": "(Crossref|DNB|DOI|ISBN|OpenLibrary)"}, "mode": "with_skill"},
+    {"id": "rli-03", "input": "Beschreibe den Ablauf, um eine Markdown-Bibliographie in den Vault zu importieren.", "expected": {"type": "regex", "value": "(Vault|add_paper|import|parse|Referenz)"}, "mode": "with_skill"}
+  ]
+}

--- a/evals/reading-list-import/trigger_evals.json
+++ b/evals/reading-list-import/trigger_evals.json
@@ -1,0 +1,27 @@
+{
+  "component": "reading-list-import",
+  "should_trigger": [
+    "Importiere meine Reading List in den Vault.",
+    "Lies die Prof-Liste ein.",
+    "Importiere diese Bibliographie.",
+    "Literaturliste einlesen bitte.",
+    "Reading List importieren.",
+    "Importiere diese Quellenliste.",
+    "Lies meine Leseliste ein und resolve die DOIs.",
+    "Importiere die Markdown-Bibliographie in den Vault.",
+    "Kannst du diese PDF-Literaturliste einlesen?",
+    "Bibliographie aus Plaintext importieren."
+  ],
+  "should_not_trigger": [
+    "Importiere meine Zotero-Bibliothek.",
+    "Importiere einen Zitierstil aus dem CSL-Repo.",
+    "Extrahiere Zitate aus dem PDF.",
+    "Schreibe Kapitel 2.",
+    "Welches Thema soll ich nehmen?",
+    "Exportiere nach LaTeX.",
+    "Pruefe meinen Text auf Plagiate.",
+    "Erstelle ein Poster.",
+    "Schaerfe meine Forschungsfrage.",
+    "Generiere einen Titel."
+  ]
+}

--- a/evals/reviewer-response/evals.json
+++ b/evals/reviewer-response/evals.json
@@ -1,0 +1,9 @@
+{
+  "component": "reviewer-response",
+  "component_type": "skill",
+  "prompts": [
+    {"id": "rr-01", "input": "Reviewer 1 schreibt: 'The sample size of 12 interviews seems too small to justify the conclusions.' Formuliere eine hoefliche, sachliche point-by-point-Antwort.", "expected": {"type": "regex", "value": "(Reviewer|sample|Stichprobe|Comment|Response)"}, "mode": "with_skill"},
+    {"id": "rr-02", "input": "Erstelle das Geruest eines Response-Letters fuer ein Revise-and-Resubmit mit drei Reviewer-Kommentaren.", "expected": {"type": "regex", "value": "(Reviewer|Comment|Response|Kommentar)"}, "mode": "with_skill"},
+    {"id": "rr-03", "input": "Reviewer 2 bemaengelt fehlende Limitations. Formuliere eine Antwort, die auf eine neu ergaenzte Limitations-Sektion verweist.", "expected": {"type": "regex", "value": "(Limitation|Einschraenkung|Reviewer|added|ergaenzt)"}, "mode": "with_skill"}
+  ]
+}

--- a/evals/reviewer-response/trigger_evals.json
+++ b/evals/reviewer-response/trigger_evals.json
@@ -1,0 +1,27 @@
+{
+  "component": "reviewer-response",
+  "should_trigger": [
+    "Hilf mir eine Antwort fuer die Reviewer zu schreiben.",
+    "Ich brauche eine Reviewer-Response nach der Einreichung.",
+    "Schreibe eine point-by-point response.",
+    "Wir haben ein Revise and Resubmit bekommen, hilf mir antworten.",
+    "Verfasse ein Response-Letter an die Gutachter.",
+    "Wie reagiere ich auf die Peer-Review-Kommentare?",
+    "Antwort fuer Reviewer 2 formulieren.",
+    "Erstelle eine strukturierte Gutachter-Antwort.",
+    "R&R-Antwortschreiben aufsetzen bitte.",
+    "Ich muss auf die Reviewer-Kommentare punktweise antworten."
+  ],
+  "should_not_trigger": [
+    "Schreibe Kapitel 1 meiner Arbeit.",
+    "Welches Thema soll ich waehlen?",
+    "Schreibe einen Foerderantrag.",
+    "Erstelle ein Konferenz-Poster.",
+    "Exportiere mein Kapitel nach LaTeX.",
+    "Pruefe meinen Text auf Plagiate.",
+    "Importiere meine Zotero-Bibliothek.",
+    "Schaerfe meine Forschungsfrage.",
+    "Generiere einen Titel.",
+    "Suche Open-Access-Paper zu Microservices."
+  ]
+}

--- a/evals/topic-brainstorm/evals.json
+++ b/evals/topic-brainstorm/evals.json
@@ -1,0 +1,9 @@
+{
+  "component": "topic-brainstorm",
+  "component_type": "skill",
+  "prompts": [
+    {"id": "tb-01", "input": "Ich studiere Wirtschaftsinformatik und brauche ein Masterarbeitsthema im Bereich Nachhaltigkeit. Schlage mir drei konkrete Themen vor und bewerte sie kurz.", "expected": {"type": "regex", "value": "(Thema|Themen|Vorschlag)"}, "mode": "with_skill"},
+    {"id": "tb-02", "input": "Bewerte die Themenidee 'KI-gestuetzte Pruefungsbewertung an Hochschulen' nach Machbarkeit und Relevanz.", "expected": {"type": "regex", "value": "(Machbarkeit|Relevanz|Bewertung)"}, "mode": "with_skill"},
+    {"id": "tb-03", "input": "Ich habe noch gar keine Richtung. Welche Themen lohnen sich aktuell in der Cybersecurity-Forschung?", "expected": {"type": "regex", "value": "(Thema|Themen|Security|Sicherheit)"}, "mode": "with_skill"}
+  ]
+}

--- a/evals/topic-brainstorm/trigger_evals.json
+++ b/evals/topic-brainstorm/trigger_evals.json
@@ -1,0 +1,27 @@
+{
+  "component": "topic-brainstorm",
+  "should_trigger": [
+    "Welches Thema soll ich fuer meine Bachelorarbeit nehmen?",
+    "Ich brauche ein Thema fuer meine Masterarbeit.",
+    "Hilf mir bei der Themenfindung.",
+    "Welches Thema lohnt sich gerade im Bereich KI-Ethik?",
+    "Ich habe noch kein Thema, kannst du mir Ideen geben?",
+    "Kannst du diese Themenidee bewerten?",
+    "Thema gesucht fuer meine Abschlussarbeit.",
+    "Ich suche ein gutes Thesis-Thema.",
+    "Welches Forschungsthema waere zukunftstraechtig?",
+    "Brainstorming fuer mein Dissertationsthema bitte."
+  ],
+  "should_not_trigger": [
+    "Schaerfe meine bestehende Forschungsfrage.",
+    "Schreibe Kapitel 2 meiner Arbeit.",
+    "Pruefe meinen Text auf Plagiate.",
+    "Formatiere meine Zitate nach APA.",
+    "Welche Methodik passt zu meiner Fallstudie?",
+    "Exportiere mein Kapitel als LaTeX.",
+    "Suche Paper zu Zero Trust.",
+    "Generiere einen Titel fuer meine Arbeit.",
+    "Erstelle ein Konferenz-Poster.",
+    "Importiere meine Zotero-Bibliothek."
+  ]
+}

--- a/evals/zotero-import/evals.json
+++ b/evals/zotero-import/evals.json
@@ -1,0 +1,9 @@
+{
+  "component": "zotero-import",
+  "component_type": "skill",
+  "prompts": [
+    {"id": "zi-01", "input": "Wie dedupliziert ein Zotero-Import Items gegen bereits vorhandene Vault-Eintraege?", "expected": {"type": "regex", "value": "(DOI|ISBN|Dedup|dupli|normalisier)"}, "mode": "with_skill"},
+    {"id": "zi-02", "input": "Beschreibe den Ablauf, um Items und PDF-Attachments aus einer Zotero-Library zu importieren.", "expected": {"type": "regex", "value": "(pyzotero|Zotero|Item|Attachment|PDF)"}, "mode": "with_skill"},
+    {"id": "zi-03", "input": "Schreibt der Zotero-Import jemals Aenderungen zurueck nach Zotero?", "expected": {"type": "regex", "value": "(read-only|nur lesen|kein Push|no_push|read only|nicht)"}, "mode": "with_skill"}
+  ]
+}

--- a/evals/zotero-import/trigger_evals.json
+++ b/evals/zotero-import/trigger_evals.json
@@ -1,0 +1,27 @@
+{
+  "component": "zotero-import",
+  "should_trigger": [
+    "Importiere meine Zotero-Items in den Vault.",
+    "Synchronisiere meine Bibliothek mit dem Vault.",
+    "Mach einen Zotero-Sync.",
+    "Importiere meine Zotero-Bibliothek.",
+    "Hol die Items und PDFs aus Zotero.",
+    "Zotero importieren bitte.",
+    "Lade meine Zotero-Sammlung in den Vault.",
+    "Sync meine Zotero-Library, read-only.",
+    "Importiere die Attachments aus Zotero.",
+    "Bibliothek aus Zotero synchronisieren."
+  ],
+  "should_not_trigger": [
+    "Importiere meine Reading List.",
+    "Importiere einen Zitierstil aus dem CSL-Repo.",
+    "Extrahiere Zitate aus dem PDF.",
+    "Schreibe Kapitel 2.",
+    "Welches Thema soll ich nehmen?",
+    "Exportiere nach LaTeX.",
+    "Pruefe meinen Text auf Plagiate.",
+    "Erstelle ein Poster.",
+    "Schaerfe meine Forschungsfrage.",
+    "Generiere einen Titel."
+  ]
+}

--- a/tests/evals/test_eval_coverage.py
+++ b/tests/evals/test_eval_coverage.py
@@ -1,0 +1,105 @@
+"""Eval-Coverage-Guard (Issue #198).
+
+Stellt sicher, dass JEDER projekteigene Skill unter ``skills/*/SKILL.md`` sowohl
+``evals/<skill>/trigger_evals.json`` als auch ``evals/<skill>/evals.json`` besitzt
+und dass diese die im SCHEMA.md dokumentierten Mindestanforderungen erfuellen.
+
+Vor Issue #198 wurden fehlende ``evals/``-Verzeichnisse von ``test_triggers.py`` und
+``test_rest_evals.py`` stillschweigend uebersprungen (``if not path.exists(): continue``
+bzw. ``pytest.skip``). Dieser Test macht die Luecke CI-sichtbar: fehlende oder
+strukturell unvollstaendige Eval-Dateien sind ein FAIL, kein Skip.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tests.evals.eval_runner import EVALS_ROOT, SKILLS_ROOT
+
+# Skills, die KEINE projekteigenen Evals brauchen:
+# - ``_common``: geteilter Code, kein eigenstaendiger Skill (kein SKILL.md-Trigger).
+# - ``xlsx``: vendorter, proprietaerer Anthropic-Document-Skill (LICENSE.txt), wird
+#   nicht vom Projekt gepflegt und ist daher von der Eval-Pflicht ausgenommen.
+EXEMPT_SKILLS = {"_common", "xlsx"}
+
+# Mindestanforderungen aus evals/SCHEMA.md / Issue #198.
+# Der Floor ist bewusst am bestehenden Repo-Baseline ausgerichtet (alle Trigger-
+# Dateien haben 10/10, alle Quality-Dateien mindestens 2 Prompts), damit der Guard
+# die Coverage-Luecke schliesst, ohne unbeteiligte Altdateien zu brechen. Neu
+# angelegte Skills (Issue #198) erfuellen die obere Schema-Vorgabe (5-10 Trigger /
+# 3-5 Quality).
+MIN_TRIGGER_CASES = 5  # 5-10 Trigger-Test-Cases (positive)
+MIN_NEGATIVE_CASES = 5  # negative Cases
+MIN_QUALITY_CASES = 2  # >= 2 Quality-Cases (Baseline); Neuzugaenge liefern 3-5
+
+
+def _project_skills() -> list[str]:
+    return sorted(
+        p.parent.name
+        for p in SKILLS_ROOT.glob("*/SKILL.md")
+        if p.parent.name not in EXEMPT_SKILLS
+    )
+
+
+PROJECT_SKILLS = _project_skills()
+
+
+@pytest.mark.parametrize("skill", PROJECT_SKILLS)
+def test_skill_has_trigger_evals(skill: str) -> None:
+    path = EVALS_ROOT / skill / "trigger_evals.json"
+    assert path.exists(), (
+        f"Skill '{skill}' hat keine trigger_evals.json unter {path} "
+        f"(Eval-Coverage-Luecke, Issue #198)."
+    )
+    data = json.loads(path.read_text())
+    assert data.get("component") == skill, (
+        f"{path}: component='{data.get('component')}' != Verzeichnisname '{skill}'"
+    )
+    should = data.get("should_trigger", [])
+    should_not = data.get("should_not_trigger", [])
+    assert len(should) >= MIN_TRIGGER_CASES, (
+        f"{skill}: nur {len(should)} should_trigger-Cases, "
+        f"mindestens {MIN_TRIGGER_CASES} gefordert."
+    )
+    assert len(should_not) >= MIN_NEGATIVE_CASES, (
+        f"{skill}: nur {len(should_not)} should_not_trigger-Cases, "
+        f"mindestens {MIN_NEGATIVE_CASES} gefordert."
+    )
+    assert all(isinstance(p, str) and p.strip() for p in should + should_not), (
+        f"{skill}: trigger-Cases muessen nicht-leere Strings sein."
+    )
+
+
+@pytest.mark.parametrize("skill", PROJECT_SKILLS)
+def test_skill_has_quality_evals(skill: str) -> None:
+    path = EVALS_ROOT / skill / "evals.json"
+    assert path.exists(), (
+        f"Skill '{skill}' hat keine evals.json unter {path} "
+        f"(Eval-Coverage-Luecke, Issue #198)."
+    )
+    data = json.loads(path.read_text())
+    assert data.get("component") == skill, (
+        f"{path}: component='{data.get('component')}' != Verzeichnisname '{skill}'"
+    )
+    assert data.get("component_type") in ("skill", "agent"), (
+        f"{path}: component_type fehlt oder ungueltig ({data.get('component_type')})."
+    )
+    prompts = data.get("prompts", [])
+    assert len(prompts) >= MIN_QUALITY_CASES, (
+        f"{skill}: nur {len(prompts)} Quality-Cases, "
+        f"mindestens {MIN_QUALITY_CASES} gefordert."
+    )
+    seen_ids: set[str] = set()
+    for p in prompts:
+        pid = p.get("id")
+        assert pid and pid not in seen_ids, f"{skill}: doppelte/fehlende prompt-id {pid!r}."
+        seen_ids.add(pid)
+        assert p.get("input", "").strip(), f"{skill}/{pid}: leeres input-Feld."
+        assert p.get("mode") in ("with_skill", "without_skill", "both"), (
+            f"{skill}/{pid}: ungueltiger mode {p.get('mode')!r}."
+        )
+        expected = p.get("expected", {})
+        assert expected.get("type") in ("substring", "regex", "json_field"), (
+            f"{skill}/{pid}: ungueltiger expected.type {expected.get('type')!r}."
+        )


### PR DESCRIPTION
## Problem

Fünf v6.5-Neuzugänge (`topic-brainstorm`, `latex-export`, `grant-proposal`, `conference-poster`, `reviewer-response`) wurden ohne jegliche Eval-Coverage gemergt: weder `trigger_evals.json` noch `evals.json` existierten. Damit wurden weder Trigger-Recall noch Quality-Δ gemessen.

Die Audit-Erweiterung im Issue zeigte, dass die Lücke größer ist: insgesamt fehlten Eval-Dateien für 14 von 28 Skills. `tests/evals/test_triggers.py` (`if not path.exists(): return None`) und `tests/evals/test_rest_evals.py` (`if not path.exists(): continue`) übersprangen fehlende `evals/`-Verzeichnisse stillschweigend — die Lücke war CI-unsichtbar.

## Fix

- **Eval-Dateien für alle 14 fehlenden Skills** angelegt (5 v6.5-Neuzugänge plus die 9 älteren: `citation-style-import`, `cluster-visualizer`, `humanizer-de`, `material-passport`, `notebook-bundle`, `prisma-flow`, `reading-list-import`, `zotero-import`, `book-handler`):
  - `trigger_evals.json` mit je 10 positiven (`should_trigger`) und 10 negativen (`should_not_trigger`) Cases, abgeleitet aus den Trigger-Phrasen der jeweiligen `SKILL.md`.
  - `evals.json` mit je 3 Quality-Cases (`prompts`, Few-Shot mit `with_skill`-Mode) gemäß `evals/SCHEMA.md`.
  - `book-handler` hatte nur eine fixture-basierte `cases`-Struktur und keine `trigger_evals.json`; ein `prompts`-Array wurde additiv ergänzt (bestehende `cases` bleiben unverändert), plus die fehlende `trigger_evals.json`.
- **Neuer CI-Guard `tests/evals/test_eval_coverage.py`**: macht fehlende oder strukturell unvollständige Eval-Dateien zum FAIL statt Skip. Prüft Existenz, `component`-Name == Verzeichnisname, `component_type`, Mindest-Case-Zahlen und Feld-Validität. `_common` (kein eigenständiger Skill) und `xlsx` (vendorter, proprietärer Anthropic-Skill mit eigener LICENSE.txt) sind begründet ausgenommen.
- `test_triggers.py` zieht die neuen `trigger_evals.json` automatisch (parametrisiert über `skills/*/SKILL.md`); die 5 neuen Skills sind jetzt in der Collection (56 statt 46 Trigger-Tests).

Die eigentlichen Trigger-Recall- (≥ 85 %) und Quality-Evals laufen nur mit `ANTHROPIC_API_KEY` (offline-hermetisch geskippt); der neue Guard validiert die Existenz und Struktur offline und schließt damit die CI-Sichtbarkeitslücke.

## TDD-Belege

1. **Rot:** `test_eval_coverage.py` zuerst geschrieben → `37 failed, 17 passed` (14 Skills ohne `trigger_evals.json`, weitere ohne valide `evals.json`-Prompt-Struktur).
2. **Grün:** nach Anlegen aller Eval-Dateien → `54 passed` (27 Skills × 2 Tests).
3. **Volle Suite:** `pytest tests/ -p no:cacheprovider -q` → `1017 passed, 148 skipped, 0 failed` (Baseline 963/148 + 54 neue Guard-Tests; Skip-Zahl unverändert, da die API-gebundenen Evals weiterhin offline skippen).
4. **Manifest-Lint:** `jq empty` auf allen 28 neuen/geänderten `*.json` → OK.

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)
