### PR TITLE
fix(security): arXiv-API über https statt http ansprechen (#229)

### DIFF
--- a/scripts/search.py
+++ b/scripts/search.py
@@ -418,7 +418,7 @@ def search_econstor(query: str, limit: int) -> list[dict[str, Any]]:
 
 def search_arxiv(query: str, limit: int) -> list[dict[str, Any]]:
     """Search arXiv via Atom feed API."""
-    url = "http://export.arxiv.org/api/query"
+    url = "https://export.arxiv.org/api/query"
     params = {
         "search_query": f"all:{query}",
         "start": 0,

--- a/tests/test_issue_229_arxiv_https.py
+++ b/tests/test_issue_229_arxiv_https.py
@@ -1,0 +1,59 @@
+"""Regressionstest fuer Issue #229.
+
+arXiv-API muss ueber https:// statt http:// angesprochen werden.
+Akzeptanzkriterium: Kein http://-Netzwerk-Endpoint mehr in scripts/.
+
+XML-Namespace-URIs (z.B. http://www.w3.org/2005/Atom) und das
+DOI-Prefix-Stripping (http://doi.org/) sind keine Netzwerk-Endpoints
+und bleiben unveraendert.
+"""
+
+import re
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+
+# Bekannte, harmlose http://-Vorkommen: XML-Namespace-Identifier und
+# DOI-Prefix-Strings. Das sind keine Netzwerk-Endpoints.
+_ALLOWED_HTTP = (
+    "http://www.w3.org/2005/Atom",
+    "http://www.openarchives.org/OAI/2.0/",
+    "http://www.openarchives.org/OAI/2.0/oai_dc/",
+    "http://purl.org/dc/elements/1.1/",
+    "http://www.loc.gov/MARC21/slim",
+    "http://www.loc.gov/zing/srw/",
+    "http://doi.org/",
+)
+
+# Finde http://-URLs, die einen .../api/query- oder export.arxiv.org-Pfad
+# enthalten (echte Endpoints).
+_ARXIV_HTTP = re.compile(r"http://(?:export\.)?arxiv\.org")
+
+
+def _iter_http_urls(text: str):
+    for match in re.finditer(r"http://[^\s\"'<>)]+", text):
+        yield match.group(0)
+
+
+def test_search_arxiv_uses_https():
+    src = (SCRIPTS_DIR / "search.py").read_text(encoding="utf-8")
+    assert "https://export.arxiv.org/api/query" in src
+    assert "http://export.arxiv.org/api/query" not in src
+
+
+def test_no_http_arxiv_endpoint_in_scripts():
+    for py in SCRIPTS_DIR.rglob("*.py"):
+        src = py.read_text(encoding="utf-8")
+        assert not _ARXIV_HTTP.search(src), (
+            f"{py} enthaelt einen unverschluesselten arXiv-Endpoint (http://)"
+        )
+
+
+def test_no_unexpected_http_endpoint_in_scripts():
+    """Kein http://-Netzwerk-Endpoint (ausser bekannten Namespace-/DOI-Strings)."""
+    for py in SCRIPTS_DIR.rglob("*.py"):
+        src = py.read_text(encoding="utf-8")
+        for url in _iter_http_urls(src):
+            assert any(url.startswith(allowed) for allowed in _ALLOWED_HTTP), (
+                f"{py}: unerwarteter http://-Endpoint {url!r}"
+            )


### PR DESCRIPTION
## Problem
`search_arxiv()` in `scripts/search.py:421` sprach die arXiv-API über einen unverschlüsselten `http://`-Endpoint an, während die identische Funktion in `scripts/pdf.py:142` bereits korrekt `https://` verwendet. Über eine MITM-Position ließen sich Suchergebnisse manipulieren (falsche DOIs/Inhalte).

## Fix
Endpoint in `search_arxiv()` auf `https://export.arxiv.org/api/query` umgestellt (`s/http:/https:/`). arXiv unterstützt HTTPS vollständig. Die verbleibenden `http://`-Vorkommen in `scripts/` sind XML-Namespace-Identifier (z.B. `http://www.w3.org/2005/Atom`) und DOI-Prefix-Strings — keine Netzwerk-Endpoints — und bleiben unverändert.

## TDD-Belege
Neue Regressionsdatei `tests/test_issue_229_arxiv_https.py` mit drei Tests, die das Akzeptanzkriterium kodieren:
- `test_search_arxiv_uses_https` — asserted `https://export.arxiv.org/api/query` und das Fehlen des `http://`-Pendants.
- `test_no_http_arxiv_endpoint_in_scripts` — kein `http://`-arXiv-Endpoint in `scripts/`.
- `test_no_unexpected_http_endpoint_in_scripts` — kein unerwarteter `http://`-Netzwerk-Endpoint (Allowlist für Namespace-/DOI-Strings).

Rot → Grün:
- Vor dem Fix: 3 failed (`AssertionError: assert 'https://export.arxiv.org/api/query' in ...` bzw. `unverschluesselten arXiv-Endpoint`).
- Nach dem Fix: 3 passed.
- Volle Suite: 966 passed, 148 skipped, 0 failed (Baseline 963 passed + 3 neue Tests).
- grep-Check: `grep -rn "http://export.arxiv.org\|http://arxiv.org" scripts/` findet nichts (Exit 1).

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)
