### PR TITLE
fix(docs+ci): Python-Mindestversion auf 3.11 konsistent machen (#201)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.11"
       - name: Frontmatter + description pruefen
         run: |
           python3 - <<'PY'
@@ -97,7 +97,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.11"
           cache: pip
       - name: Python-Deps installieren
         run: |
@@ -106,19 +106,22 @@ jobs:
       - name: pytest (Skills)
         run: pytest tests/test_skills_manifest.py tests/test_skill_naming.py -v
 
-  # 5. Vollstaendige Test-Suite auf macOS + Ubuntu
+  # 5. Vollstaendige Test-Suite auf macOS + Ubuntu, Python-Matrix 3.11/3.12/3.13
+  #    Mindestversion 3.11 ist konsistent mit README.md und pyproject.toml (#201).
+  #    3.14 folgt, sobald actions/setup-python es als stable fuehrt.
   python-tests:
-    name: pytest (${{ matrix.os }})
+    name: pytest (${{ matrix.os }}, py${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
           cache: pip
       # Hook-Tests starten .mjs-Hooks per `node` — daher zwingend noetig
       - uses: actions/setup-node@v4

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Das Plugin kommt mit vorkonfigurierten **Per-Uni-Profilen** für Leibniz FH, TU 
 | Komponente | Warum | Installation |
 |-----------|-------|--------------|
 | **Claude Code** | CLI zum Ausführen | [Installations-Anleitung](https://code.claude.com/docs/en/quickstart) |
-| **Python 3.10+** | Vault-MCP-Server, Suchskripte | `brew install python@3.11` (macOS) |
+| **Python 3.11+** (entwickelt + getestet mit 3.14) | Vault-MCP-Server, Suchskripte | `brew install python@3.11` (macOS) |
 | **`uv` oder `pipx`** | Für die automatische `browser-use`-Installation | `brew install pipx` oder `curl -LsSf https://astral.sh/uv/install.sh \| sh` |
 | **Git** | Plugin-Marketplace-Install | auf macOS/Linux meist vorinstalliert |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "academic-research"
+version = "6.6.0"
+description = "Claude-Code-Plugin fuer wissenschaftliche Recherche, Vault-MCP-Server und Fetch-Pipelines."
+readme = "README.md"
+license = { file = "LICENSE" }
+# Mindestversion: 3.11 (entwickelt + getestet mit 3.14, CI-Matrix 3.11/3.12/3.13).
+# Konsistent mit README.md und .github/workflows/ci.yml (vgl. #201).
+requires-python = ">=3.11"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -19,6 +19,15 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 mkdir -p "$BASE/sessions" "$BASE/pdfs"
 
+# Mindest-Python-Version pruefen, bevor die venv erstellt wird (vgl. #201).
+# Konsistent mit README.md ("Python 3.11+") und pyproject.toml (requires-python >=3.11).
+if ! python3 -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)'; then
+  CURRENT="$(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])' 2>/dev/null || echo "unbekannt")"
+  echo "❌ Python 3.11+ erforderlich (gefunden: $CURRENT)." >&2
+  echo "   Bitte ein neueres Python installieren, z.B. 'brew install python@3.11' (macOS)." >&2
+  exit 1
+fi
+
 if [ ! -d "$BASE/venv" ]; then
   python3 -m venv "$BASE/venv"
 fi

--- a/tests/test_issue_201_python_version.py
+++ b/tests/test_issue_201_python_version.py
@@ -1,0 +1,124 @@
+"""
+Tests fuer Issue #201 — Python-Version-Konsistenz.
+
+Befund: README sagte "Python 3.10+", real wird 3.12/3.14 genutzt (CI nutzt 3.12).
+Die Versionsangaben muessen konsistent sein zwischen README, pyproject.toml,
+CI-Matrix und setup.sh.
+
+5 Test-Cases (kein LLM-Call, keine Netzwerk-/Browser-Automation):
+1. README nennt NICHT mehr "3.10+" und nennt die korrekte Mindestversion 3.11.
+2. pyproject.toml existiert mit requires-python = ">=3.11".
+3. CI-Matrix enthaelt mindestens 3.11, 3.12, 3.13.
+4. setup.sh prueft die Python-Version vor der venv-Erstellung.
+5. Konsistenz: die in README/pyproject genannte Mindestversion stimmt mit der
+   kleinsten in der CI getesteten Version ueberein.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+README = REPO_ROOT / "README.md"
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+SETUP_SH = REPO_ROOT / "scripts" / "setup.sh"
+
+MIN_VERSION = (3, 11)
+
+
+def _ver_tuple(s: str) -> tuple[int, int]:
+    parts = s.strip().strip('"').strip("'").split(".")
+    return (int(parts[0]), int(parts[1]))
+
+
+# ---------------------------------------------------------------------------
+# 1. README
+# ---------------------------------------------------------------------------
+
+def test_readme_no_stale_310():
+    text = README.read_text(encoding="utf-8")
+    assert "3.10+" not in text, "README nennt weiterhin das veraltete 'Python 3.10+'."
+
+
+def test_readme_states_min_311():
+    text = README.read_text(encoding="utf-8")
+    # Es muss eine Angabe geben, die 3.11 als Mindestversion ausweist.
+    assert re.search(r"Python\s*3\.11\+", text), (
+        "README muss 'Python 3.11+' als Mindestversion ausweisen."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. pyproject.toml mit requires-python
+# ---------------------------------------------------------------------------
+
+def test_pyproject_exists():
+    assert PYPROJECT.exists(), "pyproject.toml fehlt im Repo-Root."
+
+
+def test_pyproject_requires_python_311():
+    assert PYPROJECT.exists(), "pyproject.toml fehlt im Repo-Root."
+    text = PYPROJECT.read_text(encoding="utf-8")
+    m = re.search(r'requires-python\s*=\s*"(>=)?\s*([0-9.]+)"', text)
+    assert m, "pyproject.toml hat kein requires-python-Feld."
+    assert _ver_tuple(m.group(2)) == MIN_VERSION, (
+        f"requires-python muss >=3.11 sein, gefunden: {m.group(0)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. CI-Matrix
+# ---------------------------------------------------------------------------
+
+def test_ci_matrix_covers_311_312_313():
+    text = CI_WORKFLOW.read_text(encoding="utf-8")
+    for v in ("3.11", "3.12", "3.13"):
+        assert v in text, f"CI-Workflow testet Version {v} nicht."
+
+
+# ---------------------------------------------------------------------------
+# 4. setup.sh prueft Python-Version
+# ---------------------------------------------------------------------------
+
+def test_setup_sh_checks_python_version():
+    text = SETUP_SH.read_text(encoding="utf-8")
+    # Vor der venv-Erstellung (python3 -m venv) muss eine Versionspruefung stehen.
+    venv_idx = text.find("python3 -m venv")
+    assert venv_idx != -1, "setup.sh erstellt keine venv mehr?"
+    head = text[:venv_idx]
+    assert "sys.version_info" in head or "version_info" in head, (
+        "setup.sh prueft die Python-Version nicht vor der venv-Erstellung."
+    )
+    assert "3.11" in head or "(3, 11)" in head, (
+        "setup.sh referenziert die Mindestversion 3.11 nicht in der Versionspruefung."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. Konsistenz README/pyproject <-> CI-Mindestversion
+# ---------------------------------------------------------------------------
+
+def test_min_version_consistent_across_readme_pyproject_ci():
+    readme = README.read_text(encoding="utf-8")
+    m_readme = re.search(r"Python\s*3\.(\d+)\+", readme)
+    assert m_readme, "README nennt keine 'Python 3.x+'-Mindestversion."
+    readme_min = (3, int(m_readme.group(1)))
+
+    pyproject = PYPROJECT.read_text(encoding="utf-8")
+    m_py = re.search(r'requires-python\s*=\s*">=\s*([0-9.]+)"', pyproject)
+    assert m_py, "pyproject.toml hat kein '>='-requires-python."
+    py_min = _ver_tuple(m_py.group(1))
+
+    ci = CI_WORKFLOW.read_text(encoding="utf-8")
+    ci_versions = sorted(
+        {_ver_tuple(v) for v in re.findall(r'python-version:\s*"?(3\.\d+)"?', ci)}
+    )
+    assert ci_versions, "CI-Workflow nennt keine python-version-Eintraege."
+    ci_min = ci_versions[0]
+
+    assert readme_min == py_min == ci_min == MIN_VERSION, (
+        f"Mindestversionen inkonsistent: README={readme_min}, "
+        f"pyproject={py_min}, CI-min={ci_min}, erwartet={MIN_VERSION}"
+    )


### PR DESCRIPTION
## Problem
Die Python-Versionsangaben im Projekt waren inkonsistent:
- `README.md` Z.129 nannte **"Python 3.10+"**.
- Real laeuft die venv auf **Python 3.14**, die CI pinnte ueberall **3.12**.
- Es gab **kein `pyproject.toml`** mit `requires-python`.
- `scripts/setup.sh` erstellte die venv **ohne vorherige Versionspruefung**.

Damit war nicht eindeutig, welche Mindestversion tatsaechlich unterstuetzt/getestet wird.

## Fix
- **README.md**: `Python 3.10+` -> `Python 3.11+ (entwickelt + getestet mit 3.14)`.
- **pyproject.toml** (neu): `requires-python = ">=3.11"`, konsistent zu README und CI.
- **.github/workflows/ci.yml**:
  - Job `python-tests` jetzt mit Python-Matrix `3.11 / 3.12 / 3.13` (zusaetzlich zur OS-Matrix); `3.14` folgt, sobald `actions/setup-python` es als stable fuehrt.
  - Quick-Jobs (`frontmatter-coverage`, `skill-tests`) auf den Floor `3.11` gepinnt, damit die kleinste in der CI verwendete Version mit der deklarierten Mindestversion uebereinstimmt.
- **scripts/setup.sh**: prueft `sys.version_info >= (3, 11)` **vor** `python3 -m venv` und bricht mit klarer Fehlermeldung ab, wenn aelter.

## TDD-Belege
Neuer Regressionstest `tests/test_issue_201_python_version.py` (7 Cases): README ohne stale `3.10+`, README nennt `3.11+`, `pyproject.toml` mit `requires-python >=3.11`, CI-Matrix deckt 3.11/3.12/3.13, setup.sh prueft Version vor venv, plus eine Konsistenzpruefung README/pyproject/CI-Minimum.
- **Rot (vor Fix):** `7 failed in 0.05s`
- **Gruen (nach Fix):** `7 passed in 0.01s`
- **Volle Suite:** `969 passed, 149 skipped` — 0 failed, keine Regression.

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)