### PR TITLE
fix(tests): zentrale pytest-Fixtures in tests/conftest.py (#183)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,102 @@
+"""Zentrale pytest-Fixtures fuer die academic-research-Testsuite (Issue #183).
+
+Bisher hatte tests/ kein conftest.py; haeufig genutzte Bausteine (Repo-Root auf
+sys.path, temporaere Vault-DB, browser-use-Mock, Beispiel-PDF, TUM-Bibliotheks-
+profil) waren in einzelnen test_*.py dupliziert. Diese Datei zentralisiert sie,
+ohne bestehende Tests zu veraendern -- die Fixtures sind rein additiv.
+
+Bereitgestellte Fixtures:
+  - temp_vault_db        Pfad auf eine frisch initialisierte SQLite-Vault-DB
+  - mock_browser_use     MagicMock als Ersatz fuer browser-use-Aufrufe
+  - sample_pdf           Pfad auf tests/fixtures/sample_book.pdf
+  - library_profile_tum  geparstes config/library-profiles/tum.yaml als dict
+"""
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Pfade: Repo-Root auf sys.path, damit `academic_vault`/`scripts` importierbar
+# sind. Dieser Block war zuvor in ~30 test_*.py dupliziert.
+# ---------------------------------------------------------------------------
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+LIBRARY_PROFILES_DIR = REPO_ROOT / "config" / "library-profiles"
+
+
+# ---------------------------------------------------------------------------
+# Vault-DB
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def temp_vault_db(tmp_path):
+    """Frisch initialisierte SQLite-Vault-DB in einem Tempdir.
+
+    Liefert den Pfad (str) auf die DB-Datei mit bereits ausgefuehrtem
+    `init_schema()`. Faellt auf ein nacktes sqlite-Setup zurueck, falls
+    `academic_vault.db` (noch) nicht importierbar ist, damit Tests, die nur
+    eine leere DB-Datei brauchen, die Fixture trotzdem nutzen koennen.
+    """
+    db_path = tmp_path / "vault.db"
+    try:
+        from academic_vault.db import VaultDB
+    except Exception:
+        # Fallback: leere DB-Datei ohne Schema (z.B. wenn sqlite-Extensions fehlen)
+        import sqlite3
+
+        conn = sqlite3.connect(str(db_path))
+        conn.close()
+        return str(db_path)
+
+    db = VaultDB(str(db_path))
+    db.init_schema()
+    return str(db_path)
+
+
+# ---------------------------------------------------------------------------
+# browser-use-Mock
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def mock_browser_use():
+    """MagicMock als Ersatz fuer browser-use-Interaktionen.
+
+    Verhindert echte Browser-Automation in Unit-Tests. `.run(...)` liefert
+    standardmaessig einen leeren Erfolgs-String; einzelne Tests koennen
+    Rueckgabewerte/Seiteneffekte ueber den Mock konfigurieren.
+    """
+    mock = MagicMock(name="browser_use")
+    mock.run.return_value = ""
+    mock.navigate.return_value = ""
+    mock.extract.return_value = {}
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Beispiel-PDF
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def sample_pdf():
+    """Pfad auf eine kleine, echte Beispiel-PDF (tests/fixtures/sample_book.pdf)."""
+    pdf_path = FIXTURES_DIR / "sample_book.pdf"
+    if not pdf_path.is_file():
+        pytest.skip(f"Beispiel-PDF fehlt: {pdf_path}")
+    return pdf_path
+
+
+# ---------------------------------------------------------------------------
+# Bibliotheksprofil TUM
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def library_profile_tum():
+    """Geparstes TUM-Bibliotheksprofil (config/library-profiles/tum.yaml) als dict."""
+    import yaml
+
+    profile_path = LIBRARY_PROFILES_DIR / "tum.yaml"
+    if not profile_path.is_file():
+        pytest.skip(f"TUM-Profil fehlt: {profile_path}")
+    with open(profile_path, encoding="utf-8") as fh:
+        return yaml.safe_load(fh)

--- a/tests/test_issue_183_conftest_fixtures.py
+++ b/tests/test_issue_183_conftest_fixtures.py
@@ -1,0 +1,91 @@
+"""Regressionstest fuer Issue #183: zentrale pytest-Fixtures in tests/conftest.py.
+
+Prueft Existenz, Importierbarkeit und korrektes Verhalten der vier zentralen
+Fixtures, die laut Akzeptanzkriterien in conftest.py definiert sein muessen:
+  - temp_vault_db       (Tempdir + sqlite-Setup via VaultDB)
+  - mock_browser_use    (MagicMock fuer browser-use-Interaktionen)
+  - sample_pdf          (Pfad auf eine echte PDF-Beispieldatei)
+  - library_profile_tum (geparstes TUM-Bibliotheksprofil)
+
+Diese Datei darf KEINE eigenen Fixtures definieren -- sie konsumiert nur die
+zentralen conftest-Fixtures, um die Akzeptanzkriterien konkret zu belegen.
+"""
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+CONFTEST_PATH = Path(__file__).parent / "conftest.py"
+
+
+# ---------------------------------------------------------------------------
+# Existenz / Importierbarkeit
+# ---------------------------------------------------------------------------
+
+def test_conftest_file_exists():
+    """tests/conftest.py muss existieren und nicht leer sein."""
+    assert CONFTEST_PATH.is_file(), "tests/conftest.py fehlt"
+    assert CONFTEST_PATH.read_text(encoding="utf-8").strip(), "conftest.py ist leer"
+
+
+def test_conftest_defines_required_fixtures():
+    """Alle vier zentralen Fixtures muessen via conftest registriert sein."""
+    from _pytest.fixtures import FixtureManager  # noqa: F401  (Verfuegbarkeit)
+
+    expected = {
+        "temp_vault_db",
+        "mock_browser_use",
+        "sample_pdf",
+        "library_profile_tum",
+    }
+    text = CONFTEST_PATH.read_text(encoding="utf-8")
+    missing = {name for name in expected if f"def {name}" not in text}
+    assert not missing, f"Fixtures fehlen in conftest.py: {sorted(missing)}"
+
+
+# ---------------------------------------------------------------------------
+# Verhalten der einzelnen Fixtures
+# ---------------------------------------------------------------------------
+
+def test_temp_vault_db_is_initialized(temp_vault_db):
+    """temp_vault_db liefert einen DB-Pfad mit initialisiertem Schema."""
+    db_path = str(temp_vault_db)
+    assert Path(db_path).exists(), "temp_vault_db-Pfad existiert nicht"
+
+    conn = sqlite3.connect(db_path)
+    try:
+        tables = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type IN ('table','view')"
+            )
+        }
+    finally:
+        conn.close()
+    # Kern-Tabellen aus schema.sql muessen vorhanden sein
+    assert "papers" in tables, f"Tabelle 'papers' fehlt; vorhanden: {sorted(tables)}"
+    assert "quotes" in tables, f"Tabelle 'quotes' fehlt; vorhanden: {sorted(tables)}"
+
+
+def test_mock_browser_use_is_mock(mock_browser_use):
+    """mock_browser_use ist ein aufrufbarer Mock fuer browser-use."""
+    # Muss aufrufbar sein und ein Ergebnis liefern, ohne echtes Browsen.
+    result = mock_browser_use.run("https://example.org")
+    assert result is not None
+    assert mock_browser_use.run.called
+
+
+def test_sample_pdf_exists(sample_pdf):
+    """sample_pdf zeigt auf eine echte, lesbare PDF-Datei."""
+    pdf_path = Path(sample_pdf)
+    assert pdf_path.is_file(), f"sample_pdf existiert nicht: {pdf_path}"
+    assert pdf_path.suffix == ".pdf"
+    assert pdf_path.read_bytes()[:4] == b"%PDF", "Datei ist keine gueltige PDF"
+
+
+def test_library_profile_tum_shape(library_profile_tum):
+    """library_profile_tum liefert das geparste TUM-Profil als dict."""
+    assert isinstance(library_profile_tum, dict)
+    assert library_profile_tum.get("uni") == "tum"
+    assert "licensed_sites" in library_profile_tum
+    assert isinstance(library_profile_tum["licensed_sites"], list)


### PR DESCRIPTION
## Problem

`tests/` enthielt 59 Test-Dateien, aber **kein `conftest.py`**. Dadurch waren gaengige Bausteine dupliziert -- insbesondere das Repo-Root-`sys.path`-Setup (in ~30 `test_*.py` woertlich wiederholt). pytest-Best-Practice (zentrale Fixtures fuer Vault-DB, Tempdirs, Mocks) war nicht umgesetzt.

Akzeptanzkriterien aus #183: `temp_vault_db`, `mock_browser_use`, `sample_pdf`, `library_profile_tum` zentral bereitstellen; Gesamtlauf vorher/nachher gleiche Pass-Zahl.

## Fix

- **`tests/conftest.py`** (neu): zentrales pytest-conftest mit
  - Repo-Root auf `sys.path` (macht `academic_vault`/`scripts` importierbar)
  - `temp_vault_db` -- frisch via `VaultDB.init_schema()` initialisierte SQLite-DB im `tmp_path`, mit Fallback auf nackte sqlite-Datei, falls `academic_vault.db` nicht importierbar ist.
  - `mock_browser_use` -- `MagicMock` als Ersatz fuer browser-use-Aufrufe (kein echtes Browsen in Unit-Tests).
  - `sample_pdf` -- Pfad auf `tests/fixtures/sample_book.pdf`.
  - `library_profile_tum` -- geparstes `config/library-profiles/tum.yaml` als dict.
- **`tests/test_issue_183_conftest_fixtures.py`** (neu): Regressionstest, der Existenz/Importierbarkeit der zentralen Fixtures sowie deren Verhalten prueft.

Die Fixtures sind **rein additiv**: bestehende Tests definieren ihre eigenen lokalen Fixtures weiter und werden nicht angefasst, daher keine Regressionsgefahr. Kuenftige Tests koennen die zentralen Fixtures direkt konsumieren.

## TDD-Belege

Neuer Regressionstest `tests/test_issue_183_conftest_fixtures.py` (6 Cases).
- **Rot (vor Fix):** `2 failed, 4 errors in 0.04s`
- **Gruen (nach Fix):** `6 passed in 0.03s`
- **Volle Suite:** `968 passed, 149 skipped` -- 0 failed, keine Regression.

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)