### PR TITLE
fix(devux): Skip-Doku, Codecov, Dependabot, Release-Marketplace-Check (#215)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+# Dependabot-Konfiguration — automatische Dependency-Updates (Issue #215, L2).
+# Deckt pip (Python-Runtime + Dev-Deps), GitHub-Actions-Workflows und npm
+# (fuer kuenftige Node-/hooks-Pakete) ab. Security-Patches (vgl. #194) werden
+# damit nicht mehr manuell getrackt.
+version: 2
+updates:
+  # Python-Abhaengigkeiten (scripts/requirements.txt + requirements-dev.txt)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+    labels:
+      - "dependencies"
+      - "python"
+
+  # GitHub-Actions in .github/workflows/*.yml aktuell halten
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  # npm — fuer kuenftige Node-/hooks-Dependencies (derzeit ohne package.json,
+  # greift automatisch sobald eine package.json hinzukommt).
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+    labels:
+      - "dependencies"
+      - "javascript"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,12 +127,20 @@ jobs:
       - name: Python-Deps installieren (erster Step, vgl. #197)
         run: |
           python -m pip install --upgrade pip
-          pip install -r scripts/requirements.txt
-          pip install pytest pytest-cov
+          pip install -r requirements-dev.txt
       - name: Smoke-Test der Kern-Importe
         run: python -c "import requests, httpx, anthropic, yaml, barcode, lxml"
       - name: pytest mit Coverage
         run: |
           pytest tests/ -p no:cacheprovider \
             --cov=scripts --cov=academic_vault \
-            --cov-report=term-missing
+            --cov-report=term-missing \
+            --cov-report=xml:coverage.xml
+      - name: Coverage-Report zu Codecov hochladen
+        if: matrix.os == 'ubuntu-latest'
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,3 +26,29 @@ jobs:
             exit 1
           fi
           echo "Version stimmt ueberein."
+      - name: marketplace.json-Version vs. plugin.json vergleichen
+        run: |
+          set -euo pipefail
+          PLUGIN="$(jq -r '.version' .claude-plugin/plugin.json)"
+          MARKET="$(jq -r '.plugins[0].version' .claude-plugin/marketplace.json)"
+          echo "plugin.json:      $PLUGIN"
+          echo "marketplace.json: $MARKET"
+          if [ "$PLUGIN" != "$MARKET" ]; then
+            echo "::error::marketplace.json plugins[0].version ($MARKET) stimmt nicht mit plugin.json version ($PLUGIN) ueberein."
+            exit 1
+          fi
+          echo "Marketplace-Version stimmt ueberein."
+
+  marketplace-notice:
+    name: Marketplace-Update-Notice
+    needs: version-match
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Hinweis zum Marketplace-Refresh ausgeben
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME#v}"
+          echo "::notice::Release v${TAG} getaggt. Marketplace-Quelle ist './' (lokal im Repo);"
+          echo "::notice::der Marketplace-Refresh erfolgt automatisch beim naechsten Plugin-Sync."
+          echo "Release ${GITHUB_REF_NAME} bereit — Manifest-Versionen geprueft." >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Academic Research v6.5
 
 [![CI](https://github.com/jamski105/academic-research/actions/workflows/ci.yml/badge.svg)](https://github.com/jamski105/academic-research/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/jamski105/academic-research/branch/main/graph/badge.svg)](https://codecov.io/gh/jamski105/academic-research)
 [![Version](https://img.shields.io/badge/version-6.5.0-blue.svg)](CHANGELOG.md)
 [![Skills](https://img.shields.io/badge/skills-23+-orange.svg)](#skills-übersicht)
 [![Tests](https://img.shields.io/badge/tests-963%20passing-success.svg)](#entwicklung-und-evals)

--- a/docs/SKIP_REASONS.md
+++ b/docs/SKIP_REASONS.md
@@ -1,0 +1,70 @@
+# Skip-Reasons
+
+Strukturierte Übersicht aller bewussten Test-Skips in `tests/`. Sie macht beim
+Review eindeutig, ob ein Skip **permanent** (umweltabhängig, nie auf jeder
+Maschine lauffähig) oder **todo** (temporär, bis ein Feature/Asset existiert) ist.
+
+Pflege-Regel: Wer einen neuen `@pytest.mark.skip(if)` oder `pytest.skip(...)`
+einführt, ergänzt hier eine Zeile. `permanent` = Skip ist erwartet und bleibt
+(z.B. fehlende optionale Dependency, kein API-Key in CI). `todo:<datum|issue>` =
+Skip soll wegfallen, sobald das genannte Artefakt vorhanden ist.
+
+## Klassifikation
+
+| Test / Datei | Skip-Grund | Reason-Text | Klasse |
+| --- | --- | --- | --- |
+| `tests/evals/eval_runner.py` | Kein `ANTHROPIC_API_KEY` in CI | `ANTHROPIC_API_KEY nicht gesetzt - Eval uebersprungen` | permanent |
+| `tests/evals/eval_runner.py` | `anthropic`-Package optional | `anthropic-Package nicht installiert` | permanent |
+| `tests/evals/eval_runner.py` | Eval-Datei (`evals.json`) fehlt | `Eval-Datei fehlt: <path>` | permanent |
+| `tests/evals/test_triggers.py` | Keine `trigger_evals.json` für Skill | `Keine trigger_evals.json fuer <skill>` | permanent |
+| `tests/evals/test_token_regression.py` | Keine Token-Baseline erfasst | `tokens.json fehlt -- noch keine Baseline` | permanent |
+| `tests/evals/test_*_evals.py` | Prompt nicht für aktiven Mode | `Prompt <id> nicht fuer Mode <mode>` | permanent |
+| `tests/test_vault_skeleton.py` | `db.py` Vault-Skeleton optional | `db.py noch nicht implementiert` | todo:vault-skeleton (#217) |
+| `tests/test_vault_skeleton.py` | `files_api.py` Vault-Skeleton optional | `files_api.py noch nicht implementiert` | todo:vault-skeleton (#217) |
+| `tests/test_ocr_detection.py` | `ocr.py` noch nicht vorhanden | `ocr.py noch nicht implementiert` | todo:ocr |
+| `tests/test_publisher_fetchers.py` | `evals.json` für Publisher fehlt | `evals.json noch nicht vorhanden` | todo:publisher-evals |
+| `tests/test_page_offset.py` | Fixture/Asset fehlt | (mehrzeilig) | todo:page-offset-fixture |
+| `tests/test_project_bootstrap.py` | `git` nicht im PATH (CI-Umgebung) | `git not in PATH` | permanent |
+
+## Regenerieren
+
+Liste der aktuellen Skip-Stellen:
+
+```bash
+grep -rn "@pytest.mark.skip\|pytest.skip(" tests/ --include="*.py"
+```
+
+Neue Zeilen oben einsortieren und mit `permanent` bzw. `todo:<…>` klassifizieren.
+
+## Wie skippe ich Tests oder Hooks bewusst?
+
+**Einzelne Tests überspringen (im Test-Code):**
+
+```python
+import pytest
+
+@pytest.mark.skip(reason="permanent: optionale Dependency fehlt")
+def test_optional():
+    ...
+
+@pytest.mark.skipif(not _FEATURE, reason="todo:#123 — Feature noch nicht da")
+def test_feature():
+    ...
+```
+
+**Beim lokalen Lauf gezielt auslassen** (ohne Code-Änderung):
+
+```bash
+pytest -k "not slow"            # nach Namensmuster filtern
+pytest --deselect tests/x.py::test_y
+```
+
+**Pre-Commit-/Git-Hooks überspringen** — nur in Notfällen und nie auf `main`:
+
+```bash
+git commit --no-verify         # überspringt die lokalen Git-Hooks
+```
+
+`--no-verify` ist die Ausnahme, nicht die Regel: Es umgeht die lokalen Checks,
+ersetzt aber nicht die CI-Gates. Jeder so umgangene Check läuft trotzdem in
+GitHub Actions (`.github/workflows/ci.yml`) — die CI ist die maßgebliche Quelle.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,6 @@
+# Entwicklungs- und Test-Abhaengigkeiten (nicht fuer Runtime noetig).
+# Runtime-Deps stehen in scripts/requirements.txt.
+-r scripts/requirements.txt
+
+pytest>=8.0
+pytest-cov>=5.0

--- a/tests/test_issue_215_dev_ux.py
+++ b/tests/test_issue_215_dev_ux.py
@@ -1,0 +1,136 @@
+"""Regressionstest fuer Issue #215 — Dev-UX-Buendel (M1+L1+L2+M4).
+
+Prueft die vier Akzeptanzkriterien aus dem Issue konkret als Datei-Existenz,
+Datei-Inhalt und valides YAML:
+
+- M1: docs/SKIP_REASONS.md mit Reason-Tabelle (Test -> Reason -> permanent/todo).
+- L1: pytest-cov in requirements-dev.txt; CI emittet coverage.xml; Codecov-Badge in README.
+- L2: .github/dependabot.yml fuer pip + npm/github-actions, valides YAML.
+- M4: .github/workflows/release.yml prueft plugin.json==Tag UND
+      marketplace.json.plugins[0].version == plugin.json.version, valides YAML.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+ROOT = Path(__file__).parent.parent
+
+
+# --------------------------------------------------------------------------- #
+# M1 — Skip-Reasons dokumentiert
+# --------------------------------------------------------------------------- #
+def test_m1_skip_reasons_doc_exists():
+    doc = ROOT / "docs" / "SKIP_REASONS.md"
+    assert doc.is_file(), "docs/SKIP_REASONS.md fehlt (M1)"
+
+
+def test_m1_skip_reasons_has_reason_table():
+    doc = ROOT / "docs" / "SKIP_REASONS.md"
+    text = doc.read_text(encoding="utf-8")
+    # Markdown-Tabelle vorhanden
+    assert "|" in text and "---" in text, "Keine Markdown-Tabelle in SKIP_REASONS.md"
+    low = text.lower()
+    assert "reason" in low or "grund" in low, "Spalte Reason/Grund fehlt"
+    # Klassifizierung permanent vs. todo
+    assert "permanent" in low, "Klassifizierung 'permanent' fehlt"
+    assert "todo" in low, "Klassifizierung 'todo' fehlt"
+
+
+# --------------------------------------------------------------------------- #
+# L1 — Coverage / Codecov
+# --------------------------------------------------------------------------- #
+def test_l1_requirements_dev_has_pytest_cov():
+    req = ROOT / "requirements-dev.txt"
+    assert req.is_file(), "requirements-dev.txt fehlt (L1)"
+    text = req.read_text(encoding="utf-8")
+    assert "pytest-cov" in text, "pytest-cov nicht in requirements-dev.txt"
+
+
+def test_l1_ci_emits_coverage_xml():
+    ci = ROOT / ".github" / "workflows" / "ci.yml"
+    text = ci.read_text(encoding="utf-8")
+    assert "coverage.xml" in text, "CI emittet keinen coverage.xml-Report (L1)"
+
+
+def test_l1_readme_has_codecov_badge():
+    readme = ROOT / "README.md"
+    text = readme.read_text(encoding="utf-8")
+    assert "codecov.io" in text, "Codecov-Badge fehlt im README (L1)"
+
+
+# --------------------------------------------------------------------------- #
+# L2 — Dependabot
+# --------------------------------------------------------------------------- #
+def test_l2_dependabot_exists_and_valid_yaml():
+    dep = ROOT / ".github" / "dependabot.yml"
+    assert dep.is_file(), ".github/dependabot.yml fehlt (L2)"
+    data = yaml.safe_load(dep.read_text(encoding="utf-8"))
+    assert isinstance(data, dict), "dependabot.yml ist kein YAML-Mapping"
+    assert data.get("version") == 2, "dependabot version muss 2 sein"
+    ecosystems = {
+        u.get("package-ecosystem") for u in data.get("updates", [])
+    }
+    assert "pip" in ecosystems, "dependabot deckt kein pip-Oekosystem ab"
+    # npm fuer Node-/hooks-Deps ODER github-actions (Workflows) muss abgedeckt sein
+    assert ecosystems & {"npm", "github-actions"}, (
+        "dependabot deckt weder npm noch github-actions ab"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# M4 — Release-Workflow mit Marketplace-Version-Check
+# --------------------------------------------------------------------------- #
+def test_m4_release_workflow_exists_and_valid_yaml():
+    rel = ROOT / ".github" / "workflows" / "release.yml"
+    assert rel.is_file(), ".github/workflows/release.yml fehlt (M4)"
+    data = yaml.safe_load(rel.read_text(encoding="utf-8"))
+    assert isinstance(data, dict), "release.yml ist kein YAML-Mapping"
+    # 'on'-Trigger fuer Tag-Push (PyYAML parst bare 'on' als True)
+    trigger = data.get("on", data.get(True))
+    assert trigger and "push" in trigger, "release.yml hat keinen push-Trigger"
+    assert "tags" in trigger["push"], "release.yml triggert nicht auf Tags"
+
+
+def test_m4_release_checks_marketplace_version_match():
+    rel = ROOT / ".github" / "workflows" / "release.yml"
+    text = rel.read_text(encoding="utf-8")
+    assert "marketplace.json" in text, (
+        "release.yml prueft marketplace.json-Version nicht (M4)"
+    )
+    # plugin.json-Tag-Check muss weiterhin existieren
+    assert "plugin.json" in text, "release.yml prueft plugin.json-Version nicht mehr"
+
+
+def test_m4_manifest_versions_currently_match():
+    """Sanity: marketplace.plugins[0].version == plugin.json.version."""
+    plugin = json.loads(
+        (ROOT / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
+    )
+    market = json.loads(
+        (ROOT / ".claude-plugin" / "marketplace.json").read_text(encoding="utf-8")
+    )
+    assert plugin["version"] == market["plugins"][0]["version"], (
+        "plugin.json und marketplace.json Versionen weichen ab"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Globale YAML-Validitaet aller Config-Dateien (Issue: 'YAML valide')
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "relpath",
+    [
+        ".github/dependabot.yml",
+        ".github/workflows/ci.yml",
+        ".github/workflows/release.yml",
+    ],
+)
+def test_config_yaml_is_valid(relpath):
+    path = ROOT / relpath
+    assert path.is_file(), f"{relpath} fehlt"
+    # Wirft yaml.YAMLError bei invalidem YAML
+    yaml.safe_load(path.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Problem
Vier kleine Dev-UX-Luecken aus dem Test+CI-Audit Round-2 (M1+L1+L2+M4):

- **M1:** 35 bewusste Test-Skips ohne strukturierte Reason-Tabelle — beim Review unklar, ob `permanent` oder `todo`.
- **L1:** `pytest-cov` nur inline im CI, keine `requirements-dev.txt`, kein `coverage.xml`-Artefakt, kein Codecov-Badge.
- **L2:** `.github/dependabot.yml` fehlte — Security-Patches (vgl. #194) mussten manuell getrackt werden.
- **M4:** `release.yml` pruefte nur `plugin.json`-Version gegen den Tag, nicht `marketplace.json`, und gab keine Marketplace-Update-Notice aus.

## Fix
- `docs/SKIP_REASONS.md` (neu): Tabelle Test -> Grund -> Reason-Text -> Klasse (`permanent`/`todo:<…>`), plus Abschnitt "Wie skippe ich Tests/Hooks?".
- `requirements-dev.txt` (neu): zieht `scripts/requirements.txt` + `pytest` + `pytest-cov`.
- `.github/workflows/ci.yml`: installiert via `requirements-dev.txt`, emittet `--cov-report=xml:coverage.xml` und laedt zu Codecov hoch (`codecov/codecov-action@v4`, ubuntu-only).
- `README.md`: Codecov-Badge nach dem CI-Badge.
- `.github/dependabot.yml` (neu): `pip`, `github-actions` und `npm`, woechentlich.
- `.github/workflows/release.yml`: zusaetzlicher Check `marketplace.json.plugins[0].version == plugin.json.version` plus Job `marketplace-notice`.

## TDD-Belege
Neuer Regressionstest `tests/test_issue_215_dev_ux.py` (12 Cases).
- **Rot (vor Fix):** `8 failed, 4 passed in 0.06s`
- **Gruen (nach Fix):** `12 passed in 0.03s`
- **Volle Suite:** `974 passed, 149 skipped` — 0 failed, keine Regression.

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)