### PR TITLE
fix(search): EconStor-OAI-PMH-Fallback mit Mengenlimit absichern (#236)

### DIFF
--- a/scripts/search.py
+++ b/scripts/search.py
@@ -116,6 +116,13 @@ TIMEOUT = 30.0
 OAI_DC_NS = "http://purl.org/dc/elements/1.1/"
 ARXIV_NS = "http://www.w3.org/2005/Atom"
 
+# Mengenlimits fuer den EconStor-OAI-PMH-Fallback (#236):
+# Verhindern, dass bei dauerhaftem REST-Ausfall der gesamte Repo-Dump
+# (> 250k Records) in den Speicher geladen wird bzw. die resumptionToken-
+# Schleife unbegrenzt paginiert.
+OAI_MAX_PAGES = 5  # max. resumptionToken-Runden (inkl. Erstabfrage)
+OAI_MAX_RECORDS = 1000  # max. insgesamt geparste Records pro Fallback
+
 log = logging.getLogger(__name__)
 
 
@@ -355,45 +362,75 @@ def search_econstor(query: str, limit: int) -> list[dict[str, Any]]:
         if rest_resp.status_code == 200 and rest_resp.headers.get("content-type", "").startswith("application/json"):
             items = rest_resp.json()
         else:
-            # Fallback: OAI-PMH harvest with client-side keyword filtering
+            # Fallback: OAI-PMH harvest with client-side keyword filtering.
+            # Mengenlimit (#236): hoechstens OAI_MAX_PAGES resumptionToken-Runden
+            # und insgesamt hoechstens OAI_MAX_RECORDS geparste Records, damit bei
+            # dauerhaftem REST-Ausfall nicht der gesamte Repo-Dump (> 250k Records)
+            # in den Speicher geladen wird und die Schleife garantiert terminiert.
             items = []
-            oai_resp = client.get(
-                "https://www.econstor.eu/oai/request",
-                params={"verb": "ListRecords", "metadataPrefix": "oai_dc"},
-            )
-            oai_resp.raise_for_status()
-            root = ET.fromstring(oai_resp.text)
             ns = {"oai": "http://www.openarchives.org/OAI/2.0/", "dc": OAI_DC_NS}
             query_lower = query.lower()
-            for record in root.findall(".//oai:record", ns):
-                metadata = record.find(".//oai:metadata", ns)
-                if metadata is None:
-                    continue
-                dc_el = metadata.find("{http://www.openarchives.org/OAI/2.0/oai_dc/}dc")
-                if dc_el is None:
-                    continue
-                title_el = dc_el.find(f"{{{OAI_DC_NS}}}title")
-                title = title_el.text if title_el is not None and title_el.text else ""
-                desc_el = dc_el.find(f"{{{OAI_DC_NS}}}description")
-                desc = desc_el.text if desc_el is not None and desc_el.text else ""
-                if query_lower not in title.lower() and query_lower not in desc.lower():
-                    continue
-                creators = [c.text for c in dc_el.findall(f"{{{OAI_DC_NS}}}creator") if c.text]
-                date_el = dc_el.find(f"{{{OAI_DC_NS}}}date")
-                year = None
-                if date_el is not None and date_el.text:
-                    year_str = date_el.text[:4]
-                    if year_str.isdigit():
-                        year = int(year_str)
-                doi = None
-                item_url = None
-                for id_el in dc_el.findall(f"{{{OAI_DC_NS}}}identifier"):
-                    if id_el.text and "doi.org" in id_el.text:
-                        doi = id_el.text.replace("https://doi.org/", "").replace("http://doi.org/", "")
-                    elif id_el.text and id_el.text.startswith("http"):
-                        item_url = id_el.text
-                items.append({"title": title, "authors": creators, "year": year, "abstract": desc, "doi": doi, "url": item_url})
-                if len(items) >= limit:
+            resumption_token: str | None = None
+            records_seen = 0
+            for _ in range(OAI_MAX_PAGES):
+                if resumption_token:
+                    oai_params: dict[str, str] = {
+                        "verb": "ListRecords",
+                        "resumptionToken": resumption_token,
+                    }
+                else:
+                    oai_params = {"verb": "ListRecords", "metadataPrefix": "oai_dc"}
+                oai_resp = client.get(
+                    "https://www.econstor.eu/oai/request",
+                    params=oai_params,
+                )
+                oai_resp.raise_for_status()
+                root = ET.fromstring(oai_resp.text)
+                page_done = False
+                for record in root.findall(".//oai:record", ns):
+                    if records_seen >= OAI_MAX_RECORDS or len(items) >= limit:
+                        page_done = True
+                        break
+                    records_seen += 1
+                    metadata = record.find(".//oai:metadata", ns)
+                    if metadata is None:
+                        continue
+                    dc_el = metadata.find("{http://www.openarchives.org/OAI/2.0/oai_dc/}dc")
+                    if dc_el is None:
+                        continue
+                    title_el = dc_el.find(f"{{{OAI_DC_NS}}}title")
+                    title = title_el.text if title_el is not None and title_el.text else ""
+                    desc_el = dc_el.find(f"{{{OAI_DC_NS}}}description")
+                    desc = desc_el.text if desc_el is not None and desc_el.text else ""
+                    if query_lower not in title.lower() and query_lower not in desc.lower():
+                        continue
+                    creators = [c.text for c in dc_el.findall(f"{{{OAI_DC_NS}}}creator") if c.text]
+                    date_el = dc_el.find(f"{{{OAI_DC_NS}}}date")
+                    year = None
+                    if date_el is not None and date_el.text:
+                        year_str = date_el.text[:4]
+                        if year_str.isdigit():
+                            year = int(year_str)
+                    doi = None
+                    item_url = None
+                    for id_el in dc_el.findall(f"{{{OAI_DC_NS}}}identifier"):
+                        if id_el.text and "doi.org" in id_el.text:
+                            doi = id_el.text.replace("https://doi.org/", "").replace("http://doi.org/", "")
+                        elif id_el.text and id_el.text.startswith("http"):
+                            item_url = id_el.text
+                    items.append({"title": title, "authors": creators, "year": year, "abstract": desc, "doi": doi, "url": item_url})
+                    if len(items) >= limit:
+                        page_done = True
+                        break
+                if page_done or len(items) >= limit or records_seen >= OAI_MAX_RECORDS:
+                    break
+                token_el = root.find(".//oai:resumptionToken", ns)
+                resumption_token = (
+                    token_el.text.strip()
+                    if token_el is not None and token_el.text and token_el.text.strip()
+                    else None
+                )
+                if not resumption_token:
                     break
     time.sleep(0.5)
     for item in items[:limit]:

--- a/tests/test_issue_236_econstor_limit.py
+++ b/tests/test_issue_236_econstor_limit.py
@@ -1,0 +1,144 @@
+"""Regression tests for issue #236.
+
+EconStor OAI-PMH-Fallback in scripts/search.py darf nicht unbegrenzt
+paginieren bzw. nicht den gesamten Repo-Dump in den Speicher laden.
+
+Akzeptanzkriterium (#236):
+- EconStor-Fallback laedt nicht den gesamten Repo-Dump in Memory.
+
+Konkret abgesichert:
+1. Es existieren explizite Mengenlimits (max. Records bzw. max.
+   resumptionToken-Runden) als Modul-Konstanten.
+2. Liefert das OAI-Endpoint endlos resumptionTokens, terminiert die
+   Schleife dennoch nach <= OAI_MAX_PAGES Requests (kein Endlos-Paginieren).
+3. Pro Seite werden hoechstens OAI_MAX_RECORDS Records geparst (kein
+   vollstaendiger Repo-Dump im Speicher).
+"""
+
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import search
+
+
+OAI_NS = "http://www.openarchives.org/OAI/2.0/"
+DC_NS = "http://purl.org/dc/elements/1.1/"
+
+
+def _record_xml(idx: int) -> str:
+    """Ein OAI-record, dessen Titel die Query 'limittest' enthaelt."""
+    return (
+        "<record><metadata>"
+        f'<oai_dc:dc xmlns:oai_dc="{OAI_NS}oai_dc/" xmlns:dc="{DC_NS}">'
+        f"<dc:title>limittest paper {idx}</dc:title>"
+        f"<dc:description>limittest abstract {idx}</dc:description>"
+        f"<dc:creator>Author {idx}</dc:creator>"
+        "<dc:date>2020-01-01</dc:date>"
+        "</oai_dc:dc>"
+        "</metadata></record>"
+    )
+
+
+def _list_records_response(n_records: int, with_token: bool) -> str:
+    records = "".join(_record_xml(i) for i in range(n_records))
+    token = (
+        "<resumptionToken>tok-next</resumptionToken>" if with_token else ""
+    )
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        f'<OAI-PMH xmlns="{OAI_NS}">'
+        f"<ListRecords>{records}{token}</ListRecords>"
+        "</OAI-PMH>"
+    )
+
+
+def test_oai_limit_constants_exist():
+    """Mengenlimit-Konstanten muessen existieren und endlich/positiv sein."""
+    assert hasattr(search, "OAI_MAX_PAGES"), "OAI_MAX_PAGES fehlt"
+    assert hasattr(search, "OAI_MAX_RECORDS"), "OAI_MAX_RECORDS fehlt"
+    assert isinstance(search.OAI_MAX_PAGES, int) and search.OAI_MAX_PAGES > 0
+    assert isinstance(search.OAI_MAX_RECORDS, int) and search.OAI_MAX_RECORDS > 0
+
+
+def test_oai_fallback_terminates_on_endless_resumption_tokens(monkeypatch):
+    """Endlos-resumptionToken darf nicht zu unbegrenztem Paginieren fuehren."""
+    request_count = {"rest": 0, "oai": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        if "find-by-metadata-field" in url:
+            request_count["rest"] += 1
+            # Kein JSON -> erzwingt OAI-Fallback.
+            return httpx.Response(503, text="upstream down")
+        if "oai/request" in url:
+            request_count["oai"] += 1
+            # Liefert IMMER einen resumptionToken -> ohne Limit Endlosschleife.
+            body = _list_records_response(n_records=2, with_token=True)
+            return httpx.Response(200, text=body)
+        return httpx.Response(404, text="")
+
+    transport = httpx.MockTransport(handler)
+    real_client = httpx.Client
+
+    def patched_client(*args, **kwargs):
+        kwargs["transport"] = transport
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr(search.httpx, "Client", patched_client)
+    monkeypatch.setattr(search.time, "sleep", lambda *a, **k: None)
+
+    results = search.search_econstor("limittest", limit=5)
+
+    # Schleife terminiert ueberhaupt (kein Hang) und respektiert das Runden-Limit.
+    assert request_count["oai"] <= search.OAI_MAX_PAGES, (
+        f"OAI wurde {request_count['oai']}x abgefragt, "
+        f"Limit ist {search.OAI_MAX_PAGES}"
+    )
+    assert isinstance(results, list)
+    assert len(results) <= 5
+
+
+def test_oai_fallback_caps_records_per_giant_page(monkeypatch):
+    """Eine riesige Seite darf nicht komplett in Memory geparst werden."""
+    huge = search.OAI_MAX_RECORDS + 5000
+    parsed = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        if "find-by-metadata-field" in url:
+            return httpx.Response(503, text="upstream down")
+        if "oai/request" in url:
+            body = _list_records_response(n_records=huge, with_token=False)
+            return httpx.Response(200, text=body)
+        return httpx.Response(404, text="")
+
+    transport = httpx.MockTransport(handler)
+    real_client = httpx.Client
+
+    def patched_client(*args, **kwargs):
+        kwargs["transport"] = transport
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr(search.httpx, "Client", patched_client)
+    monkeypatch.setattr(search.time, "sleep", lambda *a, **k: None)
+
+    # normalize_paper zaehlen, um die Anzahl tatsaechlich verarbeiteter
+    # Records zu messen (Proxy fuer "nicht der ganze Dump").
+    real_normalize = search.normalize_paper
+
+    def counting_normalize(*args, **kwargs):
+        parsed["count"] += 1
+        return real_normalize(*args, **kwargs)
+
+    monkeypatch.setattr(search, "normalize_paper", counting_normalize)
+
+    results = search.search_econstor("limittest", limit=3)
+
+    assert len(results) <= 3
+    # Es duerfen nicht zehntausende Records verarbeitet werden.
+    assert parsed["count"] <= search.OAI_MAX_RECORDS


### PR DESCRIPTION
## Problem
Wenn der EconStor-REST-Endpoint kein JSON liefert, fiel `search_econstor()` (`scripts/search.py`) auf einen OAI-PMH-`ListRecords`-Call **ohne Mengenlimit** zurueck. Der Fallback lud die komplette Seite per `ET.fromstring()` vollstaendig in den Speicher und iterierte clientseitig ueber alles. EconStor hat > 250k Records — bei dauerhaftem REST-Ausfall traf jeden Aufruf dieser O(N)-Overhead. Ein `resumptionToken`-Handling fehlte vollstaendig, ebenso jede Obergrenze fuer Seiten oder Records.

Akzeptanzkriterium (#236): EconStor-Fallback laedt nicht den gesamten Repo-Dump in Memory.

## Fix
- `scripts/search.py`: Zwei neue Modul-Konstanten `OAI_MAX_PAGES` (max. `resumptionToken`-Runden, Default 5) und `OAI_MAX_RECORDS` (max. insgesamt geparste Records, Default 1000) begrenzen den Fallback.
- Der Fallback-Block in `search_econstor()` wurde auf eine beschraenkte Paginierungsschleife umgestellt: Sie verarbeitet `resumptionToken`s, bricht aber garantiert nach `OAI_MAX_PAGES` Runden bzw. `OAI_MAX_RECORDS` geparsten Records ab — und sobald `limit` erreicht ist. Damit terminiert die Schleife auch bei endlos gelieferten `resumptionToken`s und es wird nie der gesamte Repo-Dump geparst.

## TDD-Belege
Neuer Regressionstest `tests/test_issue_236_econstor_limit.py` (3 Cases): Existenz der Limit-Konstanten, Terminierung bei Endlos-`resumptionToken` (via `httpx.MockTransport`), Deckelung der pro-Seite verarbeiteten Records bei einer riesigen Seite.
- **Rot (vor Fix):** `3 failed in 0.10s`
- **Gruen (nach Fix):** `3 passed in 0.06s`
- **Volle Suite:** `965 passed, 149 skipped` — 0 failed, keine Regression.

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)
