### PR TITLE
fix(vault): supersede_decision + list_excluded_sources als @mcp.tool registrieren (#226)

### DIFF
--- a/academic_vault/server.py
+++ b/academic_vault/server.py
@@ -891,10 +891,20 @@ def _build_mcp_server():
         """Gibt Decisions zurueck. Optionaler category-Filter, active_only-Flag."""
         return list_decisions(db_path, category=category, active_only=active_only)
 
+    @mcp.tool(name="vault.supersede_decision")
+    def _vault_supersede_decision(decision_id: str, superseded_by: str) -> None:
+        """Markiert eine Decision als superseded (verweist auf Nachfolge-Decision)."""
+        supersede_decision(db_path, decision_id=decision_id, superseded_by=superseded_by)
+
     @mcp.tool(name="vault.add_excluded_source")
     def _vault_add_excluded_source(paper_id: str, reason: str = None) -> None:
         """Fuegt paper_id zu excluded_sources hinzu (verhindert Re-Vorschlag)."""
         add_excluded_source(db_path, paper_id=paper_id, reason=reason)
+
+    @mcp.tool(name="vault.list_excluded_sources")
+    def _vault_list_excluded_sources() -> list[dict]:
+        """Gibt alle excluded_sources zurueck."""
+        return list_excluded_sources(db_path)
 
     @mcp.tool(name="vault.is_excluded")
     def _vault_is_excluded(paper_id: str) -> bool:

--- a/tests/test_issue_226_vault_mcp_tools.py
+++ b/tests/test_issue_226_vault_mcp_tools.py
@@ -1,0 +1,50 @@
+"""Regressionstest fuer #226.
+
+``supersede_decision`` und ``list_excluded_sources`` sind als Python-Funktionen
+implementiert (``server.py`` :369 / :387), waren aber nicht mit
+``@mcp.tool(name=...)`` registriert. Damit waren sie ueber MCP nicht via
+``tools/list`` sichtbar oder aufrufbar — anders als ihr registriertes
+Gegenpaar ``vault.add_excluded_source`` / ``vault.is_excluded``.
+
+Dieser Test kodiert das Akzeptanzkriterium: beide Operationen muessen via
+MCP ``tools/list`` sichtbar (und damit aufrufbar) sein.
+"""
+import asyncio
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+# Repo-Root auf den Pfad, damit `academic_vault` (Top-Level) importierbar ist.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+
+def _list_tool_names():
+    """Baut den Server und gibt die Menge der registrierten Tool-Namen zurueck."""
+    pytest.importorskip("mcp.server.fastmcp")
+    server = importlib.import_module("academic_vault.server")
+    mcp_server = server._build_mcp_server()
+    assert mcp_server is not None, (
+        "mcp SDK nicht installiert — setup.sh muss mcp>=1.0 ins venv installieren"
+    )
+    tools = asyncio.run(mcp_server.list_tools())
+    return {t.name for t in tools}
+
+
+def test_supersede_decision_registered_as_mcp_tool():
+    """``vault.supersede_decision`` ist via ``tools/list`` sichtbar (#226)."""
+    names = _list_tool_names()
+    assert "vault.supersede_decision" in names, (
+        f"vault.supersede_decision fehlt in tools/list: {sorted(names)}"
+    )
+
+
+def test_list_excluded_sources_registered_as_mcp_tool():
+    """``vault.list_excluded_sources`` ist via ``tools/list`` sichtbar (#226)."""
+    names = _list_tool_names()
+    assert "vault.list_excluded_sources" in names, (
+        f"vault.list_excluded_sources fehlt in tools/list: {sorted(names)}"
+    )


### PR DESCRIPTION
## Problem
`supersede_decision()` (`academic_vault/server.py:369`) und `list_excluded_sources()` (`:387`) waren als Python-Funktionen implementiert, aber nirgends mit `@mcp.tool(name=...)` registriert. Über MCP waren sie damit weder in `tools/list` sichtbar noch aufrufbar — Skills mussten Subprocess-Umwege nehmen. Das Komplementär-Paar `vault.add_excluded_source` / `vault.is_excluded` war dagegen bereits registriert.

## Fix
In `_build_mcp_server()` zwei Registrierungen ergänzt, analog zum bestehenden Muster:
- `@mcp.tool(name="vault.supersede_decision")` (direkt nach `vault.list_decisions`)
- `@mcp.tool(name="vault.list_excluded_sources")` (zwischen `vault.add_excluded_source` und `vault.is_excluded`)

Die registrierten Wrapper delegieren unverändert an die bestehenden Modulfunktionen. Damit erhöht sich die Anzahl der `vault.*`-Tools von 28 auf 30.

## TDD-Belege
Neuer Regressionstest `tests/test_issue_226_vault_mcp_tools.py` baut den FastMCP-Server, ruft `list_tools()` auf und asserted die Präsenz beider Tool-Namen.

- ROT (vor Fix): `vault.supersede_decision fehlt in tools/list: [...]` bzw. `vault.list_excluded_sources fehlt in tools/list: [...]` — 2 failed.
- GRÜN (nach Fix): 2 passed.
- Volle Suite: 965 passed, 148 skipped (Baseline 963 passed + 2 neue Tests, nichts gebrochen). Der bestehende `test_vault_server_start.py`-Check `len(names) >= 28` bleibt erfüllt (jetzt 30).

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)
