### PR TITLE
fix(docs): README-Glossar um fehlende v6-Begriffe ergaenzen (#211)

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,6 +609,12 @@ cp library-profiles/template-han.yaml \
 | **Site-Profile** | YAML-Konfiguration einer Hochschule, die Auth-Typ (HAN/Shibboleth/EZproxy), lizenzierte Seiten und Zugangsdaten-Keys beschreibt. Wird von `auth-helper` und `book-fetcher` genutzt. |
 | **Material-Passport** | Unveränderlicher Metadaten-Passport für ein Artefakt (Paper, Kapitel). Kann via `vault.lock_passport()` eingefroren werden — danach keine Änderungen mehr möglich. |
 | **Contextual Retrieval** | Anthropic-Pattern: vor jedem Chunk-Embedding wird ein 1-Satz-Kontext angehängt (via Prompt-Caching). Verbessert Recall@10 deutlich vs. Vanilla-vec0. |
+| **Decision-Log** | Append-only-Protokoll aller `.md`-Änderungen und Entscheidungen. Wird vom Hook `post-tool-use-decisions.mjs` (PostToolUse) automatisch befüllt; programmatisch via `vault.add_decision(text, category)`. |
+| **Vault-Lock** | Read-only-Sperre des Vault. Nach `vault.lock_passport(paper_id)` sind keine Schreibzugriffe mehr möglich — Grundlage für reproduzierbare Abgaben (siehe Repro-Lock, Skill `material-passport`). |
+| **Repro-Lock** | Reproduzierbarkeits-Sperre des Skills `material-passport`: friert den Material-Passport ein und sperrt den Vault read-only (Vault-Lock), damit Dritte den Stand exakt nachvollziehen können. |
+| **OCR-Detection** | Automatische Prüfung, ob ein PDF einen Text-Layer besitzt (`scripts/pdf.py:detect_needs_ocr`). Fehlt der Layer, schlägt das Plugin OCR via `ocrmypdf` vor. |
+| **page_offset** | Differenz zwischen PDF-Seitenzahl und gedruckter Seitenzahl bei Büchern mit Vorseiten (`printed_page = pdf_page - offset`). Wird von `scripts/page_offset.py` ermittelt und vom `book-handler` für seitengenaue Zitate genutzt. |
+| **output_targets** | Opt-in-Eintrag im Projekt-State, der Default-Off-Output-Skills (`grant-proposal`, `conference-poster`, `reviewer-response`) aktiviert. Nur wenn der passende Wert gesetzt ist, läuft der jeweilige Skill (v6.5-Opt-in-Pattern). |
 | **PRISMA** | Preferred Reporting Items for Systematic Reviews and Meta-Analyses — Standard-Framework für Transparent-Reporting. Das Plugin generiert PRISMA-2020-konforme Mermaid-Flussdiagramme. |
 | **HAN** | Hochschulauthentifizierungs-Netzwerk — Bibliotheks-Proxy für lizenzpflichtige Datenbanken. |
 | **RRF** | Reciprocal-Rank-Fusion — Methode zum Zusammenführen von BM25- und vec0-Rankings im Vault. |

--- a/tests/test_issue_211_readme_glossary.py
+++ b/tests/test_issue_211_readme_glossary.py
@@ -1,0 +1,81 @@
+"""Regressionstest für Issue #211: README-Glossar muss v6-Begriffe erklären.
+
+Das README-Glossar (Sektion 15) muss zentrale v6-Begriffe definieren:
+Decision-Log, Vault-Lock, OCR-Detection, page_offset, output_targets,
+Repro-Lock, Contextual Retrieval, RRF. Jeder Begriff braucht eine eigene
+Glossar-Zeile mit Definition.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+README = REPO_ROOT / "README.md"
+
+# v6-Begriffe, die im Glossar definiert sein müssen (Issue #211).
+REQUIRED_TERMS = [
+    "Decision-Log",
+    "Vault-Lock",
+    "OCR-Detection",
+    "page_offset",
+    "output_targets",
+    "Repro-Lock",
+    "Contextual Retrieval",
+    "RRF",
+]
+
+
+def _glossary_section() -> str:
+    """Extrahiert den Glossar-Abschnitt aus dem README."""
+    text = README.read_text(encoding="utf-8")
+    m = re.search(r"^## Glossar\s*$", text, flags=re.MULTILINE)
+    assert m, "README enthält keine '## Glossar'-Sektion"
+    start = m.end()
+    nxt = re.search(r"^## ", text[start:], flags=re.MULTILINE)
+    end = start + nxt.start() if nxt else len(text)
+    return text[start:end]
+
+
+def _glossary_entries(section: str) -> dict[str, str]:
+    """Mappt Glossar-Begriff (bold in Spalte 1) auf seine Bedeutung."""
+    entries: dict[str, str] = {}
+    for line in section.splitlines():
+        line = line.strip()
+        if not line.startswith("|"):
+            continue
+        cells = [c.strip() for c in line.strip("|").split("|")]
+        if len(cells) < 2:
+            continue
+        term = cells[0]
+        meaning = cells[1]
+        # Header- und Trennzeilen überspringen.
+        if term.lower() in {"begriff", ""} or set(term) <= set("-: "):
+            continue
+        # Bold-Markup entfernen für den Schlüsselvergleich.
+        key = term.replace("**", "").strip()
+        entries[key] = meaning
+    return entries
+
+
+@pytest.mark.parametrize("term", REQUIRED_TERMS)
+def test_glossary_defines_v6_term(term):
+    section = _glossary_section()
+    entries = _glossary_entries(section)
+    assert term in entries, (
+        f"Glossar-Begriff '{term}' fehlt im README-Glossar (Issue #211). "
+        f"Vorhandene Begriffe: {sorted(entries)}"
+    )
+    meaning = entries[term]
+    assert len(meaning) >= 20, (
+        f"Glossar-Eintrag für '{term}' hat keine substanzielle Definition: {meaning!r}"
+    )
+
+
+def test_glossary_entries_are_bold():
+    """Jeder geforderte Begriff steht als **fetter** Glossar-Eintrag."""
+    section = _glossary_section()
+    for term in REQUIRED_TERMS:
+        assert f"**{term}**" in section, (
+            f"Glossar-Begriff '{term}' ist nicht als **{term}** ausgezeichnet."
+        )


### PR DESCRIPTION
## Problem
Das README-Glossar (Sektion 15) erklärte mehrere zentrale v6-Begriffe nicht. Laut Scope-Update vom 2026-06-03 waren `Contextual Retrieval` und `RRF` bereits ergänzt; offen blieben: `Decision-Log`, `Vault-Lock`, `OCR-Detection`, `page_offset`, `output_targets` und `Repro-Lock`. Damit fehlte die im Akzeptanzkriterium geforderte Definition (je 1–2 Sätze + Querverweis Skill/Hook/MCP-Tool) und die Konsistenz mit der SKILL.md-Verwendung war nicht dokumentiert.

## Fix
- `README.md` — sechs neue Glossar-Zeilen in die Tabelle der Sektion 15 eingefügt, jeweils mit konkretem Querverweis:
  - **Decision-Log** → Hook `post-tool-use-decisions.mjs` + `vault.add_decision`.
  - **Vault-Lock** → `vault.lock_passport(paper_id)`, read-only-Sperre.
  - **Repro-Lock** → Skill `material-passport`, koppelt Passport-Freeze an Vault-Lock.
  - **OCR-Detection** → `scripts/pdf.py:detect_needs_ocr` + `ocrmypdf`.
  - **page_offset** → `scripts/page_offset.py`, `printed_page = pdf_page - offset`, genutzt von `book-handler`.
  - **output_targets** → v6.5-Opt-in-Pattern für `grant-proposal`/`conference-poster`/`reviewer-response`.

## TDD-Belege
Neuer Regressionstest `tests/test_issue_211_readme_glossary.py` (9 Cases: 8 parametrisierte Begriffe + Bold-Markup-Check).
- **Rot (vor Fix):** `7 failed, 2 passed in 0.03s`
- **Gruen (nach Fix):** `9 passed in 0.01s`
- **Volle Suite:** `971 passed, 149 skipped` — 0 failed, keine Regression.

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)