### PR TITLE
fix(deps): ungenutzte pandas + openpyxl aus scripts/requirements.txt entfernen (#235)

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -2,8 +2,6 @@ anthropic>=0.40
 httpx>=0.25.0
 PyPDF2>=3.0.0
 pyyaml>=6.0
-openpyxl>=3.1
-pandas>=2.0
 requests>=2.28.0
 lxml>=4.9.0
 # Barcode-Generierung fuer /academic-research:pickup (Skill: barcode_utils)

--- a/tests/test_issue_235_unused_deps.py
+++ b/tests/test_issue_235_unused_deps.py
@@ -1,0 +1,64 @@
+"""Regressionstest fuer Issue #235: pandas + openpyxl ungenutzt.
+
+`pandas` und `openpyxl` standen in `scripts/requirements.txt`, werden aber
+von keinem `scripts/*.py` importiert (`openpyxl` nur im separaten Skill
+`skills/xlsx`). Dieser Test sichert ab, dass
+
+1. `scripts/requirements.txt` weder `pandas` noch `openpyxl` listet, und
+2. kein `scripts/`-Code `pandas` oder `openpyxl` importiert,
+
+sodass nur tatsaechlich genutzte Pakete im Top-Level-Requirements stehen.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+REQUIREMENTS = REPO_ROOT / "scripts" / "requirements.txt"
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+
+# Pakete, die laut Akzeptanzkriterien NICHT mehr im Top-Level-Requirements
+# stehen duerfen, weil sie von scripts/ nicht importiert werden.
+UNUSED_PACKAGES = ("pandas", "openpyxl")
+
+
+def _listed_packages() -> set[str]:
+    """Liefert die in requirements.txt gelisteten Paketnamen (lowercase)."""
+    packages: set[str] = set()
+    for raw in REQUIREMENTS.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        # Paketname = alles vor Version-Specifier / Extras / Whitespace.
+        name = re.split(r"[<>=!~\[ ;]", line, maxsplit=1)[0].strip().lower()
+        if name:
+            packages.add(name)
+    return packages
+
+
+@pytest.mark.parametrize("package", UNUSED_PACKAGES)
+def test_unused_package_not_in_requirements(package: str) -> None:
+    """`pandas`/`openpyxl` duerfen nicht in scripts/requirements.txt stehen."""
+    assert package not in _listed_packages(), (
+        f"{package!r} steht in scripts/requirements.txt, wird aber von "
+        f"scripts/ nicht importiert (siehe Issue #235)."
+    )
+
+
+@pytest.mark.parametrize("package", UNUSED_PACKAGES)
+def test_unused_package_not_imported_in_scripts(package: str) -> None:
+    """Kein scripts/*.py darf pandas/openpyxl importieren (Regression-Guard)."""
+    import_pattern = re.compile(
+        rf"^\s*(?:import\s+{re.escape(package)}\b|from\s+{re.escape(package)}\b)",
+        re.MULTILINE,
+    )
+    offenders = []
+    for py_file in SCRIPTS_DIR.rglob("*.py"):
+        if import_pattern.search(py_file.read_text()):
+            offenders.append(str(py_file.relative_to(REPO_ROOT)))
+    assert not offenders, (
+        f"{package!r} wird in scripts/ importiert ({offenders}); Entfernen aus "
+        f"requirements.txt waere falsch."
+    )


### PR DESCRIPTION
## Problem
`pandas` und `openpyxl` standen in `scripts/requirements.txt`, werden aber von keinem `scripts/*.py` importiert. `openpyxl` wird ausschliesslich im separaten Teilsystem `skills/xlsx/scripts/recalc.py` genutzt (eigene Deps, konsumiert nicht das Top-Level-Requirements). Die Pakete wurden sinnlos ins venv installiert (~50 MB), verlaengerten `scripts/setup.sh` und vergroesserten die CVE-Angriffsflaeche.

Akzeptanzkriterium: Nur tatsaechlich von `scripts/` importierte Pakete duerfen in `scripts/requirements.txt` stehen.

Verifikation vor dem Fix (adversarisch gegengeprueft):
- `grep -rn "pandas|openpyxl" scripts/` -> kein Import-Treffer, nur die requirements.txt-Zeilen selbst.
- Repo-weit: `openpyxl` nur in `skills/xlsx/scripts/recalc.py` (anderes Subsystem). `pandas` nirgends.

## Fix
- `scripts/requirements.txt`: Zeilen `openpyxl>=3.1` und `pandas>=2.0` entfernt. Alle weiterhin von `scripts/` importierten Pakete (anthropic, httpx, PyPDF2, pyyaml, requests, lxml, ...) bleiben unveraendert.
- `tests/test_issue_235_unused_deps.py` (neu): Regressionstest.

## TDD-Belege
Neuer Regressionstest `tests/test_issue_235_unused_deps.py` (4 Cases: je `pandas`/`openpyxl` x not-in-requirements / not-imported-in-scripts).
- **Rot (vor Fix):** `2 failed, 2 passed in 0.03s`
- **Gruen (nach Fix):** `4 passed in 0.02s`
- **Volle Suite:** `966 passed, 149 skipped` — 0 failed, keine Regression.

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)