### PR TITLE
fix(vault): add_chapter wirft ValueError bei malformed csl_json (#232)

### DIFF
--- a/academic_vault/server.py
+++ b/academic_vault/server.py
@@ -280,8 +280,10 @@ def add_chapter(
         csl = json.loads(csl_json)
         csl.setdefault("type", "chapter")
         csl_json = json.dumps(csl, ensure_ascii=False)
-    except Exception:
-        pass
+    except Exception as exc:
+        # Kein stilles Durchreichen von malformed csl_json -- sonst wuerde
+        # add_paper() es als article-journal fehlklassifizieren (siehe #232).
+        raise ValueError(f"add_chapter: Ungueltiges csl_json: {exc}") from exc
     add_paper(
         db_path=db_path,
         paper_id=paper_id,

--- a/tests/test_issue_232_add_chapter_malformed_json.py
+++ b/tests/test_issue_232_add_chapter_malformed_json.py
@@ -1,0 +1,88 @@
+"""Regressionstest fuer Issue #232.
+
+add_chapter() fing fehlerhaftes csl_json mit ``except Exception: pass`` ab,
+sodass das originale (malformed) JSON unveraendert an add_paper() durchgereicht
+und dort still als ``article-journal`` klassifiziert wurde -- ein Buchkapitel
+landete so mit falschem Typ im Vault und die Typ-Validierung war unterlaufen.
+
+Akzeptanzkriterium: Malformed csl_json an add_chapter fuehrt zu einem klaren
+Error statt stiller Fehlklassifikation.
+"""
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+import sys
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from academic_vault import server
+from academic_vault.db import VaultDB
+
+
+PARENT_ID = "buch_2024"
+
+
+def _make_db_path() -> str:
+    """Erstellt temporaere DB-Datei, initialisiert Schema und legt Parent-Buch an.
+
+    Der Parent muss existieren, weil chapter.parent_paper_id eine FOREIGN-KEY-
+    Referenz auf papers(paper_id) traegt. So bleibt als einzige Fehlerquelle in
+    den Malformed-Tests tatsaechlich nur das fehlerhafte csl_json.
+    """
+    tf = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    db_path = tf.name
+    tf.close()
+    db = VaultDB(db_path)
+    db.init_schema()
+    db.add_paper(
+        paper_id=PARENT_ID,
+        csl_json=json.dumps({"type": "book", "title": "Testbuch"}),
+    )
+    return db_path
+
+
+def test_add_chapter_malformed_json_raises():
+    """Malformed csl_json -> klarer ValueError statt stiller Fehlklassifikation."""
+    db_path = _make_db_path()
+    malformed = '{"type": "chapter", "title": "Kaputt"'  # fehlende schliessende Klammer
+    with pytest.raises(ValueError, match="csl_json"):
+        server.add_chapter(
+            db_path=db_path,
+            parent_paper_id=PARENT_ID,
+            chapter_number=3,
+            csl_json=malformed,
+        )
+
+
+def test_add_chapter_malformed_json_not_stored_as_article():
+    """Bei malformed csl_json darf KEIN Kapitel still als article-journal landen."""
+    db_path = _make_db_path()
+    malformed = "das ist gar kein json"
+    paper_id = "buch_2024-ch3"
+    with pytest.raises(ValueError):
+        server.add_chapter(
+            db_path=db_path,
+            parent_paper_id=PARENT_ID,
+            chapter_number=3,
+            csl_json=malformed,
+            paper_id=paper_id,
+        )
+    # Es darf nichts (insb. kein article-journal) persistiert worden sein.
+    assert server.get_paper(db_path, paper_id) is None
+
+
+def test_add_chapter_valid_json_still_works():
+    """Gueltiges csl_json wird weiterhin korrekt als chapter gespeichert."""
+    db_path = _make_db_path()
+    csl = json.dumps({"title": "Kapitel 3: Methoden"})  # type fehlt absichtlich
+    paper_id = server.add_chapter(
+        db_path=db_path,
+        parent_paper_id=PARENT_ID,
+        chapter_number=3,
+        csl_json=csl,
+    )
+    paper = server.get_paper(db_path, paper_id)
+    assert paper is not None
+    assert paper["type"] == "chapter"


### PR DESCRIPTION
## Problem
In `add_chapter()` (`academic_vault/server.py`) wurde `csl_json` geparst und `type=chapter` per `setdefault` gesetzt. Bei fehlerhaftem JSON griff `except Exception: pass` -- das **originale** malformed `csl_json` ging unveraendert an `add_paper()` weiter. Dort schlug der Parse erneut fehl und der Typ fiel auf den stillen Default `article-journal` zurueck (`db.py`), der die Typ-Validierung passierte. Erst tief in SQLite wurde das kaputte JSON mit einem opaken `OperationalError: malformed JSON` abgewiesen. Ergebnis: Ein Buchkapitel konnte als `article-journal` fehlklassifiziert im Vault landen und die Typ-Validierung war unterlaufen.

## Fix
Der `except`-Block in `add_chapter()` wirft jetzt einen klaren `ValueError(f"add_chapter: Ungueltiges csl_json: {exc}")` (mit `raise ... from exc`), statt das JSON still weiterzureichen. Damit schlaegt malformed `csl_json` frueh und mit eindeutiger Fehlermeldung fehl, bevor irgendetwas persistiert wird.

Hinweis: Der verwandte stille Default in `db.add_paper()` (#213) bleibt bewusst ausserhalb des Scopes dieses PRs.

## TDD-Belege
Neue Datei `tests/test_issue_232_add_chapter_malformed_json.py`:
- `test_add_chapter_malformed_json_raises` -- malformed `csl_json` muss `ValueError` (Match `csl_json`) werfen.
- `test_add_chapter_malformed_json_not_stored_as_article` -- nach dem Fehler darf kein Kapitel (insb. kein `article-journal`) persistiert sein.
- `test_add_chapter_valid_json_still_works` -- gueltiges `csl_json` wird weiterhin korrekt als `chapter` gespeichert.

rot -> gruen:
- Vor dem Fix: `2 failed, 1 passed` (Malformed-Tests scheiterten mit `sqlite3.OperationalError: malformed JSON` statt klarem `ValueError`).
- Nach dem Fix: `3 passed`.
- Volle Suite: `966 passed, 148 skipped` (Baseline 963 + 3 neue Tests, 0 failed, 0 errors).

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)
