### PR TITLE
fix(license): vollen Namen 'Jonas Ahler' im Copyright nennen (#242)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Jonas
+Copyright (c) 2026 Jonas Ahler
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/tests/test_issue_242_license_name.py
+++ b/tests/test_issue_242_license_name.py
@@ -1,0 +1,33 @@
+"""Regressionstest fuer Issue #242.
+
+Die LICENSE-Datei nannte im Copyright nur den Vornamen 'Jonas' statt des
+vollstaendigen Namens 'Jonas Ahler'. Der Copyright-Inhaber im LICENSE muss
+dem author.name aus plugin.json entsprechen (Akzeptanzkriterium).
+"""
+
+import json
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+LICENSE_PATH = REPO_ROOT / "LICENSE"
+PLUGIN_JSON = REPO_ROOT / ".claude-plugin" / "plugin.json"
+
+
+def _license_copyright_holder() -> str:
+    """Extrahiert den Copyright-Inhaber aus der LICENSE-Zeile."""
+    text = LICENSE_PATH.read_text(encoding="utf-8")
+    match = re.search(r"Copyright \(c\) \d{4}\s+(.+)", text)
+    assert match, "LICENSE enthaelt keine Copyright-Zeile im erwarteten Format"
+    return match.group(1).strip()
+
+
+def test_license_nennt_vollen_namen():
+    """Copyright-Zeile muss den vollen Namen 'Jonas Ahler' nennen."""
+    assert _license_copyright_holder() == "Jonas Ahler"
+
+
+def test_license_copyright_entspricht_manifest():
+    """Copyright-Inhaber im LICENSE entspricht author.name in plugin.json."""
+    manifest_author = json.loads(PLUGIN_JSON.read_text(encoding="utf-8"))["author"]["name"]
+    assert _license_copyright_holder() == manifest_author


### PR DESCRIPTION
## Problem
`LICENSE:3` lautete `Copyright (c) 2026 Jonas` und nannte damit nur den Vornamen. Die Manifeste (`plugin.json`, `marketplace.json`) fuehren hingegen den vollstaendigen Namen `Jonas Ahler` als `author.name`. Diese Inkonsistenz erschwerte die korrekte Attribution. Akzeptanzkriterium: Der Copyright-Inhaber im LICENSE entspricht dem Manifest.

## Fix
- `LICENSE` (Zeile 3): `Copyright (c) 2026 Jonas` → `Copyright (c) 2026 Jonas Ahler`. Damit stimmt der Copyright-Inhaber mit `author.name` aus `plugin.json` ueberein.

## TDD-Belege
Neuer Regressionstest `tests/test_issue_242_license_name.py` (2 Cases): prueft den vollen Namen und die Uebereinstimmung mit `plugin.json`.
- **Rot (vor Fix):** `2 failed in 0.02s` (`assert 'Jonas' == 'Jonas Ahler'`)
- **Gruen (nach Fix):** `2 passed in 0.01s`
- **Volle Suite:** `964 passed, 149 skipped` — 0 failed, keine Regression.

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)
