### PR TITLE
fix(vault): SQLite-Connection-Leak bei Exception schliessen (#237)

### DIFF
--- a/academic_vault/db.py
+++ b/academic_vault/db.py
@@ -2,12 +2,13 @@
 
 Context-Manager-Klasse mit sqlite-vec-Fallback und FTS5-Volltext-Suche.
 """
+import contextlib
 import json
 import os
 import sqlite3
 import time
 from pathlib import Path
-from typing import Optional
+from typing import Iterator, Optional
 from uuid import uuid4
 
 
@@ -61,6 +62,32 @@ class VaultDB:
             return self._conn
         return self._open(self.db_path)
 
+    @contextlib.contextmanager
+    def _connection(self, commit: bool = False) -> Iterator[sqlite3.Connection]:
+        """Stellt eine Connection bereit und schliesst sie garantiert.
+
+        Verhindert SQLite-Connection-Leaks bei Exceptions (Issue #237). Wird die
+        Connection in dieser Methode selbst geoeffnet (``self._conn is None``,
+        also ausserhalb des Context-Managers), so wird sie im ``finally``-Block
+        immer geschlossen — auch wenn ``conn.execute()`` z. B. einen
+        ``IntegrityError`` wirft. Bei ``commit=True`` wird im Erfolgsfall vorher
+        committet. Eine geteilte Connection (``self._conn`` gesetzt) wird hier
+        weder committet noch geschlossen; das uebernimmt ``__exit__``.
+
+        Args:
+            commit: Bei True wird die selbst geoeffnete Connection im Erfolgsfall
+                committet (fuer write-Methoden).
+        """
+        own_conn = self._conn is None
+        conn = self._get_conn()
+        try:
+            yield conn
+            if own_conn and commit:
+                conn.commit()
+        finally:
+            if own_conn:
+                conn.close()
+
     def load_vec_extension(self, conn: Optional[sqlite3.Connection] = None) -> bool:
         """Versucht sqlite_vec Extension zu laden. Gibt True bei Erfolg zurueck.
 
@@ -101,28 +128,22 @@ class VaultDB:
     def init_schema(self) -> None:
         """Erstellt alle Tabellen gemaess schema.sql. Versucht vec0 zu erstellen."""
         ddl = _SCHEMA_PATH.read_text(encoding="utf-8")
-        conn = self._get_conn()
-        own_conn = self._conn is None
+        with self._connection(commit=True) as conn:
+            # vec-Extension auf derselben Connection laden (optional)
+            self.load_vec_extension(conn)
 
-        # vec-Extension auf derselben Connection laden (optional)
-        self.load_vec_extension(conn)
+            # Basis-Schema ausfuehren (ohne vec0-Block — der ist auskommentiert)
+            conn.executescript(ddl)
 
-        # Basis-Schema ausfuehren (ohne vec0-Block — der ist auskommentiert)
-        conn.executescript(ddl)
-
-        # quote_embeddings via vec0 versuchen (nur wenn Extension geladen)
-        if self.vec_available:
-            try:
-                conn.execute(
-                    "CREATE VIRTUAL TABLE IF NOT EXISTS quote_embeddings "
-                    "USING vec0(quote_id TEXT PRIMARY KEY, embedding FLOAT[384])"
-                )
-            except sqlite3.OperationalError:
-                self.vec_available = False
-
-        if own_conn:
-            conn.commit()
-            conn.close()
+            # quote_embeddings via vec0 versuchen (nur wenn Extension geladen)
+            if self.vec_available:
+                try:
+                    conn.execute(
+                        "CREATE VIRTUAL TABLE IF NOT EXISTS quote_embeddings "
+                        "USING vec0(quote_id TEXT PRIMARY KEY, embedding FLOAT[384])"
+                    )
+                except sqlite3.OperationalError:
+                    self.vec_available = False
 
     # ------------------------------------------------------------------
     # Papers CRUD
@@ -159,51 +180,44 @@ class VaultDB:
             )
 
         now = int(time.time())
-        conn = self._get_conn()
-        own_conn = self._conn is None
-        conn.execute(
-            """
-            INSERT INTO papers
-              (paper_id, type, csl_json, doi, isbn, pdf_path, page_offset,
-               editor, chapter, page_first, page_last, container_title,
-               parent_paper_id,
-               added_at, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(paper_id) DO UPDATE SET
-              type            = excluded.type,
-              csl_json        = excluded.csl_json,
-              doi             = excluded.doi,
-              isbn            = excluded.isbn,
-              pdf_path        = excluded.pdf_path,
-              page_offset     = excluded.page_offset,
-              editor          = excluded.editor,
-              chapter         = excluded.chapter,
-              page_first      = excluded.page_first,
-              page_last       = excluded.page_last,
-              container_title = excluded.container_title,
-              parent_paper_id = excluded.parent_paper_id,
-              updated_at      = excluded.updated_at
-            """,
-            (
-                paper_id, paper_type, csl_json, doi, isbn, pdf_path, page_offset,
-                editor, chapter, page_first, page_last, container_title,
-                parent_paper_id,
-                now, now,
-            ),
-        )
-        if own_conn:
-            conn.commit()
-            conn.close()
+        with self._connection(commit=True) as conn:
+            conn.execute(
+                """
+                INSERT INTO papers
+                  (paper_id, type, csl_json, doi, isbn, pdf_path, page_offset,
+                   editor, chapter, page_first, page_last, container_title,
+                   parent_paper_id,
+                   added_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(paper_id) DO UPDATE SET
+                  type            = excluded.type,
+                  csl_json        = excluded.csl_json,
+                  doi             = excluded.doi,
+                  isbn            = excluded.isbn,
+                  pdf_path        = excluded.pdf_path,
+                  page_offset     = excluded.page_offset,
+                  editor          = excluded.editor,
+                  chapter         = excluded.chapter,
+                  page_first      = excluded.page_first,
+                  page_last       = excluded.page_last,
+                  container_title = excluded.container_title,
+                  parent_paper_id = excluded.parent_paper_id,
+                  updated_at      = excluded.updated_at
+                """,
+                (
+                    paper_id, paper_type, csl_json, doi, isbn, pdf_path, page_offset,
+                    editor, chapter, page_first, page_last, container_title,
+                    parent_paper_id,
+                    now, now,
+                ),
+            )
 
     def get_paper(self, paper_id: str) -> Optional[dict]:
         """Gibt Paper-Record als dict zurueck oder None."""
-        conn = self._get_conn()
-        own_conn = self._conn is None
-        row = conn.execute(
-            "SELECT * FROM papers WHERE paper_id = ?", (paper_id,)
-        ).fetchone()
-        if own_conn:
-            conn.close()
+        with self._connection() as conn:
+            row = conn.execute(
+                "SELECT * FROM papers WHERE paper_id = ?", (paper_id,)
+            ).fetchone()
         if row is None:
             return None
         return dict(row)
@@ -212,38 +226,27 @@ class VaultDB:
         self, paper_id: str, file_id: str, expires_at: int
     ) -> None:
         """Setzt file_id und file_id_expires_at fuer ein Paper."""
-        conn = self._get_conn()
-        own_conn = self._conn is None
-        conn.execute(
-            "UPDATE papers SET file_id = ?, file_id_expires_at = ?, updated_at = ? "
-            "WHERE paper_id = ?",
-            (file_id, expires_at, int(time.time()), paper_id),
-        )
-        if own_conn:
-            conn.commit()
-            conn.close()
+        with self._connection(commit=True) as conn:
+            conn.execute(
+                "UPDATE papers SET file_id = ?, file_id_expires_at = ?, updated_at = ? "
+                "WHERE paper_id = ?",
+                (file_id, expires_at, int(time.time()), paper_id),
+            )
 
     def set_page_offset(self, paper_id: str, offset: int) -> None:
         """Setzt page_offset fuer ein Paper."""
-        conn = self._get_conn()
-        own_conn = self._conn is None
-        conn.execute(
-            "UPDATE papers SET page_offset = ?, updated_at = ? WHERE paper_id = ?",
-            (offset, int(time.time()), paper_id),
-        )
-        if own_conn:
-            conn.commit()
-            conn.close()
+        with self._connection(commit=True) as conn:
+            conn.execute(
+                "UPDATE papers SET page_offset = ?, updated_at = ? WHERE paper_id = ?",
+                (offset, int(time.time()), paper_id),
+            )
 
     def get_page_offset(self, paper_id: str) -> int:
         """Gibt page_offset fuer ein Paper zurueck. Fallback: 0."""
-        conn = self._get_conn()
-        own_conn = self._conn is None
-        row = conn.execute(
-            "SELECT page_offset FROM papers WHERE paper_id = ?", (paper_id,)
-        ).fetchone()
-        if own_conn:
-            conn.close()
+        with self._connection() as conn:
+            row = conn.execute(
+                "SELECT page_offset FROM papers WHERE paper_id = ?", (paper_id,)
+            ).fetchone()
         if row is None:
             return 0
         return int(row["page_offset"] or 0)
@@ -267,47 +270,37 @@ class VaultDB:
     ) -> None:
         """INSERT eines Quotes in die quotes-Tabelle."""
         now = int(time.time())
-        conn = self._get_conn()
-        own_conn = self._conn is None
-        conn.execute(
-            """
-            INSERT INTO quotes
-              (quote_id, paper_id, verbatim, pdf_page, printed_page,
-               section, context_before, context_after,
-               extraction_method, api_response_id, created_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                quote_id, paper_id, verbatim, pdf_page, printed_page,
-                section, context_before, context_after,
-                extraction_method, api_response_id, now,
-            ),
-        )
-        if own_conn:
-            conn.commit()
-            conn.close()
+        with self._connection(commit=True) as conn:
+            conn.execute(
+                """
+                INSERT INTO quotes
+                  (quote_id, paper_id, verbatim, pdf_page, printed_page,
+                   section, context_before, context_after,
+                   extraction_method, api_response_id, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    quote_id, paper_id, verbatim, pdf_page, printed_page,
+                    section, context_before, context_after,
+                    extraction_method, api_response_id, now,
+                ),
+            )
 
     def get_quote(self, quote_id: str) -> Optional[dict]:
         """Gibt Quote-Record als dict zurueck oder None."""
-        conn = self._get_conn()
-        own_conn = self._conn is None
-        row = conn.execute(
-            "SELECT * FROM quotes WHERE quote_id = ?", (quote_id,)
-        ).fetchone()
-        if own_conn:
-            conn.close()
+        with self._connection() as conn:
+            row = conn.execute(
+                "SELECT * FROM quotes WHERE quote_id = ?", (quote_id,)
+            ).fetchone()
         return dict(row) if row is not None else None
 
     def search_quote_text(self, verbatim: str, k: int = 5) -> list[dict]:
         """LIKE-Suche in quotes.verbatim. Gibt [{quote_id, verbatim, paper_id}] zurueck."""
-        conn = self._get_conn()
-        own_conn = self._conn is None
-        rows = conn.execute(
-            "SELECT quote_id, verbatim, paper_id FROM quotes WHERE verbatim LIKE ? LIMIT ?",
-            (f"%{verbatim}%", k),
-        ).fetchall()
-        if own_conn:
-            conn.close()
+        with self._connection() as conn:
+            rows = conn.execute(
+                "SELECT quote_id, verbatim, paper_id FROM quotes WHERE verbatim LIKE ? LIMIT ?",
+                (f"%{verbatim}%", k),
+            ).fetchall()
         return [dict(r) for r in rows]
 
     def find_quotes(
@@ -317,45 +310,34 @@ class VaultDB:
         k: int = 10,
     ) -> list[dict]:
         """Suche Quotes fuer ein Paper, optional per verbatim-LIKE-Filter."""
-        conn = self._get_conn()
-        own_conn = self._conn is None
-        if query:
-            rows = conn.execute(
-                "SELECT * FROM quotes WHERE paper_id = ? AND verbatim LIKE ? LIMIT ?",
-                (paper_id, f"%{query}%", k),
-            ).fetchall()
-        else:
-            rows = conn.execute(
-                "SELECT * FROM quotes WHERE paper_id = ? LIMIT ?",
-                (paper_id, k),
-            ).fetchall()
-        if own_conn:
-            conn.close()
+        with self._connection() as conn:
+            if query:
+                rows = conn.execute(
+                    "SELECT * FROM quotes WHERE paper_id = ? AND verbatim LIKE ? LIMIT ?",
+                    (paper_id, f"%{query}%", k),
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    "SELECT * FROM quotes WHERE paper_id = ? LIMIT ?",
+                    (paper_id, k),
+                ).fetchall()
         return [dict(r) for r in rows]
 
     def set_ocr_done(self, paper_id: str, value: int = 1) -> None:
         """Setzt ocr_done-Flag fuer ein Paper."""
-        conn = self._get_conn()
-        own_conn = self._conn is None
-        conn.execute(
-            "UPDATE papers SET ocr_done = ?, updated_at = ? WHERE paper_id = ?",
-            (value, int(time.time()), paper_id),
-        )
-        if own_conn:
-            conn.commit()
-            conn.close()
+        with self._connection(commit=True) as conn:
+            conn.execute(
+                "UPDATE papers SET ocr_done = ?, updated_at = ? WHERE paper_id = ?",
+                (value, int(time.time()), paper_id),
+            )
 
     def update_pdf_path(self, paper_id: str, new_path: str) -> None:
         """Aktualisiert pdf_path fuer ein Paper."""
-        conn = self._get_conn()
-        own_conn = self._conn is None
-        conn.execute(
-            "UPDATE papers SET pdf_path = ?, updated_at = ? WHERE paper_id = ?",
-            (new_path, int(time.time()), paper_id),
-        )
-        if own_conn:
-            conn.commit()
-            conn.close()
+        with self._connection(commit=True) as conn:
+            conn.execute(
+                "UPDATE papers SET pdf_path = ?, updated_at = ? WHERE paper_id = ?",
+                (new_path, int(time.time()), paper_id),
+            )
 
     # ------------------------------------------------------------------
     # Figures CRUD
@@ -372,42 +354,32 @@ class VaultDB:
         """INSERT einer Figure. Gibt figure_id (UUID) zurueck."""
         figure_id = str(uuid4())
         now = int(time.time())
-        conn = self._get_conn()
-        own_conn = self._conn is None
-        conn.execute(
-            """
-            INSERT INTO figures
-              (figure_id, paper_id, page, caption, vlm_description, data_extracted_json, created_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
-            """,
-            (figure_id, paper_id, page, caption, vlm_description, data_extracted_json, now),
-        )
-        if own_conn:
-            conn.commit()
-            conn.close()
+        with self._connection(commit=True) as conn:
+            conn.execute(
+                """
+                INSERT INTO figures
+                  (figure_id, paper_id, page, caption, vlm_description, data_extracted_json, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (figure_id, paper_id, page, caption, vlm_description, data_extracted_json, now),
+            )
         return figure_id
 
     def get_figure(self, figure_id: str) -> Optional[dict]:
         """Gibt Figure-Record als dict zurueck oder None."""
-        conn = self._get_conn()
-        own_conn = self._conn is None
-        row = conn.execute(
-            "SELECT * FROM figures WHERE figure_id = ?", (figure_id,)
-        ).fetchone()
-        if own_conn:
-            conn.close()
+        with self._connection() as conn:
+            row = conn.execute(
+                "SELECT * FROM figures WHERE figure_id = ?", (figure_id,)
+            ).fetchone()
         return dict(row) if row is not None else None
 
     def list_figures(self, paper_id: str) -> list[dict]:
         """Alle Figures fuer ein Paper, nach page sortiert."""
-        conn = self._get_conn()
-        own_conn = self._conn is None
-        rows = conn.execute(
-            "SELECT * FROM figures WHERE paper_id = ? ORDER BY page",
-            (paper_id,),
-        ).fetchall()
-        if own_conn:
-            conn.close()
+        with self._connection() as conn:
+            rows = conn.execute(
+                "SELECT * FROM figures WHERE paper_id = ? ORDER BY page",
+                (paper_id,),
+            ).fetchall()
         return [dict(r) for r in rows]
 
     def find_figures_by_caption(
@@ -416,20 +388,17 @@ class VaultDB:
         paper_id: Optional[str] = None,
     ) -> list[dict]:
         """LIKE-Suche in figures.caption. Optionaler paper_id-Filter."""
-        conn = self._get_conn()
-        own_conn = self._conn is None
-        if paper_id is not None:
-            rows = conn.execute(
-                "SELECT * FROM figures WHERE caption LIKE ? AND paper_id = ?",
-                (f"%{caption_fragment}%", paper_id),
-            ).fetchall()
-        else:
-            rows = conn.execute(
-                "SELECT * FROM figures WHERE caption LIKE ?",
-                (f"%{caption_fragment}%",),
-            ).fetchall()
-        if own_conn:
-            conn.close()
+        with self._connection() as conn:
+            if paper_id is not None:
+                rows = conn.execute(
+                    "SELECT * FROM figures WHERE caption LIKE ? AND paper_id = ?",
+                    (f"%{caption_fragment}%", paper_id),
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    "SELECT * FROM figures WHERE caption LIKE ?",
+                    (f"%{caption_fragment}%",),
+                ).fetchall()
         return [dict(r) for r in rows]
 
     # ------------------------------------------------------------------
@@ -445,31 +414,23 @@ class VaultDB:
         """INSERT einer Decision. Gibt decision_id (UUID) zurueck."""
         decision_id = str(uuid4())
         now = int(time.time())
-        conn = self._get_conn()
-        own_conn = self._conn is None
-        conn.execute(
-            """
-            INSERT INTO decisions (decision_id, category, text, rationale, created_at)
-            VALUES (?, ?, ?, ?, ?)
-            """,
-            (decision_id, category, text, rationale, now),
-        )
-        if own_conn:
-            conn.commit()
-            conn.close()
+        with self._connection(commit=True) as conn:
+            conn.execute(
+                """
+                INSERT INTO decisions (decision_id, category, text, rationale, created_at)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (decision_id, category, text, rationale, now),
+            )
         return decision_id
 
     def supersede_decision(self, decision_id: str, superseded_by: str) -> None:
         """Setzt superseded_by fuer eine Decision."""
-        conn = self._get_conn()
-        own_conn = self._conn is None
-        conn.execute(
-            "UPDATE decisions SET superseded_by = ? WHERE decision_id = ?",
-            (superseded_by, decision_id),
-        )
-        if own_conn:
-            conn.commit()
-            conn.close()
+        with self._connection(commit=True) as conn:
+            conn.execute(
+                "UPDATE decisions SET superseded_by = ? WHERE decision_id = ?",
+                (superseded_by, decision_id),
+            )
 
     def list_decisions(
         self,
@@ -477,8 +438,6 @@ class VaultDB:
         active_only: bool = True,
     ) -> list[dict]:
         """Gibt Decisions zurueck, optional nach Kategorie und/oder active gefiltert."""
-        conn = self._get_conn()
-        own_conn = self._conn is None
         clauses = []
         params: list = []
         if category is not None:
@@ -487,12 +446,11 @@ class VaultDB:
         if active_only:
             clauses.append("superseded_by IS NULL")
         where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
-        rows = conn.execute(
-            f"SELECT * FROM decisions {where} ORDER BY created_at DESC",
-            params,
-        ).fetchall()
-        if own_conn:
-            conn.close()
+        with self._connection() as conn:
+            rows = conn.execute(
+                f"SELECT * FROM decisions {where} ORDER BY created_at DESC",
+                params,
+            ).fetchall()
         return [dict(r) for r in rows]
 
     # ------------------------------------------------------------------
@@ -502,37 +460,29 @@ class VaultDB:
     def add_excluded_source(self, paper_id: str, reason: Optional[str] = None) -> None:
         """INSERT or REPLACE eines excluded_source-Eintrags."""
         now = int(time.time())
-        conn = self._get_conn()
-        own_conn = self._conn is None
-        conn.execute(
-            """
-            INSERT OR REPLACE INTO excluded_sources (paper_id, reason, excluded_at)
-            VALUES (?, ?, ?)
-            """,
-            (paper_id, reason, now),
-        )
-        if own_conn:
-            conn.commit()
-            conn.close()
+        with self._connection(commit=True) as conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO excluded_sources (paper_id, reason, excluded_at)
+                VALUES (?, ?, ?)
+                """,
+                (paper_id, reason, now),
+            )
 
     def list_excluded_sources(self) -> list[dict]:
         """Gibt alle excluded_sources zurueck."""
-        conn = self._get_conn()
-        own_conn = self._conn is None
-        rows = conn.execute("SELECT * FROM excluded_sources ORDER BY excluded_at DESC").fetchall()
-        if own_conn:
-            conn.close()
+        with self._connection() as conn:
+            rows = conn.execute(
+                "SELECT * FROM excluded_sources ORDER BY excluded_at DESC"
+            ).fetchall()
         return [dict(r) for r in rows]
 
     def is_excluded(self, paper_id: str) -> bool:
         """Prueft ob paper_id in excluded_sources ist."""
-        conn = self._get_conn()
-        own_conn = self._conn is None
-        row = conn.execute(
-            "SELECT 1 FROM excluded_sources WHERE paper_id = ?", (paper_id,)
-        ).fetchone()
-        if own_conn:
-            conn.close()
+        with self._connection() as conn:
+            row = conn.execute(
+                "SELECT 1 FROM excluded_sources WHERE paper_id = ?", (paper_id,)
+            ).fetchone()
         return row is not None
 
     # ------------------------------------------------------------------
@@ -548,19 +498,15 @@ class VaultDB:
         """INSERT eines RoB-Assessments. Gibt assessment_id (UUID) zurueck."""
         assessment_id = str(uuid4())
         now = int(time.time())
-        conn = self._get_conn()
-        own_conn = self._conn is None
-        conn.execute(
-            """
-            INSERT INTO risk_of_bias_assessments
-              (assessment_id, paper_id, study_type, domain_scores_json, ts)
-            VALUES (?, ?, ?, ?, ?)
-            """,
-            (assessment_id, paper_id, study_type, domain_scores_json, now),
-        )
-        if own_conn:
-            conn.commit()
-            conn.close()
+        with self._connection(commit=True) as conn:
+            conn.execute(
+                """
+                INSERT INTO risk_of_bias_assessments
+                  (assessment_id, paper_id, study_type, domain_scores_json, ts)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (assessment_id, paper_id, study_type, domain_scores_json, now),
+            )
         return assessment_id
 
     def list_risk_of_bias(
@@ -568,19 +514,16 @@ class VaultDB:
         paper_id: Optional[str] = None,
     ) -> list[dict]:
         """Gibt RoB-Assessments zurueck, optional nach paper_id gefiltert."""
-        conn = self._get_conn()
-        own_conn = self._conn is None
-        if paper_id is not None:
-            rows = conn.execute(
-                "SELECT * FROM risk_of_bias_assessments WHERE paper_id = ? ORDER BY ts DESC",
-                (paper_id,),
-            ).fetchall()
-        else:
-            rows = conn.execute(
-                "SELECT * FROM risk_of_bias_assessments ORDER BY ts DESC"
-            ).fetchall()
-        if own_conn:
-            conn.close()
+        with self._connection() as conn:
+            if paper_id is not None:
+                rows = conn.execute(
+                    "SELECT * FROM risk_of_bias_assessments WHERE paper_id = ? ORDER BY ts DESC",
+                    (paper_id,),
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    "SELECT * FROM risk_of_bias_assessments ORDER BY ts DESC"
+                ).fetchall()
         return [dict(r) for r in rows]
 
     # ------------------------------------------------------------------
@@ -596,18 +539,14 @@ class VaultDB:
         """INSERT eines Score-Snapshots. Gibt snapshot_id (UUID) zurueck."""
         snapshot_id = str(uuid4())
         now = int(time.time())
-        conn = self._get_conn()
-        own_conn = self._conn is None
-        conn.execute(
-            """
-            INSERT INTO score_history (snapshot_id, paper_id, session_id, ts, scores_json)
-            VALUES (?, ?, ?, ?, ?)
-            """,
-            (snapshot_id, paper_id, session_id, now, scores_json),
-        )
-        if own_conn:
-            conn.commit()
-            conn.close()
+        with self._connection(commit=True) as conn:
+            conn.execute(
+                """
+                INSERT INTO score_history (snapshot_id, paper_id, session_id, ts, scores_json)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (snapshot_id, paper_id, session_id, now, scores_json),
+            )
         return snapshot_id
 
     def get_score_history(
@@ -616,20 +555,17 @@ class VaultDB:
         k: Optional[int] = None,
     ) -> list[dict]:
         """Gibt Score-History fuer ein Paper zurueck, nach ts DESC sortiert."""
-        conn = self._get_conn()
-        own_conn = self._conn is None
-        if k is not None:
-            rows = conn.execute(
-                "SELECT * FROM score_history WHERE paper_id = ? ORDER BY ts DESC LIMIT ?",
-                (paper_id, k),
-            ).fetchall()
-        else:
-            rows = conn.execute(
-                "SELECT * FROM score_history WHERE paper_id = ? ORDER BY ts DESC",
-                (paper_id,),
-            ).fetchall()
-        if own_conn:
-            conn.close()
+        with self._connection() as conn:
+            if k is not None:
+                rows = conn.execute(
+                    "SELECT * FROM score_history WHERE paper_id = ? ORDER BY ts DESC LIMIT ?",
+                    (paper_id, k),
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    "SELECT * FROM score_history WHERE paper_id = ? ORDER BY ts DESC",
+                    (paper_id,),
+                ).fetchall()
         return [dict(r) for r in rows]
 
     # ------------------------------------------------------------------
@@ -659,58 +595,44 @@ class VaultDB:
         """
         chunk_id = str(uuid4())
         now = int(time.time())
-        conn = self._get_conn()
-        own_conn = self._conn is None
-        conn.execute(
-            """
-            INSERT INTO chunk_embeddings
-              (chunk_id, paper_id, chunk_text, context_sentence, embedding_text,
-               embedding_vector, created_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
-            """,
-            (chunk_id, paper_id, chunk_text, context_sentence, embedding_text,
-             embedding_vector, now),
-        )
-        if own_conn:
-            conn.commit()
-            conn.close()
+        with self._connection(commit=True) as conn:
+            conn.execute(
+                """
+                INSERT INTO chunk_embeddings
+                  (chunk_id, paper_id, chunk_text, context_sentence, embedding_text,
+                   embedding_vector, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (chunk_id, paper_id, chunk_text, context_sentence, embedding_text,
+                 embedding_vector, now),
+            )
         return chunk_id
 
     def get_chunk_embeddings(self, paper_id: str) -> list[dict]:
         """Gibt alle Chunk-Embeddings fuer ein Paper zurueck."""
-        conn = self._get_conn()
-        own_conn = self._conn is None
-        rows = conn.execute(
-            "SELECT * FROM chunk_embeddings WHERE paper_id = ? ORDER BY created_at",
-            (paper_id,),
-        ).fetchall()
-        if own_conn:
-            conn.close()
+        with self._connection() as conn:
+            rows = conn.execute(
+                "SELECT * FROM chunk_embeddings WHERE paper_id = ? ORDER BY created_at",
+                (paper_id,),
+            ).fetchall()
         return [dict(r) for r in rows]
 
     def lock_vault(self, slug: str) -> None:
         """Setzt Vault-Lock fuer einen Slug. Idempotent."""
         now = int(time.time())
-        conn = self._get_conn()
-        own_conn = self._conn is None
-        conn.execute(
-            """
-            INSERT OR REPLACE INTO vault_locked_status (slug, locked_at)
-            VALUES (?, ?)
-            """,
-            (slug, now),
-        )
-        if own_conn:
-            conn.commit()
-            conn.close()
+        with self._connection(commit=True) as conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO vault_locked_status (slug, locked_at)
+                VALUES (?, ?)
+                """,
+                (slug, now),
+            )
 
     def is_locked(self, slug: str) -> bool:
         """Prueft ob Vault-Lock fuer Slug gesetzt ist."""
-        conn = self._get_conn()
-        own_conn = self._conn is None
-        row = conn.execute(
-            "SELECT 1 FROM vault_locked_status WHERE slug = ?", (slug,)
-        ).fetchone()
-        if own_conn:
-            conn.close()
+        with self._connection() as conn:
+            row = conn.execute(
+                "SELECT 1 FROM vault_locked_status WHERE slug = ?", (slug,)
+            ).fetchone()
         return row is not None

--- a/tests/test_issue_237_db_conn_leak.py
+++ b/tests/test_issue_237_db_conn_leak.py
@@ -1,0 +1,187 @@
+"""Regressionstest fuer Issue #237 — SQLite-Connection-Leak bei Exception.
+
+Alle write-Methoden in ``VaultDB`` oeffneten eine eigene Connection ohne
+``try/finally`` bzw. Context-Manager. Wirft ``conn.execute()`` eine Exception
+(z. B. IntegrityError bei FK-/CHECK-Verletzung), blieb die Verbindung im
+WAL-Modus offen und leakte. Diese Tests weisen nach, dass bei einer Exception
+keine offene Connection zurueckbleibt.
+
+Akzeptanzkriterium (Issue #237):
+- Bei Exception in einer write-Methode wird die Verbindung garantiert
+  geschlossen (Regressionstest mit erzwungenem IntegrityError).
+"""
+import os
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# Worktree-Root zum PYTHONPATH hinzufuegen damit academic_vault importierbar ist
+_WORKTREE_ROOT = Path(__file__).parent.parent
+if str(_WORKTREE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_WORKTREE_ROOT))
+
+from academic_vault.db import VaultDB
+
+
+class _ConnTracker:
+    """Zaehlt geoeffnete vs. geschlossene sqlite3-Connections.
+
+    Patcht ``academic_vault.db.sqlite3.connect`` so, dass jede zurueckgegebene
+    Connection beim ``close()`` registriert wird. ``sqlite3.Connection.close``
+    ist read-only, daher wird eine Subklasse als ``factory`` untergeschoben,
+    die ``close()`` ueberschreibt. So laesst sich nachweisen, dass eine in einer
+    Methode geoeffnete Connection auch bei Exception wieder geschlossen wird
+    (keine leaks).
+    """
+
+    def __init__(self) -> None:
+        self.opened: list[sqlite3.Connection] = []
+        self.closed: list[sqlite3.Connection] = []
+        self._orig_connect = sqlite3.connect
+
+    def connect(self, *args, **kwargs):
+        tracker = self
+
+        class _TrackedConnection(sqlite3.Connection):
+            def close(self_inner):  # noqa: N805
+                tracker.closed.append(self_inner)
+                return super().close()
+
+        kwargs.setdefault("factory", _TrackedConnection)
+        conn = self._orig_connect(*args, **kwargs)
+        self.opened.append(conn)
+        return conn
+
+    @property
+    def open_count(self) -> int:
+        """Anzahl der noch nicht geschlossenen Connections."""
+        return len(self.opened) - len(self.closed)
+
+
+def _fresh_db():
+    """Erstellt eine frische Vault-DB-Datei mit initialisiertem Schema."""
+    tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    tmp.close()
+    db = VaultDB(tmp.name)
+    db.init_schema()
+    return tmp.name, db
+
+
+def test_add_quote_fk_violation_closes_connection(monkeypatch):
+    """add_quote mit nicht-existentem paper_id (FK-Verletzung) darf keine
+    Connection leaken."""
+    db_path, db = _fresh_db()
+    try:
+        tracker = _ConnTracker()
+        monkeypatch.setattr("academic_vault.db.sqlite3.connect", tracker.connect)
+
+        with pytest.raises(sqlite3.IntegrityError):
+            db.add_quote(
+                quote_id="q-leak",
+                paper_id="paper-does-not-exist",
+                verbatim="Zitat das eine FK-Verletzung ausloest.",
+                extraction_method="manual",
+            )
+
+        assert tracker.opened, "add_quote sollte mindestens eine Connection oeffnen"
+        assert tracker.open_count == 0, (
+            "Connection-Leak: %d offene Connection(s) nach Exception in add_quote"
+            % tracker.open_count
+        )
+    finally:
+        os.unlink(db_path)
+
+
+def test_add_score_snapshot_fk_violation_closes_connection(monkeypatch):
+    """add_score_snapshot mit FK-Verletzung darf keine Connection leaken."""
+    db_path, db = _fresh_db()
+    try:
+        tracker = _ConnTracker()
+        monkeypatch.setattr("academic_vault.db.sqlite3.connect", tracker.connect)
+
+        with pytest.raises(sqlite3.IntegrityError):
+            db.add_score_snapshot(
+                paper_id="paper-does-not-exist",
+                session_id="s1",
+                scores_json="{}",
+            )
+
+        assert tracker.opened
+        assert tracker.open_count == 0, (
+            "Connection-Leak nach Exception in add_score_snapshot: %d offen"
+            % tracker.open_count
+        )
+    finally:
+        os.unlink(db_path)
+
+
+def test_add_risk_of_bias_fk_violation_closes_connection(monkeypatch):
+    """add_risk_of_bias mit FK-Verletzung darf keine Connection leaken."""
+    db_path, db = _fresh_db()
+    try:
+        tracker = _ConnTracker()
+        monkeypatch.setattr("academic_vault.db.sqlite3.connect", tracker.connect)
+
+        with pytest.raises(sqlite3.IntegrityError):
+            db.add_risk_of_bias(
+                paper_id="paper-does-not-exist",
+                study_type="rct",
+                domain_scores_json="{}",
+            )
+
+        assert tracker.opened
+        assert tracker.open_count == 0, (
+            "Connection-Leak nach Exception in add_risk_of_bias: %d offen"
+            % tracker.open_count
+        )
+    finally:
+        os.unlink(db_path)
+
+
+def test_successful_write_also_closes_connection(monkeypatch):
+    """Auch der Erfolgsfall darf keine selbst-geoeffnete Connection offen lassen
+    (Regression gegen ein evtl. fehlerhaftes Refactoring)."""
+    db_path, db = _fresh_db()
+    try:
+        tracker = _ConnTracker()
+        monkeypatch.setattr("academic_vault.db.sqlite3.connect", tracker.connect)
+
+        db.add_paper("p-ok", '{"title": "OK"}')
+
+        assert tracker.opened
+        assert tracker.open_count == 0, (
+            "Connection-Leak im Erfolgsfall von add_paper: %d offen"
+            % tracker.open_count
+        )
+    finally:
+        os.unlink(db_path)
+
+
+def test_shared_connection_not_closed_on_exception(monkeypatch):
+    """Wird die Methode im Context-Manager (self._conn gesetzt) aufgerufen,
+    darf die geteilte Connection bei Exception NICHT geschlossen werden — nur
+    selbst geoeffnete Connections werden geschlossen."""
+    db_path = tempfile.NamedTemporaryFile(suffix=".db", delete=False).name
+    try:
+        with VaultDB(db_path) as db:
+            db.init_schema()
+            tracker = _ConnTracker()
+            monkeypatch.setattr(
+                "academic_vault.db.sqlite3.connect", tracker.connect
+            )
+            with pytest.raises(sqlite3.IntegrityError):
+                db.add_quote(
+                    quote_id="q-shared",
+                    paper_id="paper-does-not-exist",
+                    verbatim="Zitat.",
+                    extraction_method="manual",
+                )
+            # Im geteilten Modus oeffnet add_quote KEINE neue Connection und
+            # schliesst die geteilte auch nicht.
+            assert tracker.open_count == 0
+            assert len(tracker.closed) == 0
+    finally:
+        os.unlink(db_path)


### PR DESCRIPTION
## Problem
Alle write- und read-Methoden in `VaultDB` (`academic_vault/db.py`) folgten dem Muster `conn = self._get_conn(); own_conn = (self._conn is None); conn.execute(...); if own_conn: conn.commit(); conn.close()` — das `conn.close()` stand **nicht** in einem `finally`. Wirft `conn.execute()` eine Exception (IntegrityError bei FK-/CHECK-Verletzung), blieb die selbst geoeffnete Verbindung im WAL-Modus offen und leakte. In einem lang laufenden MCP-Server akkumulieren diese Leaks, das WAL waechst und Sperren koennen klemmen.

Akzeptanzkriterium aus #237: Bei einer Exception in einer write-Methode muss die Verbindung garantiert geschlossen werden (Regressionstest mit erzwungenem IntegrityError).

## Fix
`academic_vault/db.py`:
- Neuer Context-Manager `VaultDB._connection(commit: bool = False)` (via `contextlib.contextmanager`). Er liefert eine Connection und schliesst sie im `finally`-Block garantiert — aber **nur**, wenn sie in der Methode selbst geoeffnet wurde (`self._conn is None`). Bei `commit=True` wird im Erfolgsfall vorher committet. Eine geteilte Connection (Context-Manager-Modus, `self._conn` gesetzt) wird hier weder committet noch geschlossen; das uebernimmt weiterhin `__exit__`.
- Alle ~30 Methoden (`add_paper`, `get_paper`, `set_file_id`, `set_page_offset`, `get_page_offset`, `add_quote`, `get_quote`, `search_quote_text`, `find_quotes`, `set_ocr_done`, `update_pdf_path`, `add_figure`, `get_figure`, `list_figures`, `find_figures_by_caption`, `add_decision`, `supersede_decision`, `list_decisions`, `add_excluded_source`, `list_excluded_sources`, `is_excluded`, `add_risk_of_bias`, `list_risk_of_bias`, `add_score_snapshot`, `get_score_history`, `add_chunk_embedding`, `get_chunk_embeddings`, `lock_vault`, `is_locked`, `init_schema`) auf `with self._connection(...) as conn:` umgestellt. Die explizite `own_conn`-Buchhaltung und das nachgelagerte `conn.commit()/conn.close()` entfallen.
- Verhalten unveraendert: Validierungen (z. B. `ValueError` in `add_paper`) bleiben vor dem Connection-Aufbau, UUID-Rueckgaben bleiben erhalten.

## TDD-Belege
Neuer Regressionstest `tests/test_issue_237_db_conn_leak.py` (5 Cases): Ein `_ConnTracker` patcht `academic_vault.db.sqlite3.connect` mit einer `Connection`-Subklasse, die `close()` mitzaehlt, und prueft `open_count == 0` nach erzwungenem `IntegrityError` (FK-Verletzung) in `add_quote`, `add_score_snapshot`, `add_risk_of_bias` sowie im Erfolgsfall und im geteilten Context-Manager-Modus.
- **Rot (vor Fix):** `3 failed, 2 passed in 0.05s`
- **Gruen (nach Fix):** `5 passed in 0.04s`
- **Volle Suite:** `967 passed, 149 skipped` — 0 failed, keine Regression.

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)
