### PR TITLE
fix(setup): SciHub-Opt-in in setup.sh implementieren (#234)

### DIFF
--- a/scripts/scihub_optin.py
+++ b/scripts/scihub_optin.py
@@ -1,0 +1,88 @@
+"""SciHub-Opt-in (F18) — wird am Ende von setup.sh aufgerufen.
+
+setup.md (Schritt 7) verlangt, dass das Setup den Nutzer fragt, ob der
+rechtlich umstrittene SciHub-Last-Resort-Tier aktiviert werden soll, und das
+Ergebnis als ``scihub_optin`` nach
+``~/.academic-research/library-profiles/active.yaml`` schreibt.
+
+Default: ``false`` (DEAKTIVIERT). Die Aktivierung erfolgt ausschliesslich nach
+explizitem Opt-in. Bei nicht-interaktivem stdin gilt der sichere Default.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROMPT = (
+    "SciHub-Tier aktivieren? (Rechtlich umstritten — Nutzung auf deine eigene Verantwortung)\n"
+    "SciHub ist ein Dienst, der Zugang zu wissenschaftlichen Artikeln ohne Genehmigung der\n"
+    "Verlage bereitstellt. Die Nutzung kann in deinem Land gegen das Urheberrecht verstossen.\n"
+    "Nur aktivieren, wenn du die rechtliche Lage in deinem Land kennst und akzeptierst.\n"
+    "[j/N] SciHub aktivieren?"
+)
+
+
+def _default_active_path() -> Path:
+    return Path.home() / ".academic-research" / "library-profiles" / "active.yaml"
+
+
+def set_optin(active_yaml: Path, enabled: bool) -> None:
+    """Schreibt ``scihub_optin: <enabled>`` nach ``active_yaml``.
+
+    Erhaelt alle anderen Zeilen/Keys. Existiert die Datei nicht, wird sie mit
+    dem ``scihub_optin``-Eintrag neu angelegt. Idempotent: bei mehrfachem Aufruf
+    entsteht genau ein ``scihub_optin``-Eintrag (vorhandener Wert wird ersetzt,
+    nicht dupliziert).
+    """
+    active_yaml = Path(active_yaml)
+    value = "true" if enabled else "false"
+    new_line = f"scihub_optin: {value}"
+
+    if active_yaml.exists():
+        lines = active_yaml.read_text(encoding="utf-8").splitlines()
+        out: list[str] = []
+        replaced = False
+        for line in lines:
+            stripped = line.lstrip()
+            # Kommentare (# scihub_optin …) unangetastet lassen, nur echten Key ersetzen.
+            if not stripped.startswith("#") and stripped.split(":", 1)[0].strip() == "scihub_optin":
+                if not replaced:
+                    out.append(new_line)
+                    replaced = True
+                # weitere doppelte Keys verwerfen
+            else:
+                out.append(line)
+        if not replaced:
+            out.append(new_line)
+        active_yaml.parent.mkdir(parents=True, exist_ok=True)
+        active_yaml.write_text("\n".join(out) + "\n", encoding="utf-8")
+    else:
+        active_yaml.parent.mkdir(parents=True, exist_ok=True)
+        active_yaml.write_text(new_line + "\n", encoding="utf-8")
+
+
+def _prompt_optin() -> bool:
+    """Interaktive Opt-in-Frage. Bei nicht-interaktivem stdin: sicherer Default ``False``."""
+    if not sys.stdin.isatty():
+        return False
+    answer = input(f"{PROMPT} ").strip().lower()
+    return answer in ("j", "ja", "y", "yes")
+
+
+def main() -> int:
+    active = _default_active_path()
+    enabled = _prompt_optin()
+    set_optin(active, enabled)
+    if enabled:
+        print(f"✅ SciHub Opt-in: aktiviert (scihub_optin: true in {active})")
+        print(
+            "   Hinweis: Bei jedem SciHub-Fund erscheint *\"Quelle via SciHub bezogen — "
+            "bitte zusätzlich legalen Zugriff klären.\"*"
+        )
+    else:
+        print(f"ℹ️  SciHub Opt-in: deaktiviert (Default) (scihub_optin: false in {active})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -7,6 +7,8 @@
 #   3. browser-use CLI (via uv oder pipx)
 #   4. Check: globaler browser-use Claude-Skill
 #   5. Claude-Code-Permissions via configure_permissions.py
+#   6. Projekt-Bootstrap (Auto-Detect) via project_bootstrap.py
+#   7. SciHub Opt-in (F18) via scihub_optin.py
 
 set -euo pipefail
 
@@ -100,10 +102,22 @@ echo ""
 python3 "$SCRIPT_DIR/configure_permissions.py"
 
 # ---------------------------------------------------------------------------
-# 7. Projekt-Bootstrap (Auto-Detect)
+# 6. Projekt-Bootstrap (Auto-Detect)
 # ---------------------------------------------------------------------------
 
 "$BASE/venv/bin/python" "$SCRIPT_DIR/project_bootstrap.py"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# 7. SciHub Opt-in (F18)
+# ---------------------------------------------------------------------------
+# Fragt interaktiv, ob der rechtlich umstrittene SciHub-Last-Resort-Tier
+# aktiviert werden soll, und schreibt das Ergebnis als scihub_optin nach
+# ~/.academic-research/library-profiles/active.yaml. Default: false.
+# Bei nicht-interaktivem stdin (z.B. CI) gilt der sichere Default (deaktiviert).
+
+"$BASE/venv/bin/python" "$SCRIPT_DIR/scihub_optin.py"
 
 echo ""
 echo "Setup complete: $BASE"

--- a/tests/test_issue_234_scihub_optin_impl.py
+++ b/tests/test_issue_234_scihub_optin_impl.py
@@ -1,0 +1,154 @@
+"""Regressionstest fuer Issue #234.
+
+setup.md (Schritt 7) beschreibt ein SciHub-Opt-in, das setup.sh NICHT
+implementiert hat (kein read-Prompt, kein Schreiben von scihub_optin). Diese
+Tests pruefen das *reale* Verhalten:
+
+1. scripts/scihub_optin.py existiert und ist importierbar.
+2. set_optin() schreibt scihub_optin in active.yaml (true UND false), erhaelt
+   andere Keys, legt die Datei aus Default an, wenn sie fehlt — idempotent.
+3. _prompt_optin() faellt auf False (Safety-Default) zurueck, wenn stdin
+   nicht interaktiv ist.
+4. setup.sh ruft den Opt-in-Helper auf (setup.md und setup.sh stimmen ueberein)
+   und die Kommentar-Nummerierung springt nicht mehr 5 -> 7 ohne 6.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+SETUP_SH = SCRIPTS_DIR / "setup.sh"
+OPTIN_SCRIPT = SCRIPTS_DIR / "scihub_optin.py"
+
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+# ---------------------------------------------------------------------------
+# 1. Helper existiert und ist importierbar
+# ---------------------------------------------------------------------------
+
+def test_scihub_optin_script_exists():
+    assert OPTIN_SCRIPT.exists(), (
+        f"scripts/scihub_optin.py fehlt — setup.sh kann SciHub-Opt-in nicht "
+        f"implementieren ({OPTIN_SCRIPT})"
+    )
+
+
+def test_scihub_optin_importable():
+    import scihub_optin  # noqa: F401
+
+    assert hasattr(scihub_optin, "set_optin")
+    assert hasattr(scihub_optin, "_prompt_optin")
+
+
+# ---------------------------------------------------------------------------
+# 2. set_optin schreibt das Flag korrekt
+# ---------------------------------------------------------------------------
+
+def test_set_optin_creates_file_with_false_default(tmp_path):
+    import scihub_optin
+
+    active = tmp_path / "active.yaml"
+    scihub_optin.set_optin(active, False)
+    assert active.exists()
+    data = yaml.safe_load(active.read_text())
+    assert data["scihub_optin"] is False
+
+
+def test_set_optin_writes_true(tmp_path):
+    import scihub_optin
+
+    active = tmp_path / "active.yaml"
+    scihub_optin.set_optin(active, True)
+    data = yaml.safe_load(active.read_text())
+    assert data["scihub_optin"] is True
+
+
+def test_set_optin_preserves_other_keys(tmp_path):
+    import scihub_optin
+
+    active = tmp_path / "active.yaml"
+    active.write_text("uni: tum\nauth_type: shibboleth\nscihub_optin: false\n")
+    scihub_optin.set_optin(active, True)
+    data = yaml.safe_load(active.read_text())
+    assert data["scihub_optin"] is True
+    assert data["uni"] == "tum"
+    assert data["auth_type"] == "shibboleth"
+
+
+def test_set_optin_idempotent(tmp_path):
+    import scihub_optin
+
+    active = tmp_path / "active.yaml"
+    scihub_optin.set_optin(active, True)
+    first = active.read_text()
+    scihub_optin.set_optin(active, True)
+    second = active.read_text()
+    data = yaml.safe_load(second)
+    assert data["scihub_optin"] is True
+    # Re-run darf keine doppelten Keys o.ae. erzeugen
+    assert second.count("scihub_optin") == 1
+    assert first == second
+
+
+def test_set_optin_overwrites_existing_value(tmp_path):
+    import scihub_optin
+
+    active = tmp_path / "active.yaml"
+    scihub_optin.set_optin(active, True)
+    scihub_optin.set_optin(active, False)
+    data = yaml.safe_load(active.read_text())
+    assert data["scihub_optin"] is False
+    assert active.read_text().count("scihub_optin") == 1
+
+
+# ---------------------------------------------------------------------------
+# 3. Prompt-Default ist sicher (False) bei nicht-interaktivem stdin
+# ---------------------------------------------------------------------------
+
+def test_prompt_optin_defaults_false_non_interactive(monkeypatch):
+    import scihub_optin
+
+    class _FakeStdin:
+        @staticmethod
+        def isatty():
+            return False
+
+    monkeypatch.setattr(sys, "stdin", _FakeStdin())
+    assert scihub_optin._prompt_optin() is False
+
+
+# ---------------------------------------------------------------------------
+# 4. setup.sh stimmt mit setup.md ueberein
+# ---------------------------------------------------------------------------
+
+def test_setup_sh_invokes_scihub_optin():
+    content = SETUP_SH.read_text(encoding="utf-8")
+    assert "scihub_optin.py" in content, (
+        "setup.sh muss den SciHub-Opt-in-Helper aufrufen — setup.md Schritt 7 "
+        "verlangt das, setup.sh implementierte es bisher nicht (Issue #234)"
+    )
+
+
+def test_setup_sh_numbering_has_step_six():
+    """Die Nummerierung darf nicht kommentarlos 5 -> 7 springen (Issue #234)."""
+    content = SETUP_SH.read_text(encoding="utf-8")
+    # Schritt 6 (Projekt-Bootstrap) muss als Kommentar vorhanden sein,
+    # bevor Schritt 7 (SciHub) kommt.
+    assert "# 6." in content, "setup.sh fehlt Schritt-6-Kommentar (Nummerierung springt 5->7)"
+    six = content.index("# 6.")
+    seven = content.index("# 7.")
+    assert six < seven, "Schritt 6 muss vor Schritt 7 stehen"
+
+
+def test_setup_sh_prints_scihub_status_markers():
+    """setup.sh muss die in setup.md dokumentierten Status-Marker ausgeben."""
+    content = SETUP_SH.read_text(encoding="utf-8")
+    assert "SciHub Opt-in" in content, (
+        "setup.sh muss SciHub-Opt-in-Status melden (setup.md Interpretationstabelle)"
+    )


### PR DESCRIPTION
## Problem

`commands/setup.md` beschreibt in Schritt 7 ausführlich ein „SciHub Opt-in": `setup.sh` fragt den Nutzer und schreibt `scihub_optin` nach `~/.academic-research/library-profiles/active.yaml`. In `scripts/setup.sh` existierte dafür **weder** die interaktive Frage **noch** das Schreiben von `scihub_optin`. Die Kommentar-Nummerierung sprang kommentarlos von `# 5.` auf `# 7.`. Der bestehende `tests/test_scihub_optin.py` prüfte nur den Text von `setup.md` und fiel daher nicht auf die Lücke herein.

## Fix

- Neuer Helper `scripts/scihub_optin.py` (analog zu `project_bootstrap.py`):
  - `set_optin(active_yaml, enabled)` schreibt bzw. aktualisiert `scihub_optin` in `active.yaml` — idempotent, erhält alle anderen Keys, legt die Datei bei Bedarf an, erzeugt nie doppelte Einträge, lässt Kommentarzeilen unangetastet.
  - `_prompt_optin()` stellt die in `setup.md` dokumentierte Frage und fällt bei nicht-interaktivem stdin (z. B. CI) auf den sicheren Default `false` zurück.
  - `main()` gibt die in `setup.md` dokumentierten Status-Marker aus (`✅ SciHub Opt-in: aktiviert` / `ℹ️ SciHub Opt-in: deaktiviert (Default)`).
- `scripts/setup.sh` ruft den Helper als Schritt 7 auf und korrigiert die Nummerierung `5 → 6 → 7`; der Header-Kommentar listet die Schritte 6 und 7 ebenfalls.

`setup.md` und `setup.sh` stimmen damit beim SciHub-Opt-in überein.

## TDD-Belege

Neuer Regressionstest `tests/test_issue_234_scihub_optin_impl.py` (11 Cases) prüft das **reale** Verhalten: Existenz/Importierbarkeit des Helpers, `set_optin`-Schreiblogik (true/false, Key-Erhalt, Idempotenz, Überschreiben), sicherer Prompt-Default sowie Konsistenz von `setup.sh` mit `setup.md` (Helper-Aufruf, Schritt-6-Kommentar, Status-Marker).

- **Rot (vor Fix):** `11 failed in 0.05s` — u. a. „scripts/scihub_optin.py fehlt", „setup.sh fehlt Schritt-6-Kommentar (Nummerierung springt 5->7)", „setup.sh muss SciHub-Opt-in-Status melden".
- **Grün (nach Fix):** `11 passed in 0.03s`.
- **Volle Suite:** `974 passed, 148 skipped` (Baseline `963 passed, 148 skipped` — nicht verschlechtert). `bash -n scripts/setup.sh` und Python-AST-Check ohne Fehler. Keine JSON-/`.mjs`-/Frontmatter-relevanten Dateien angefasst.

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)
