### PR TITLE
fix(command): doppeltes Relevanz-Scoring in search.md entfernen (#227)

### DIFF
--- a/commands/search.md
+++ b/commands/search.md
@@ -104,13 +104,7 @@ Ergebnisse an `$SESSION_DIR/api_results.json` anhängen.
 
 Die Heuristik-Dimensionen (Aktualität, Qualität, Autorität, Zugang) werden direkt in diesem Command berechnet — siehe Formeln in `commands/score.md` → „4 weitere Dimensionen berechnen". Gesamtscore wie dort, Clusterzuweisung ebenfalls. Das Resultat in `$SESSION_DIR/ranked.json` schreiben.
 
-### Schritt 7: LLM-Relevanz-Scoring
-
-Den `relevance-scorer`-Agent in Batches von 10 Papers starten.
-LLM-Scores ins Ranking einmischen. Top-N nach Modus wählen (quick=15, standard=25, deep=40).
-Als `$SESSION_DIR/papers.json` speichern.
-
-### Schritt 8: PRISMA-Zähler speichern
+### Schritt 7: PRISMA-Zähler speichern
 
 ```bash
 ~/.academic-research/venv/bin/python -c "
@@ -130,7 +124,7 @@ save_prisma_counters('$SESSION_DIR', counters)
 
 Die Zähler werden in `$SESSION_DIR/prisma_counters.json` gespeichert.
 
-### Schritt 9: Relevanz-Scoring (Standard vs. Batch)
+### Schritt 8: Relevanz-Scoring (Standard vs. Batch)
 
 **Standard (< 50 Paper oder kein `--batch`):**  
 Den `relevance-scorer`-Agent in Batches von 10 Papers starten.
@@ -155,7 +149,7 @@ print('Abholung via: /history --batch', job['batch_id'])
 Job-ID wird in `$SESSION_DIR/batch.json` gespeichert. Abholung über
 `/history --batch <id>` (sobald Batch-Status `ended` ist, ca. 1 h).
 
-### Schritt 10: Interactive Mode — Phase 1 (nur bei `--interactive`)
+### Schritt 9: Interactive Mode — Phase 1 (nur bei `--interactive`)
 
 Falls `--interactive=off` (Standard): diesen Schritt überspringen.
 
@@ -183,7 +177,7 @@ Optionen:
 
 Bei "Weiter": Phase 2 (Deep-Investigation) starten = vollständiges Scoring + Kapitelplanung.
 
-### Schritt 11: Ergebnisse anzeigen
+### Schritt 10: Ergebnisse anzeigen
 
 Eine formatierte Tabelle mit Rang, Titel, Jahr, Score, Cluster und Quellmodul ausgeben.
 Pfad des Session-Verzeichnisses melden.

--- a/tests/test_search_interactive.py
+++ b/tests/test_search_interactive.py
@@ -153,6 +153,49 @@ def test_search_md_interactive_off_documented():
 
 
 # ---------------------------------------------------------------------------
+# Regression #227: relevance-scorer darf nur einmal pro Suchlauf aufgerufen werden
+# ---------------------------------------------------------------------------
+
+def test_search_md_relevance_scorer_invoked_once():
+    """commands/search.md darf den relevance-scorer-Agent nur EINMAL als
+    Ausführungsschritt starten (kein doppeltes LLM-Relevanz-Scoring).
+
+    Issue #227: Schritt 7 (Draft-Überbleibsel) und Schritt 9 beschrieben
+    beide wortidentisch das Starten des relevance-scorer-Agents in Batches
+    von 10 Papers -> Scorer-Doppelaufruf -> unnötige API-Kosten +
+    inkonsistentes Überschreiben von papers.json.
+    """
+    search_md = REPO_ROOT / "commands" / "search.md"
+    content = search_md.read_text(encoding="utf-8")
+    phrase = "Den `relevance-scorer`-Agent in Batches von 10 Papers starten."
+    occurrences = content.count(phrase)
+    assert occurrences == 1, (
+        f"relevance-scorer-Start-Anweisung kommt {occurrences}x vor "
+        f"(erwartet: genau 1) -> doppeltes Relevanz-Scoring (#227)"
+    )
+
+
+def test_search_md_no_duplicate_step_numbers():
+    """commands/search.md darf keine doppelten Schritt-Nummern haben.
+
+    Nach Entfernen des redundanten Schritts (#227) müssen die verbleibenden
+    Schritte lückenlos und eindeutig nummeriert sein.
+    """
+    import re
+    search_md = REPO_ROOT / "commands" / "search.md"
+    content = search_md.read_text(encoding="utf-8")
+    numbers = [int(m) for m in re.findall(r"^### Schritt (\d+):", content, re.MULTILINE)]
+    assert numbers, "Keine '### Schritt N:'-Überschriften gefunden"
+    assert len(numbers) == len(set(numbers)), (
+        f"Doppelte Schritt-Nummern gefunden: {numbers}"
+    )
+    # Lückenlos von 1 aufsteigend
+    assert numbers == list(range(1, len(numbers) + 1)), (
+        f"Schritt-Nummern nicht lückenlos aufsteigend: {numbers}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # chapter-writer SKILL.md approval gate
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

In `commands/search.md` beschrieben **Schritt 7** und **Schritt 9** dasselbe: den `relevance-scorer`-Agent in Batches von 10 Papers starten, die LLM-Scores ins Ranking einmischen und das Ergebnis als `papers.json` speichern. Schritt 7 (`:107-111`) war ein Draft-Überbleibsel und wortidentisch zur Standard-Variante in Schritt 9 (`:133-138`). Schritt 9 ist die vollständigere Version (inkl. Batch-Modus).

Folge: Ein Ausführungsagent hätte den Scorer doppelt aufrufen können — unnötige API-Kosten und inkonsistentes Überschreiben von `papers.json`.

## Fix

- Schritt 7 (`### Schritt 7: LLM-Relevanz-Scoring` samt redundantem Block) entfernt.
- Schritt 9 (`Relevanz-Scoring (Standard vs. Batch)`) als einzigen Scoring-Schritt behalten — er enthält sowohl die Standard- als auch die Batch-Logik.
- Verbleibende Schritte 8–11 zu 7–10 neu nummeriert; Nummerierung jetzt lückenlos 1–10.
- Keine JSON-Manifeste, Hooks oder Frontmatter berührt; `description:`-Frontmatter von `search.md` bleibt unverändert.

## TDD-Belege

Zwei Regressionstests in `tests/test_search_interactive.py` (gleiche Stilvorlage wie bestehende `search.md`-assertierende Tests):

- `test_search_md_relevance_scorer_invoked_once` — die Anweisung „Den `relevance-scorer`-Agent in Batches von 10 Papers starten." darf genau **einmal** vorkommen.
- `test_search_md_no_duplicate_step_numbers` — `### Schritt N:`-Überschriften müssen eindeutig und lückenlos von 1 aufsteigend sein.

Rot → Grün:
- Vor dem Fix: `test_search_md_relevance_scorer_invoked_once` schlug fehl mit `AssertionError: relevance-scorer-Start-Anweisung kommt 2x vor (erwartet: genau 1)` (`assert 2 == 1`).
- Nach dem Fix: `tests/test_search_interactive.py` → 14 passed.
- Volle Suite: `965 passed, 148 skipped` (Baseline 963 + 2 neue Tests, 0 failed).

Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)
