### PR TITLE
test(evals): verbatim-guard-Runner in pytest integrieren (#241)

### DIFF
--- a/evals/verbatim-guard/runner.py
+++ b/evals/verbatim-guard/runner.py
@@ -65,11 +65,26 @@ def _build_test_db(cases: list[dict]) -> str:
     return db_path
 
 
-def run_eval() -> None:
+def run_eval_cases() -> dict:
+    """Fuehrt alle Eval-Cases aus und gibt strukturierte Ergebnisse zurueck.
+
+    Importierbar (z. B. aus pytest), ohne zu printen oder ``sys.exit`` zu rufen.
+
+    Rueckgabe:
+        dict mit Schluesseln:
+          - ``passed``  (int): Anzahl korrekt klassifizierter Cases
+          - ``failed``  (int): Anzahl fehlklassifizierter Cases
+          - ``total``   (int): Gesamtzahl der Cases
+          - ``fpr``     (float): False-Positive-Rate in Prozent
+                        (echter Quote faelschlich geblockt)
+          - ``real_pass`` (bool): alle echten Quotes bestanden
+          - ``invented_block`` (bool): alle erfundenen Quotes geblockt
+          - ``details`` (list[dict]): pro Case id/type/status/expected/actual/hits
+    """
     cases = json.loads(CASES_PATH.read_text(encoding="utf-8"))
     db_path = _build_test_db(cases)
 
-    results = {"pass": 0, "fail": 0, "details": []}
+    results: dict = {"pass": 0, "fail": 0, "details": []}
 
     try:
         for case in cases:
@@ -95,27 +110,61 @@ def run_eval() -> None:
                     "hits": len(hits),
                 }
             )
-            print(f"  [{status}] Case {case['id']} ({case['type']}): expected={expected}, actual={actual}, hits={len(hits)}")
-
     finally:
         os.unlink(db_path)
 
-    total = len(cases)
-    passed = results["pass"]
-    failed = results["fail"]
+    # FPR berechnen: echter Quote, der geblockt wird = False Positive
+    fp = sum(
+        1 for d in results["details"] if d["type"] == "real" and d["actual"] == "block"
+    )
+    real_total = sum(1 for c in cases if c["type"] == "real")
+    fpr = (fp / real_total * 100) if real_total > 0 else 0.0
+
+    real_pass = all(
+        d["status"] == "OK" for d in results["details"] if d["type"] == "real"
+    )
+    invented_block = all(
+        d["status"] == "OK" for d in results["details"] if d["type"] == "invented"
+    )
+
+    return {
+        "passed": results["pass"],
+        "failed": results["fail"],
+        "total": len(cases),
+        "fpr": fpr,
+        "real_pass": real_pass,
+        "invented_block": invented_block,
+        "details": results["details"],
+    }
+
+
+def run_eval() -> None:
+    """CLI-Einstiegspunkt: fuehrt die Cases aus, printet Report, exit 1 bei Fehler."""
+    summary = run_eval_cases()
+
+    for d in summary["details"]:
+        print(
+            f"  [{d['status']}] Case {d['id']} ({d['type']}): "
+            f"expected={d['expected']}, actual={d['actual']}, hits={d['hits']}"
+        )
+
+    total = summary["total"]
+    passed = summary["passed"]
+    failed = summary["failed"]
 
     print(f"\n{'='*50}")
     print(f"Ergebnis: {passed}/{total} korrekt ({failed} Fehler)")
 
-    # FPR berechnen: Anzahl real-quotes die geblockt werden (False Positive = echter Quote wird geblockt)
-    fp = sum(1 for d in results["details"] if d["type"] == "real" and d["actual"] == "block")
-    real_total = sum(1 for c in cases if c["type"] == "real")
-    fpr = (fp / real_total * 100) if real_total > 0 else 0
+    fpr = summary["fpr"]
+    fp = sum(
+        1 for d in summary["details"] if d["type"] == "real" and d["actual"] == "block"
+    )
+    real_total = sum(1 for d in summary["details"] if d["type"] == "real")
     print(f"False-Positive-Rate: {fp}/{real_total} = {fpr:.1f}% (AC: < 5 %)")
 
     # Acceptance Criteria pruefen
-    real_pass = all(d["status"] == "OK" for d in results["details"] if d["type"] == "real")
-    invented_block = all(d["status"] == "OK" for d in results["details"] if d["type"] == "invented")
+    real_pass = summary["real_pass"]
+    invented_block = summary["invented_block"]
 
     print(f"\nAC-Check:")
     print(f"  Echte Quotes 100 % pass:      {'✅' if real_pass else '❌'}")

--- a/tests/evals/test_verbatim_guard_evals.py
+++ b/tests/evals/test_verbatim_guard_evals.py
@@ -1,0 +1,120 @@
+"""pytest-Integration fuer den verbatim-guard-Eval-Runner (Issue #241).
+
+Der Runner unter ``evals/verbatim-guard/runner.py`` enthaelt 10 Vault-Lookup-
+Cases (``cases.json``), die ``academic_vault.server.search_quote_text()`` gegen
+echte vs. erfundene Zitate pruefen. Bis Issue #241 war der Runner ein reines
+CLI-Skript (``if __name__ == '__main__'``) und wurde von keiner pytest-Datei
+aufgerufen → er lief in CI nie automatisch.
+
+Diese Datei bindet den Runner als echten pytest-Test ein:
+  * importiert eine wiederverwendbare Funktion aus ``runner.py``,
+  * parametrisiert ueber alle 10 Cases (FAIL statt still-skip),
+  * verifiziert die Akzeptanzkriterien (100 % pass/block, FPR < 5 %).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Runner-Modul dynamisch laden (Verzeichnis enthaelt Bindestrich → kein Paket)
+# ---------------------------------------------------------------------------
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+RUNNER_PATH = REPO_ROOT / "evals" / "verbatim-guard" / "runner.py"
+CASES_PATH = REPO_ROOT / "evals" / "verbatim-guard" / "cases.json"
+
+
+def _load_runner():
+    """Laedt evals/verbatim-guard/runner.py als Modul (Pfad mit Bindestrich)."""
+    assert RUNNER_PATH.exists(), f"Runner fehlt: {RUNNER_PATH}"
+    spec = importlib.util.spec_from_file_location("verbatim_guard_runner", RUNNER_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def runner():
+    return _load_runner()
+
+
+@pytest.fixture(scope="module")
+def eval_results(runner):
+    """Fuehrt den verbatim-guard-Eval-Lauf genau einmal pro Modul aus.
+
+    Erwartet eine importierbare Funktion ``run_eval_cases()``, die strukturierte
+    Ergebnisse zurueckgibt (statt nur zu printen und ``sys.exit`` zu rufen).
+    """
+    assert hasattr(runner, "run_eval_cases"), (
+        "runner.py muss eine importierbare run_eval_cases()-Funktion exportieren, "
+        "damit der verbatim-guard ueber pytest erreichbar ist (Issue #241)."
+    )
+    return runner.run_eval_cases()
+
+
+def _load_cases() -> list[dict]:
+    return json.loads(CASES_PATH.read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# AC: Die 10 Vault-Lookup-Cases laufen bei jedem pytest-Lauf.
+# ---------------------------------------------------------------------------
+
+def test_runner_is_importable_via_pytest(runner):
+    """runner.py wird ueber pytest erreicht und exportiert run_eval_cases()."""
+    assert hasattr(runner, "run_eval_cases"), (
+        "verbatim-guard-Runner ist nicht ueber pytest erreichbar (Issue #241)."
+    )
+
+
+def test_all_ten_cases_execute(eval_results):
+    """Alle 10 Cases werden tatsaechlich ausgefuehrt (kein still-skip)."""
+    details = eval_results["details"]
+    assert len(details) == 10, f"Erwartet 10 ausgefuehrte Cases, erhalten: {len(details)}"
+    assert len(_load_cases()) == 10, "cases.json muss 10 Cases enthalten."
+
+
+@pytest.mark.parametrize("case", _load_cases(), ids=lambda c: f"case{c['id']}-{c['type']}")
+def test_each_case_matches_expected(case, eval_results):
+    """Jeder einzelne Case erfuellt sein expected (pass/block) — FAIL statt skip."""
+    detail = next(d for d in eval_results["details"] if d["id"] == case["id"])
+    assert detail["actual"] == case["expected"], (
+        f"Case {case['id']} ({case['type']}): "
+        f"expected={case['expected']} actual={detail['actual']} hits={detail['hits']}"
+    )
+
+
+def test_real_quotes_all_pass(eval_results):
+    """AC: Echte Quotes werden zu 100 % gefunden (pass)."""
+    real = [d for d in eval_results["details"] if d["type"] == "real"]
+    assert real, "Es muss mindestens einen real-Case geben."
+    assert all(d["actual"] == "pass" for d in real), (
+        f"Nicht alle echten Quotes bestehen: {real}"
+    )
+
+
+def test_invented_quotes_all_blocked(eval_results):
+    """AC: Erfundene Quotes werden zu 100 % geblockt (block)."""
+    invented = [d for d in eval_results["details"] if d["type"] == "invented"]
+    assert invented, "Es muss mindestens einen invented-Case geben."
+    assert all(d["actual"] == "block" for d in invented), (
+        f"Nicht alle erfundenen Quotes werden geblockt: {invented}"
+    )
+
+
+def test_false_positive_rate_below_threshold(eval_results):
+    """AC: False-Positive-Rate (echter Quote faelschlich geblockt) < 5 %."""
+    assert eval_results["fpr"] < 5.0, (
+        f"FPR {eval_results['fpr']:.1f}% verletzt AC (< 5 %)."
+    )
+
+
+def test_overall_pass(eval_results):
+    """Gesamtergebnis: kein einziger Case schlaegt fehl."""
+    assert eval_results["failed"] == 0, (
+        f"{eval_results['failed']} Eval-Case(s) fehlgeschlagen: {eval_results['details']}"
+    )

--- a/tests/test_issue_241_verbatim_guard_pytest.py
+++ b/tests/test_issue_241_verbatim_guard_pytest.py
@@ -1,0 +1,59 @@
+"""Regressionstest fuer Issue #241 (verbatim-guard nicht in pytest integriert).
+
+Sicherstellt, dass der verbatim-guard-Eval-Runner ueber pytest erreichbar ist:
+  * die pytest-Integrationsdatei ``tests/evals/test_verbatim_guard_evals.py``
+    existiert,
+  * ``evals/verbatim-guard/runner.py`` exportiert eine importierbare
+    ``run_eval_cases()``-Funktion (statt nur CLI/``sys.exit``),
+  * ein realer pytest-Lauf fuehrt alle 10 Vault-Lookup-Cases aus und sie
+    bestehen die Akzeptanzkriterien.
+
+Die fachlichen Per-Case-Asserts liegen in der Integrationsdatei; dieser Test
+verriegelt die strukturelle AC (verbatim-guard wird ueber pytest erreicht).
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RUNNER_PATH = REPO_ROOT / "evals" / "verbatim-guard" / "runner.py"
+INTEGRATION_TEST = REPO_ROOT / "tests" / "evals" / "test_verbatim_guard_evals.py"
+
+
+def _load_runner():
+    spec = importlib.util.spec_from_file_location("verbatim_guard_runner_241", RUNNER_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_pytest_integration_file_exists():
+    """Die pytest-Integration fuer den verbatim-guard muss existieren (Issue #241)."""
+    assert INTEGRATION_TEST.exists(), (
+        f"verbatim-guard ist nicht in pytest integriert — fehlt: {INTEGRATION_TEST}"
+    )
+
+
+def test_runner_exposes_importable_entrypoint():
+    """runner.py muss eine importierbare run_eval_cases()-Funktion bereitstellen."""
+    runner = _load_runner()
+    assert hasattr(runner, "run_eval_cases"), (
+        "runner.py exportiert keine run_eval_cases() — verbatim-guard nicht ueber "
+        "pytest erreichbar (Issue #241)."
+    )
+    assert callable(runner.run_eval_cases)
+
+
+def test_runner_executes_ten_cases_and_passes():
+    """Ein realer Lauf fuehrt alle 10 Cases aus und erfuellt die AC (kein still-skip)."""
+    runner = _load_runner()
+    results = runner.run_eval_cases()
+    assert len(results["details"]) == 10, (
+        f"Erwartet 10 Cases, ausgefuehrt: {len(results['details'])}"
+    )
+    assert results["failed"] == 0, (
+        f"verbatim-guard-Eval fehlgeschlagen: {results['details']}"
+    )
+    assert results["fpr"] < 5.0, f"FPR {results['fpr']:.1f}% verletzt AC (< 5 %)."


### PR DESCRIPTION
## Problem
`evals/verbatim-guard/runner.py` enthaelt 10 Vault-Lookup-Cases (`cases.json`), die `academic_vault.server.search_quote_text()` gegen echte vs. erfundene Zitate pruefen (AC: 100 % pass/block, FPR < 5 %). Der Runner war ein reines CLI-Skript (`if __name__ == '__main__'` + `sys.exit`) und wurde von keiner pytest-Datei aufgerufen → er lief in CI nie automatisch. `grep -rn 'runner.py' tests/` und `ls tests/evals/ | grep verbatim` lieferten keinen Treffer.

## Fix
- **`evals/verbatim-guard/runner.py`**: Logik in eine importierbare `run_eval_cases()`-Funktion extrahiert, die ein strukturiertes Ergebnis (`passed`/`failed`/`total`/`fpr`/`real_pass`/`invented_block`/`details`) zurueckgibt — ohne zu printen oder `sys.exit` zu rufen. Der bestehende CLI-Einstiegspunkt `run_eval()` ruft jetzt `run_eval_cases()` und printet den Report unveraendert weiter (CLI-Verhalten und Exit-Codes bleiben gleich).
- **`tests/evals/test_verbatim_guard_evals.py`** (neu): laedt `runner.py` ueber `importlib` (Verzeichnis mit Bindestrich ist kein Paket), parametrisiert ueber alle 10 Cases und verifiziert die AC (jeder Case `expected`, echte Quotes 100 % pass, erfundene 100 % block, FPR < 5 %).
- **`tests/test_issue_241_verbatim_guard_pytest.py`** (neu): Regressionstest, der strukturell verriegelt, dass der verbatim-guard ueber pytest erreicht wird (Integrationsdatei existiert, `run_eval_cases()` importierbar, realer Lauf fuehrt 10 Cases aus, 0 failed).

## TDD-Belege
Neuer Regressionstest `tests/test_issue_241_verbatim_guard_pytest.py` plus Integration `tests/evals/test_verbatim_guard_evals.py` (zusammen 19 Cases).
- **Rot (vor Fix):** `3 failed, 1 passed, 15 errors in 0.06s`
- **Gruen (nach Fix):** `19 passed in 0.05s`
- **Volle Suite:** `981 passed, 149 skipped` — 0 failed, keine Regression.

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)