### PR TITLE
fix(command): /history --batch dokumentieren + Abhol-API ergaenzen (#228)

### DIFF
--- a/commands/history.md
+++ b/commands/history.md
@@ -1,7 +1,7 @@
 ---
 description: View past research sessions and their results; restore snapshots
 allowed-tools: Read, Bash(cat ~/.academic-research/*), Bash(ls ~/.academic-research/*), Bash(~/.academic-research/venv/bin/python *), Bash(ls ~/.academic-research/snapshots/*), Bash(tar *)
-argument-hint: [optional: search query, date, --restore <ts>, --snapshots]
+argument-hint: [optional: search query, date, --restore <ts>, --snapshots, --batch <id>]
 disable-model-invocation: true
 ---
 
@@ -17,12 +17,14 @@ Vergangene Recherche-Sessions ansehen und Snapshots verwalten.
 - `/academic-research:history stats` — Aggregatstatistik anzeigen
 - `/academic-research:history --snapshots` — Alle verfügbaren Snapshots auflisten
 - `/academic-research:history --restore <ts>` — Snapshot wiederherstellen (z.B. `--restore 20260507-1430`)
+- `/academic-research:history --batch <id>` — Eingereichten Batch-Job abholen (Relevanz-Scoring, siehe `search --batch`)
 
 ## Umsetzung
 
 1. Argument prüfen:
    - `--restore <ts>` → **Snapshot-Wiederherstellung** (siehe unten)
    - `--snapshots` → Snapshot-Liste anzeigen (siehe unten)
+   - `--batch <id>` → **Batch-Job-Abholung** (siehe unten)
    - Datum → Session von diesem Tag finden, Details anzeigen
    - `"stats"` → Aggregatstatistik anzeigen
    - Sonst → Sessions per Query-Text durchsuchen oder alle auflisten
@@ -88,3 +90,36 @@ print('Wiederhergestellt.' if ok else 'Fehler: Snapshot nicht gefunden.')
    - Fehler: `❌ Snapshot <ts> nicht gefunden unter ~/.academic-research/snapshots/<slug>/`
 
 **Hinweis:** Vor der Wiederherstellung werden aktuelle Dateien überschrieben. Empfehlung: Neuen Snapshot erstellen bevor --restore ausgeführt wird.
+
+## Batch-Job-Abholung (`--batch <id>`)
+
+`/academic-research:search --batch` reicht das Relevanz-Scoring grosser Treffermengen (≥ 50 Paper) asynchron über die Anthropic Message Batches API ein und gibt am Ende `Abholung via: /history --batch <id>` aus. Mit diesem Workflow holst du das Ergebnis ab, sobald der Batch fertig ist (Status `ended`, typischerweise ca. 1 h nach Einreichung).
+
+Ablauf:
+1. Batch-ID aus dem Argument (`<id>`, Format `msgbatch_…`) übernehmen.
+2. Batch-Status prüfen und — wenn `ended` — die Relevanz-Scores einlesen:
+
+```bash
+~/.academic-research/venv/bin/python -c "
+import sys
+sys.path.insert(0, '${CLAUDE_PLUGIN_ROOT}/scripts')
+from batch_api import get_batch_status, fetch_batch_results
+
+batch_id = '<id>'
+status = get_batch_status(batch_id)
+print('Batch-Status:', status)
+if status == 'ended':
+    scores = fetch_batch_results(batch_id)
+    print('Scores abgeholt:', len(scores))
+    for custom_id, score in sorted(scores.items()):
+        print(f'  {custom_id}: {score:.2f}')
+else:
+    print('Noch nicht fertig — bitte später erneut /history --batch', batch_id)
+"
+```
+
+3. Ergebnis ausgeben:
+   - Fertig (`ended`): `✅ Batch <id> abgeholt — <n> Relevanz-Scores gelesen` und die Scores in die Session-`ranked.json` zurückschreiben (Reihenfolge über die `paper_<i>`-`custom_id` mappen).
+   - Noch laufend (`in_progress`): `⏳ Batch <id> läuft noch (Status: <status>) — in ~1 h erneut /history --batch <id> aufrufen`.
+
+**Hinweis:** Die Batch-Job-Metadaten liegen in `<SESSION_DIR>/batch.json` (von `search --batch` via `save_batch_job` geschrieben); `load_batch_job(<SESSION_DIR>)` liest sie zurück, falls du die `<id>` nicht zur Hand hast.

--- a/scripts/batch_api.py
+++ b/scripts/batch_api.py
@@ -7,9 +7,10 @@ Usage:
   job = submit_batch(papers, query="DevOps", model="claude-haiku-4-5")
   save_batch_job(session_dir, job)
 
-  # later
+  # later (pickup via /history --batch <id>)
   job = load_batch_job(session_dir)
-  print(job["batch_id"])
+  if get_batch_status(job["batch_id"]) == "ended":
+      scores = fetch_batch_results(job["batch_id"])
 """
 
 from __future__ import annotations
@@ -109,3 +110,55 @@ def load_batch_job(session_dir: str) -> dict[str, Any]:
     """Load batch job metadata from <session_dir>/batch.json."""
     path = Path(session_dir) / _BATCH_JSON
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def get_batch_status(batch_id: str, api_key: str | None = None) -> str:
+    """Return the processing status of a submitted batch.
+
+    Polls the Anthropic Message Batches API. The batch is ready to be
+    retrieved once the status is ``ended``.
+
+    Args:
+        batch_id: The ``msgbatch_...`` id returned by submit_batch().
+        api_key: Anthropic API key (falls back to ANTHROPIC_API_KEY env var).
+
+    Returns:
+        The processing status string (e.g. ``in_progress`` or ``ended``).
+    """
+    key = api_key or os.environ.get("ANTHROPIC_API_KEY")
+    client = anthropic.Anthropic(api_key=key)
+    batch = client.beta.messages.batches.retrieve(batch_id)
+    return batch.processing_status
+
+
+def fetch_batch_results(batch_id: str, api_key: str | None = None) -> dict[str, float]:
+    """Fetch and parse relevance scores for a finished batch.
+
+    Should only be called once :func:`get_batch_status` reports ``ended``.
+    Maps each ``paper_<i>`` custom_id back to its parsed relevance score.
+
+    Args:
+        batch_id: The ``msgbatch_...`` id of an ``ended`` batch.
+        api_key: Anthropic API key (falls back to ANTHROPIC_API_KEY env var).
+
+    Returns:
+        Mapping of custom_id (e.g. ``paper_0``) to relevance score (float).
+        Entries that did not succeed or could not be parsed are skipped.
+    """
+    key = api_key or os.environ.get("ANTHROPIC_API_KEY")
+    client = anthropic.Anthropic(api_key=key)
+
+    scores: dict[str, float] = {}
+    for entry in client.beta.messages.batches.results(batch_id):
+        if getattr(entry.result, "type", None) != "succeeded":
+            continue
+        message = entry.result.message
+        text = "".join(
+            block.text for block in message.content if getattr(block, "type", None) == "text"
+        )
+        try:
+            parsed = json.loads(text)
+            scores[entry.custom_id] = float(parsed["score"])
+        except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+            continue
+    return scores

--- a/tests/test_batch_api.py
+++ b/tests/test_batch_api.py
@@ -131,6 +131,77 @@ def test_submit_batch_skips_when_below_threshold():
 
 
 # ---------------------------------------------------------------------------
+# Batch-Abholung (#228): get_batch_status / fetch_batch_results
+# ---------------------------------------------------------------------------
+
+def test_batch_api_has_get_batch_status():
+    """batch_api must expose get_batch_status() for --batch pickup."""
+    import batch_api
+    assert hasattr(batch_api, "get_batch_status")
+    assert callable(batch_api.get_batch_status)
+
+
+def test_batch_api_has_fetch_batch_results():
+    """batch_api must expose fetch_batch_results() for --batch pickup."""
+    import batch_api
+    assert hasattr(batch_api, "fetch_batch_results")
+    assert callable(batch_api.fetch_batch_results)
+
+
+def test_get_batch_status_returns_processing_status():
+    """get_batch_status() returns the API processing_status string."""
+    import batch_api
+
+    mock_batch = MagicMock()
+    mock_batch.processing_status = "ended"
+
+    with patch("batch_api.anthropic") as mock_anthropic:
+        mock_client = MagicMock()
+        mock_anthropic.Anthropic.return_value = mock_client
+        mock_client.beta.messages.batches.retrieve.return_value = mock_batch
+
+        status = batch_api.get_batch_status("msgbatch_test001")
+
+    assert status == "ended"
+    mock_client.beta.messages.batches.retrieve.assert_called_once_with("msgbatch_test001")
+
+
+def test_fetch_batch_results_parses_scores():
+    """fetch_batch_results() maps custom_id -> parsed relevance score."""
+    import batch_api
+
+    def _entry(custom_id, text, rtype="succeeded"):
+        block = MagicMock()
+        block.type = "text"
+        block.text = text
+        message = MagicMock()
+        message.content = [block]
+        result = MagicMock()
+        result.type = rtype
+        result.message = message
+        entry = MagicMock()
+        entry.custom_id = custom_id
+        entry.result = result
+        return entry
+
+    entries = [
+        _entry("paper_0", '{"score": 0.9}'),
+        _entry("paper_1", '{"score": 0.1}'),
+        _entry("paper_2", "not json"),          # unparsable -> skipped
+        _entry("paper_3", '{"score": 0.5}', rtype="errored"),  # failed -> skipped
+    ]
+
+    with patch("batch_api.anthropic") as mock_anthropic:
+        mock_client = MagicMock()
+        mock_anthropic.Anthropic.return_value = mock_client
+        mock_client.beta.messages.batches.results.return_value = iter(entries)
+
+        scores = batch_api.fetch_batch_results("msgbatch_test001")
+
+    assert scores == {"paper_0": 0.9, "paper_1": 0.1}
+
+
+# ---------------------------------------------------------------------------
 # commands/search.md contains --batch flag
 # ---------------------------------------------------------------------------
 

--- a/tests/test_issue_228_history_batch_flag.py
+++ b/tests/test_issue_228_history_batch_flag.py
@@ -1,0 +1,89 @@
+"""Regressionstest fuer Issue #228:
+
+commands/search.md weist Nutzer an, Batch-Jobs via `/history --batch <id>`
+abzuholen (search.md:151,156). commands/history.md kannte dieses Flag aber
+weder im `argument-hint` (Frontmatter :4) noch im Workflow-Body. Wer `--batch`
+gemaess Anweisung aufrief, erhielt kein definiertes Verhalten.
+
+Dieser Test kodiert das Akzeptanzkriterium:
+  - `/academic-research:history --batch <id>` ist dokumentiert.
+
+Reiner Markdown-Assert-Test (kein LLM-Call), analog zu test_fetch_command.py.
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+HISTORY_MD = REPO_ROOT / "commands" / "history.md"
+SEARCH_MD = REPO_ROOT / "commands" / "search.md"
+
+
+def _parse_frontmatter(path: Path) -> dict:
+    """Parse YAML frontmatter delimited by '---' lines (ohne yaml-Dep)."""
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}
+    end = None
+    for i, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            end = i
+            break
+    if end is None:
+        return {}
+    fm: dict[str, str] = {}
+    for line in lines[1:end]:
+        if ":" in line:
+            key, _, value = line.partition(":")
+            fm[key.strip()] = value.strip()
+    return fm
+
+
+# ---------------------------------------------------------------------------
+# Voraussetzung: search.md verweist tatsaechlich auf /history --batch
+# ---------------------------------------------------------------------------
+
+def test_search_md_references_history_batch():
+    """search.md verweist Nutzer auf /history --batch <id> (Quelle des Issues)."""
+    content = SEARCH_MD.read_text(encoding="utf-8")
+    assert "/history --batch" in content, (
+        "search.md sollte weiterhin auf /history --batch verweisen "
+        "(Grundlage von Issue #228)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Akzeptanzkriterium: --batch in history.md dokumentiert
+# ---------------------------------------------------------------------------
+
+def test_history_md_argument_hint_documents_batch():
+    """`--batch <id>` muss im argument-hint-Frontmatter von history.md stehen."""
+    fm = _parse_frontmatter(HISTORY_MD)
+    hint = fm.get("argument-hint", "")
+    assert "--batch" in hint, (
+        f"argument-hint von history.md dokumentiert --batch nicht: {hint!r}"
+    )
+
+
+def test_history_md_body_documents_batch_workflow():
+    """history.md muss einen Workflow-Abschnitt fuer --batch-Abholung enthalten."""
+    content = HISTORY_MD.read_text(encoding="utf-8")
+    assert "--batch" in content, "history.md erwaehnt --batch ueberhaupt nicht"
+    # Workflow muss den Batch-Status pruefen und Ergebnisse einlesen.
+    assert "batch_id" in content or "Batch-Job" in content, (
+        "history.md --batch-Workflow referenziert keine batch_id/Batch-Job"
+    )
+    assert "ended" in content, (
+        "history.md --batch-Workflow prueft den Batch-Status 'ended' nicht"
+    )
+
+
+def test_history_md_batch_uses_batch_api_module():
+    """Der --batch-Workflow muss das batch_api-Modul nutzen (load_batch_job)."""
+    content = HISTORY_MD.read_text(encoding="utf-8")
+    assert "batch_api" in content, (
+        "history.md --batch-Workflow importiert das batch_api-Modul nicht"
+    )
+    assert "load_batch_job" in content, (
+        "history.md --batch-Workflow nutzt load_batch_job nicht"
+    )


### PR DESCRIPTION
## Problem

`commands/search.md` weist Nutzer im Batch-Modus an, das Relevanz-Scoring grosser Treffermengen abzuholen via `Abholung via: /history --batch <id>` (`search.md:151,156`). `commands/history.md` kannte dieses Flag jedoch nicht — weder im `argument-hint` (Frontmatter `:4`) noch im Workflow-Body. Wer `--batch` gemaess Anweisung aufrief, erhielt kein definiertes Verhalten. Zusaetzlich fehlte im `batch_api`-Modul ueberhaupt eine Funktion, um Status/Ergebnisse eines eingereichten Batches abzuholen.

## Fix

- `commands/history.md`: `--batch <id>` in `argument-hint`, in die Verwendungs-Liste und ins Argument-Routing aufgenommen.
- Neuen Workflow-Abschnitt **Batch-Job-Abholung (`--batch <id>`)** ergaenzt: Batch-Status pruefen und — wenn `ended` — die Relevanz-Scores einlesen, sonst Hinweis "laeuft noch, spaeter erneut aufrufen".
- `scripts/batch_api.py`: `get_batch_status()` (pollt `processing_status`) und `fetch_batch_results()` (mappt `paper_<i>`-`custom_id` → Score, ueberspringt fehlgeschlagene/unparsbare Eintraege) ergaenzt, damit der dokumentierte Flow tatsaechlich funktioniert.

## TDD-Belege

Neuer Regressionstest `tests/test_issue_228_history_batch_flag.py` kodiert das Akzeptanzkriterium (argument-hint + Workflow-Body + `batch_api`/`load_batch_job`-Nutzung + `ended`-Status).

- ROT (vor Fix): `3 failed, 1 passed` — `--batch` fehlte in `argument-hint` und im gesamten Body (`assert '--batch' in '[optional: search query, date, --restore <ts>, --snapshots]'`), `batch_api` nicht referenziert.
- GRUEN (nach Fix): `tests/test_issue_228_history_batch_flag.py tests/test_batch_api.py` → `18 passed`.
- Volle Suite: `971 passed, 148 skipped` (Baseline `963 passed, 148 skipped`; +8 neue Tests, 0 failed/errors).

Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)
