### PR TITLE
fix(evals): temperature=0 in eval_runner für deterministische Trigger-Evals (#231)

### DIFF
--- a/tests/evals/eval_runner.py
+++ b/tests/evals/eval_runner.py
@@ -54,6 +54,7 @@ def call_claude(system: str, user: str, model: str = "claude-sonnet-4-6") -> str
     resp = client.messages.create(
         model=model,
         max_tokens=2048,
+        temperature=0,  # deterministisch — verhindert flaky Trigger-Evals (#231)
         system=system,
         messages=[{"role": "user", "content": user}],
     )
@@ -128,6 +129,7 @@ def call_claude_with_tokens(
     resp = client.messages.create(
         model=model,
         max_tokens=2048,
+        temperature=0,  # deterministisch — verhindert flaky Trigger-Evals (#231)
         system=system,
         messages=[{"role": "user", "content": user}],
     )

--- a/tests/evals/test_issue_231_temperature.py
+++ b/tests/evals/test_issue_231_temperature.py
@@ -1,0 +1,65 @@
+"""Regression-Test fuer Issue #231.
+
+`call_claude()` / `call_claude_with_tokens()` muessen `temperature=0` an die
+Claude-API uebergeben, damit Trigger-Evals deterministisch sind und nicht durch
+nicht-deterministisches Sampling intermittierend in der CI fehlschlagen.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from tests.evals import eval_runner
+
+
+class _CaptureClient:
+    """Anthropic-Client-Stub, der die kwargs von messages.create festhaelt."""
+
+    def __init__(self, *args, **kwargs) -> None:  # noqa: D401 - Stub
+        self.captured: dict | None = None
+        self.messages = SimpleNamespace(create=self._create)
+
+    def _create(self, **kwargs):
+        self.captured = kwargs
+        # Minimal-Response mit .content und .usage wie die echte SDK-Antwort.
+        return SimpleNamespace(
+            content=[SimpleNamespace(text="ok")],
+            usage=SimpleNamespace(input_tokens=1, output_tokens=1),
+        )
+
+
+@pytest.fixture
+def captured_kwargs(monkeypatch):
+    """Patcht das anthropic-Modul, sodass kein echter API-Call passiert.
+
+    Liefert eine Liste, in die der einzige _CaptureClient nach Konstruktion
+    seine create-kwargs schreibt.
+    """
+    holder: dict[str, dict] = {}
+
+    def _client_factory(*args, **kwargs):
+        client = _CaptureClient(*args, **kwargs)
+        holder["client"] = client
+        return client
+
+    fake_anthropic = SimpleNamespace(Anthropic=_client_factory)
+    monkeypatch.setattr(eval_runner, "anthropic", fake_anthropic)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    return holder
+
+
+def test_call_claude_uses_temperature_zero(captured_kwargs):
+    eval_runner.call_claude("sys", "user")
+    kwargs = captured_kwargs["client"].captured
+    assert kwargs is not None, "messages.create wurde nicht aufgerufen"
+    assert "temperature" in kwargs, "temperature fehlt -> nicht-deterministisch"
+    assert kwargs["temperature"] == 0
+
+
+def test_call_claude_with_tokens_uses_temperature_zero(captured_kwargs):
+    eval_runner.call_claude_with_tokens("sys", "user")
+    kwargs = captured_kwargs["client"].captured
+    assert kwargs is not None, "messages.create wurde nicht aufgerufen"
+    assert "temperature" in kwargs, "temperature fehlt -> nicht-deterministisch"
+    assert kwargs["temperature"] == 0


### PR DESCRIPTION
## Problem
`call_claude()` und `call_claude_with_tokens()` in `tests/evals/eval_runner.py` übergaben kein `temperature`-Argument an die Claude-API, sodass der nicht-deterministische Default genutzt wurde. Alle 13 `trigger_evals.json` arbeiten mit N=10 Samples bei Schwellen von recall ≥ 85 % (max. 1 Miss) und FPR ≤ 10 % (max. 1 False-Positive). Eine einzige abweichende LLM-Antwort kippt PASS→FAIL und verursacht intermittierende CI-Failures.

## Fix
In beiden `call_claude*`-Funktionen wird jetzt `temperature=0` (greedy decoding) gesetzt. Damit liefern identische Eingaben deterministisch identische Trigger-Eval-Ergebnisse. Der Scope bleibt eng auf die zwei API-Aufrufe begrenzt; Sample-Size und Schwellen bleiben unverändert.

## TDD-Belege
Neuer Regressionstest `tests/evals/test_issue_231_temperature.py` stubt das `anthropic`-Modul und fängt die kwargs von `messages.create` ab.

- ROT (vor Fix): `AssertionError: temperature fehlt -> nicht-deterministisch` für beide Funktionen.
- GRÜN (nach Fix): `2 passed`.
- Volle Suite: `965 passed, 148 skipped` (Baseline 963 passed + 2 neue Tests), 0 failed/errors, keine Regressionen.

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)
