### PR TITLE
chore(repo): pre-commit-Konfig + README-Hinweis, .DS_Store-Guard (#189)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+# pre-commit-Konfiguration (optional, empfohlen).
+# Installation:  pip install pre-commit && pre-commit install
+# Verhindert u. a. das versehentliche Committen großer Dateien, neuer Submodule
+# und privater Schlüssel. Lokale OS-Artefakte wie .DS_Store werden bereits via
+# .gitignore ausgeschlossen.
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-added-large-files
+      - id: forbid-new-submodules
+      - id: detect-private-key

--- a/README.md
+++ b/README.md
@@ -654,6 +654,18 @@ cp library-profiles/template-han.yaml \
 
 Aktuell: ~60 Tests, inkl. Regression-Guards (`test_skill_naming.py`, `test_cross_references.py`).
 
+### pre-commit (empfohlen)
+
+Für lokale Hygiene wird `pre-commit` empfohlen. Die Konfiguration liegt in
+[`.pre-commit-config.yaml`](.pre-commit-config.yaml) und blockt versehentlich
+committete große Dateien, neue Submodule und private Schlüssel. OS-Artefakte wie
+`.DS_Store` werden bereits über `.gitignore` ausgeschlossen.
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
 ### Evals
 
 ```bash

--- a/tests/test_issue_189_dsstore_cleanup.py
+++ b/tests/test_issue_189_dsstore_cleanup.py
@@ -1,0 +1,67 @@
+"""Regression guard für Issue #189: lokales Cleanup .DS_Store + optionaler pre-commit hook.
+
+Akzeptanzkriterien (siehe Issue #189):
+- Kein `.DS_Store` ist im git-Index getrackt.
+- `.gitignore` schließt `.DS_Store` aus.
+- `.pre-commit-config.yaml` existiert mit den Hooks `check-added-large-files`,
+  `forbid-new-submodules`, `detect-private-key`.
+- README enthält einen Hinweis, dass pre-commit empfohlen wird.
+"""
+import subprocess
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).parent.parent
+
+
+def _tracked_files() -> list[str]:
+    out = subprocess.run(
+        ["git", "ls-files"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return out.stdout.splitlines()
+
+
+def test_no_dsstore_is_tracked():
+    tracked = _tracked_files()
+    offenders = [p for p in tracked if Path(p).name == ".DS_Store"]
+    assert not offenders, f".DS_Store darf nicht getrackt sein: {offenders}"
+
+
+def test_gitignore_excludes_dsstore():
+    gitignore = REPO_ROOT / ".gitignore"
+    assert gitignore.exists(), ".gitignore fehlt"
+    entries = {
+        line.strip()
+        for line in gitignore.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+    assert ".DS_Store" in entries, ".gitignore muss '.DS_Store' ausschließen"
+
+
+def test_pre_commit_config_exists_with_required_hooks():
+    cfg = REPO_ROOT / ".pre-commit-config.yaml"
+    assert cfg.exists(), ".pre-commit-config.yaml fehlt"
+    data = yaml.safe_load(cfg.read_text(encoding="utf-8"))
+    assert isinstance(data, dict) and data.get("repos"), (
+        ".pre-commit-config.yaml muss einen 'repos'-Block haben"
+    )
+    hook_ids = {
+        hook.get("id")
+        for repo in data["repos"]
+        for hook in repo.get("hooks", [])
+    }
+    for required in ("check-added-large-files", "forbid-new-submodules", "detect-private-key"):
+        assert required in hook_ids, f"pre-commit hook '{required}' fehlt"
+
+
+def test_readme_mentions_pre_commit():
+    readme = REPO_ROOT / "README.md"
+    assert readme.exists(), "README.md fehlt"
+    assert "pre-commit" in readme.read_text(encoding="utf-8").lower(), (
+        "README sollte einen Hinweis auf pre-commit enthalten"
+    )


### PR DESCRIPTION
## Problem

Pre-Release-Audit (MINOR): Lokale `.DS_Store`-Artefakte sollen aus dem Working Tree
entfernt und dauerhaft ausgeschlossen sein. `.gitignore` schloss `.DS_Store` zwar
bereits aus und es war nichts getrackt, aber es fehlte (a) ein Regressionsschutz dafuer
und (b) der optional empfohlene pre-commit-Hook samt Hinweis in der Doku.

Akzeptanzkriterien aus #189:
- kein `.DS_Store` getrackt + `.gitignore` schliesst `.DS_Store` aus
- optionale `.pre-commit-config.yaml` mit `check-added-large-files`,
  `forbid-new-submodules`, `detect-private-key`
- README/CONTRIBUTING-Hinweis: pre-commit empfohlen

## Fix

- **`.pre-commit-config.yaml`** (neu): pre-commit-Konfiguration mit den drei geforderten
  Hooks aus `pre-commit/pre-commit-hooks` (`check-added-large-files`,
  `forbid-new-submodules`, `detect-private-key`).
- **`README.md`**: neuer Unterabschnitt "pre-commit (empfohlen)" unter
  "Entwicklung und Evals" mit Installationshinweis.
- **`tests/test_issue_189_dsstore_cleanup.py`** (neu): Regressionstest, der die
  Akzeptanzkriterien konkret prueft.
- Lokale `.DS_Store`-Dateien im Working Tree entfernt (einmalig).

## TDD-Belege

Neuer Regressionstest `tests/test_issue_189_dsstore_cleanup.py` (4 Cases).
- **Rot (vor Fix):** `2 failed, 2 passed in 0.05s`
- **Gruen (nach Fix):** `4 passed in 0.03s`
- **Volle Suite:** `966 passed, 149 skipped` — 0 failed, keine Regression.

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)