### PR TITLE
fix(security): settings.local.json atomar schreiben (#230)

### DIFF
--- a/scripts/configure_permissions.py
+++ b/scripts/configure_permissions.py
@@ -7,6 +7,7 @@ Adds required tool permissions to ~/.claude/settings.local.json.
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -24,11 +25,40 @@ REQUIRED_PERMISSIONS = [
 ]
 
 
-def main() -> int:
-    settings: dict = {}
-    if SETTINGS_PATH.exists():
+def atomic_write_text(path: Path, text: str) -> None:
+    """Schreibe ``text`` atomar nach ``path``.
+
+    Es wird zunächst in eine temporäre Datei im selben Verzeichnis geschrieben,
+    auf die Platte geflusht und anschließend per ``os.replace`` an die Zielposition
+    umbenannt. ``os.replace`` ist auf POSIX und Windows atomar. Bricht der Prozess
+    vor dem ``os.replace`` ab (SIGKILL, Stromausfall, volle Disk), bleibt die alte
+    Zieldatei unverändert erhalten; ein eventuell übrig gebliebenes Tempfile wird
+    weggeräumt.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(path.name + ".tmp")
+    try:
+        with open(tmp_path, "w", encoding="utf-8") as fh:
+            fh.write(text)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_path, path)
+    except BaseException:
+        # Bei jedem Fehler keine halbfertige Tempdatei zurücklassen.
         try:
-            settings = json.loads(SETTINGS_PATH.read_text(encoding="utf-8"))
+            os.remove(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def main(settings_path: Path | None = None) -> int:
+    settings_path = Path(settings_path) if settings_path is not None else SETTINGS_PATH
+
+    settings: dict = {}
+    if settings_path.exists():
+        try:
+            settings = json.loads(settings_path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError):
             pass
 
@@ -40,11 +70,13 @@ def main() -> int:
             added += 1
 
     settings.setdefault("permissions", {})["allow"] = allow_list
-    SETTINGS_PATH.parent.mkdir(parents=True, exist_ok=True)
-    SETTINGS_PATH.write_text(json.dumps(settings, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    atomic_write_text(
+        settings_path,
+        json.dumps(settings, indent=2, ensure_ascii=False) + "\n",
+    )
 
     print(f"✅ Permissions updated ({added} new rules added)")
-    print(f"   File: {SETTINGS_PATH}")
+    print(f"   File: {settings_path}")
     return 0
 
 

--- a/tests/test_issue_230_atomic_settings_write.py
+++ b/tests/test_issue_230_atomic_settings_write.py
@@ -1,0 +1,119 @@
+"""Regressionstests für Issue #230:
+
+scripts/configure_permissions.py muss settings.local.json ATOMAR schreiben
+(Tempfile + os.replace), damit ein Abbruch während des Schreibens (SIGKILL,
+Stromausfall, volle Disk) niemals eine kaputte/leere Datei hinterlässt.
+
+Akzeptanzkriterium (#230):
+  - Abbruch während des Schreibens hinterlässt die alte gültige Datei
+    (Test mit simuliertem Fehler).
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import configure_permissions  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Modul-API
+# ---------------------------------------------------------------------------
+
+def test_main_accepts_settings_path_override():
+    """main() muss einen settings_path-Parameter akzeptieren (testbar machen)."""
+    import inspect
+
+    sig = inspect.signature(configure_permissions.main)
+    assert "settings_path" in sig.parameters, (
+        "main() muss einen optionalen settings_path-Parameter besitzen, "
+        "damit der Schreibpfad in Tests umgelenkt werden kann."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy Path
+# ---------------------------------------------------------------------------
+
+def test_writes_valid_json_and_keeps_existing_settings(tmp_path):
+    """Nach erfolgreichem Lauf ist die Datei valides JSON inkl. Permissions."""
+    target = tmp_path / "settings.local.json"
+    target.write_text(
+        json.dumps({"theme": "dark", "permissions": {"allow": ["Bash(ls *)"]}}),
+        encoding="utf-8",
+    )
+
+    rc = configure_permissions.main(settings_path=target)
+    assert rc == 0
+
+    data = json.loads(target.read_text(encoding="utf-8"))
+    # Fremd-Settings bleiben erhalten
+    assert data["theme"] == "dark"
+    # Bestehende und neue Permissions sind vorhanden
+    allow = data["permissions"]["allow"]
+    assert "Bash(ls *)" in allow
+    for perm in configure_permissions.REQUIRED_PERMISSIONS:
+        assert perm in allow
+
+
+def test_creates_file_when_missing(tmp_path):
+    """Existiert die Datei nicht, wird sie frisch und valide angelegt."""
+    target = tmp_path / "nested" / "settings.local.json"
+    rc = configure_permissions.main(settings_path=target)
+    assert rc == 0
+    data = json.loads(target.read_text(encoding="utf-8"))
+    allow = data["permissions"]["allow"]
+    for perm in configure_permissions.REQUIRED_PERMISSIONS:
+        assert perm in allow
+
+
+# ---------------------------------------------------------------------------
+# Kern-Akzeptanzkriterium: Abbruch hinterlässt die alte gültige Datei
+# ---------------------------------------------------------------------------
+
+def test_interrupted_write_keeps_old_valid_file(tmp_path):
+    """Bricht der Schreibvorgang ab, bleibt die ORIGINALE gültige Datei intakt."""
+    target = tmp_path / "settings.local.json"
+    original = {"theme": "dark", "permissions": {"allow": ["Bash(custom *)"]}}
+    original_text = json.dumps(original, indent=2)
+    target.write_text(original_text, encoding="utf-8")
+
+    # Simuliere Abbruch genau beim finalen, atomaren Umbenennen.
+    with patch.object(
+        configure_permissions.os,
+        "replace",
+        side_effect=OSError("simulierter Abbruch (z.B. SIGKILL / volle Disk)"),
+    ):
+        with pytest.raises(OSError):
+            configure_permissions.main(settings_path=target)
+
+    # Die alte Datei MUSS unverändert und valide vorhanden sein.
+    assert target.exists(), "Originaldatei wurde gelöscht/überschrieben"
+    survived = json.loads(target.read_text(encoding="utf-8"))
+    assert survived == original, (
+        "Originalinhalt ging beim abgebrochenen Schreiben verloren"
+    )
+
+
+def test_no_temp_file_leftover_after_failed_write(tmp_path):
+    """Nach einem fehlgeschlagenen atomaren Schreiben bleibt kein Tempfile-Müll
+    auf dem eigentlichen Zielpfad liegen (das Ziel selbst bleibt valide)."""
+    target = tmp_path / "settings.local.json"
+    target.write_text(json.dumps({"permissions": {"allow": []}}), encoding="utf-8")
+
+    with patch.object(
+        configure_permissions.os,
+        "replace",
+        side_effect=OSError("boom"),
+    ):
+        with pytest.raises(OSError):
+            configure_permissions.main(settings_path=target)
+
+    # Das Ziel ist weiterhin gültiges JSON (nicht halb beschrieben).
+    json.loads(target.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Problem

`scripts/configure_permissions.py` überschrieb `~/.claude/settings.local.json` direkt via `Path.write_text()` — ohne Tempfile + atomares Umbenennen. Wird der Prozess während des Schreibens unterbrochen (SIGKILL, Stromausfall, volle Disk), bleibt eine halb geschriebene, kaputte oder leere JSON-Datei zurück. Beim nächsten Claude-Start fehlen dann nicht nur alle Permissions, sondern auch alle übrigen User-Settings. Das Risiko ist erhöht, weil `setup.sh` dieses Skript bei jedem Setup-Durchlauf aufruft.

## Fix

- Neue Hilfsfunktion `atomic_write_text()`: schreibt zunächst in `<pfad>.tmp` im selben Verzeichnis, `flush` + `os.fsync`, danach `os.replace(tmp, ziel)` (auf POSIX und Windows atomar).
- Schlägt das Schreiben fehl, wird ein eventuell übrig gebliebenes Tempfile aufgeräumt und der Fehler weitergereicht — die alte gültige Zieldatei bleibt unangetastet.
- `main()` erhält einen optionalen `settings_path`-Parameter (Default unverändert `SETTINGS_PATH`), damit der Schreibpfad in Tests umgelenkt werden kann.

Scope eng gehalten: nur `configure_permissions.py`, keine Verhaltensänderung am produktiven Default-Pfad.

## TDD-Belege

Neuer Test `tests/test_issue_230_atomic_settings_write.py` (5 Fälle), u.a. das Kern-Akzeptanzkriterium `test_interrupted_write_keeps_old_valid_file`: `os.replace` wird per Mock zum Abbruch gezwungen; danach wird verifiziert, dass die ORIGINALE Datei unverändert und valide vorliegt.

- ROT (vor dem Fix): `5 failed` — `module 'configure_permissions' has no attribute 'os'` bzw. fehlender `settings_path`-Parameter und nicht-atomares `write_text`.
- GRÜN (nach dem Fix): `5 passed`.
- Volle Suite: `968 passed, 148 skipped` (Baseline 963 passed + 5 neue Tests, keine Regression, 0 failed / 0 errors).

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)
