### PR TITLE
fix(vault): apply_reranker Fallback gibt enriched statt candidates zurueck (#233)

### DIFF
--- a/academic_vault/retrieval.py
+++ b/academic_vault/retrieval.py
@@ -225,7 +225,7 @@ def apply_reranker(
         except Exception:
             pass
 
-    return candidates
+    return enriched
 
 
 def compute_recall_at_k(

--- a/tests/test_vault_rerank.py
+++ b/tests/test_vault_rerank.py
@@ -259,6 +259,100 @@ class TestRerankerIntegration:
 
 
 # ---------------------------------------------------------------------------
+# Tests: Fallback-Struktur-Konsistenz (#233)
+# ---------------------------------------------------------------------------
+
+class TestRerankerFallbackStructure:
+    """Regressionstests fuer #233: Fallback liefert enriched-Struktur (inkl. text)."""
+
+    def test_fallback_no_api_key_returns_text_field(self):
+        """Ohne Reranker-Key muss jeder Kandidat ein text-Feld haben (#233)."""
+        from academic_vault.retrieval import apply_reranker
+
+        # Kandidaten OHNE text-Feld (wie aus RRF-Fusion)
+        candidates = [
+            {"paper_id": "p001", "snippet": "Transformer networks.", "rrf_score": 0.02},
+            {"paper_id": "p002", "snippet": "Convolutional networks.", "rrf_score": 0.015},
+        ]
+
+        result = apply_reranker(
+            query="test query",
+            candidates=candidates,
+            voyage_api_key=None,
+            cohere_api_key=None,
+        )
+
+        # Fallback-Pfad muss enriched-Struktur liefern: text-Feld vorhanden
+        for entry in result:
+            assert "text" in entry, "Fallback-Kandidat ohne text-Feld (#233)"
+        assert result[0]["text"] == "Transformer networks."
+        assert result[1]["text"] == "Convolutional networks."
+
+    def test_fallback_on_voyage_exception_returns_text_field(self):
+        """Wenn Voyage eine Exception wirft, muss der Fallback enriched liefern (#233)."""
+        from academic_vault.retrieval import apply_reranker
+
+        candidates = [
+            {"paper_id": "p001", "snippet": "Dense retrieval.", "rrf_score": 0.02},
+        ]
+
+        with patch("academic_vault.retrieval._get_voyage_client") as mock_voyage:
+            mock_instance = MagicMock()
+            mock_instance.rerank.side_effect = RuntimeError("Voyage API down")
+            mock_voyage.return_value = mock_instance
+
+            result = apply_reranker(
+                query="test",
+                candidates=candidates,
+                voyage_api_key="voyage-key",
+                cohere_api_key=None,
+            )
+
+        assert "text" in result[0], "Exception-Fallback ohne text-Feld (#233)"
+        assert result[0]["text"] == "Dense retrieval."
+
+    def test_fallback_structure_matches_reranker_path(self):
+        """Fallback-Pfad liefert dieselben Keys wie der Reranker-Pfad (#233)."""
+        from academic_vault.retrieval import apply_reranker
+
+        candidates = [
+            {"paper_id": "p001", "snippet": "A", "rrf_score": 0.02},
+            {"paper_id": "p002", "snippet": "B", "rrf_score": 0.01},
+        ]
+
+        # Reranker-Pfad (Voyage) — fuegt text + rerank_score hinzu
+        mock_result = MagicMock()
+        mock_result.results = [
+            MagicMock(index=0, relevance_score=0.9),
+            MagicMock(index=1, relevance_score=0.5),
+        ]
+        with patch("academic_vault.retrieval._get_voyage_client") as mock_voyage:
+            mock_instance = MagicMock()
+            mock_instance.rerank.return_value = mock_result
+            mock_voyage.return_value = mock_instance
+            reranked = apply_reranker(
+                query="q",
+                candidates=candidates,
+                voyage_api_key="voyage-key",
+                cohere_api_key=None,
+            )
+
+        # Fallback-Pfad — kein Key
+        fallback = apply_reranker(
+            query="q",
+            candidates=candidates,
+            voyage_api_key=None,
+            cohere_api_key=None,
+        )
+
+        # Beide Pfade muessen das text-Feld enthalten
+        reranked_text_keys = {"text" in e for e in reranked}
+        fallback_text_keys = {"text" in e for e in fallback}
+        assert reranked_text_keys == {True}
+        assert fallback_text_keys == {True}
+
+
+# ---------------------------------------------------------------------------
 # Tests: Recall@10 Eval-Set
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem
`apply_reranker()` baut in `academic_vault/retrieval.py` eine `enriched`-Liste auf, die jedem Kandidaten ein `text`-Feld hinzufügt (Zeilen 209-214). Im Fallback-Pfad — kein Reranker-Key konfiguriert oder beide Reranker-APIs (Voyage/Cohere) werfen eine Exception — gab die Funktion jedoch `return candidates` (Zeile 228) zurück, also die unveränderte Eingabeliste **ohne** `text`-Feld. Konsumierender Code erhielt damit je nach Pfad inkonsistente Dict-Strukturen.

## Fix
`return candidates` → `return enriched` in `apply_reranker()`. Der Fallback-Pfad liefert nun dieselbe Dict-Struktur (inkl. `text`) wie der Reranker-Pfad. Minimaler Eingriff, eine Zeile.

## TDD-Belege
Neue Regressionstests in `tests/test_vault_rerank.py`, Klasse `TestRerankerFallbackStructure`:
- `test_fallback_no_api_key_returns_text_field`
- `test_fallback_on_voyage_exception_returns_text_field`
- `test_fallback_structure_matches_reranker_path`

Rot → grün:
- Vor dem Fix: 3 Tests rot (`assert {False} == {True}` — `text`-Feld fehlte im Fallback).
- Nach dem Fix: `tests/test_vault_rerank.py` 22 passed.
- Volle Suite: 966 passed, 148 skipped, 0 failed (Baseline 963 passed + 148 skipped, keine Regression).

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)
