### PR TITLE
fix: README 33 MCP-Tools + Drift-Anker (post-merge green-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,9 +484,9 @@ Der **Vault** (`academic_vault/`) ist die Kernkomponente seit v6.0. Er ersetzt d
 
 **Datenbank:** `~/.academic-research/projects/<slug>/vault.db`
 
-### MCP-Tools (alle 28)
+### MCP-Tools (alle 33)
 
-Der Server registriert **28 MCP-Tools** (`@mcp.tool`). Maßgebliche Code-Referenz: [`academic_vault/server.py`](academic_vault/server.py) (Funktion `_build_mcp_server`). Die folgenden Tabellen sind nach Kategorie geordnet; Signatur mit Default-Werten, Beschreibung und Beispiel-Call.
+Der Server registriert **33 MCP-Tools** (`@mcp.tool`). Maßgebliche Code-Referenz: [`academic_vault/server.py`](academic_vault/server.py) (Funktion `_build_mcp_server`). Die folgenden Tabellen sind nach Kategorie geordnet; Signatur mit Default-Werten, Beschreibung und Beispiel-Call.
 
 **Suche & Papers**
 
@@ -531,8 +531,10 @@ Der Server registriert **28 MCP-Tools** (`@mcp.tool`). Maßgebliche Code-Referen
 |------|-------------|------|
 | `vault.add_decision(category=None, text="", rationale=None)` | Fügt Entscheidung ins Decision-Log ein; gibt `decision_id` zurück | `vault.add_decision(category="scope", text="Nur Studien ab 2015", rationale="Aktualität")` |
 | `vault.list_decisions(category=None, active_only=True)` | Gibt Decisions zurück (optionaler `category`-Filter) | `vault.list_decisions(category="scope")` |
+| `vault.supersede_decision(decision_id, superseded_by)` | Markiert eine Decision als abgelöst durch eine neuere (`superseded_by`) | `vault.supersede_decision("dec_3", "dec_7")` |
 | `vault.add_excluded_source(paper_id, reason=None)` | Fügt `paper_id` zu `excluded_sources` (verhindert Re-Vorschlag) | `vault.add_excluded_source("smith2010", reason="off-topic")` |
 | `vault.is_excluded(paper_id)` | Prüft, ob `paper_id` ausgeschlossen ist | `vault.is_excluded("smith2010")` |
+| `vault.list_excluded_sources()` | Gibt alle ausgeschlossenen Quellen zurück | `vault.list_excluded_sources()` |
 | `vault.list_papers_by_provenance(provenance)` | Provenance-Audit: alle Papers mit gegebenem Herkunfts-Tag (z.B. `"scihub"`) | `vault.list_papers_by_provenance("scihub")` |
 
 **Risk-of-Bias & Score-Historie** (v6.4)
@@ -551,6 +553,13 @@ Der Server registriert **28 MCP-Tools** (`@mcp.tool`). Maßgebliche Code-Referen
 | `vault.export_material_passport(slug, output_dir=".", score_algo_version="1.0", plugin_version="6.4")` | Exportiert `material-passport.json`; gibt Dateipfad zurück | `vault.export_material_passport("mein-projekt")` |
 | `vault.lock_passport(slug)` | Setzt Vault-Lock für `slug` (macht Vault read-only) | `vault.lock_passport("mein-projekt")` |
 | `vault.is_locked(slug)` | Prüft, ob der Vault für `slug` gelockt ist | `vault.is_locked("mein-projekt")` |
+
+**Snapshots & Backup**
+
+| Tool (Signatur mit Defaults) | Beschreibung | Beispiel-Call |
+|------|-------------|------|
+| `vault.export_snapshot(slug, project_dir=".", snapshots_dir=None)` | Exportiert State-Dateien + Vault-DB als `.tgz`-Snapshot; gibt Pfad zurück (`snapshots_dir` default `~/.academic-research/snapshots`) | `vault.export_snapshot("mein-projekt")` |
+| `vault.restore_snapshot(slug, ts, snapshots_dir=None, target_dir=".")` | Stellt Snapshot `<slug>/<ts>.tgz` wieder her; gibt `True`/`False` zurück | `vault.restore_snapshot("mein-projekt", "20260604-0930")` |
 
 ### Halluzinationsschutz
 

--- a/tests/test_issue_207_readme_mcp_tools.py
+++ b/tests/test_issue_207_readme_mcp_tools.py
@@ -26,11 +26,15 @@ def _readme_text() -> str:
     return README.read_text()
 
 
-def test_all_28_tools_are_registered_in_server() -> None:
-    """Sanity-Check: server.py registriert genau 28 MCP-Tools (Drift-Anker)."""
+def test_registered_tool_count_is_stable() -> None:
+    """Sanity-Check: server.py registriert genau 33 MCP-Tools (Drift-Anker).
+
+    Erhoeht sich, wenn neue @mcp.tool dazukommen (zuletzt +5 via #204/#226/#195).
+    Bei Aenderung: README-Tabellen UND diese Zahl gemeinsam aktualisieren.
+    """
     tools = _registered_tools()
-    assert len(tools) == 28, (
-        f"Erwartet 28 registrierte @mcp.tool, gefunden {len(tools)}: {tools}"
+    assert len(tools) == 33, (
+        f"Erwartet 33 registrierte @mcp.tool, gefunden {len(tools)}: {tools}"
     )
 
 


### PR DESCRIPTION
Macht main wieder grün nach den 67 gemergten Fix-PRs.

**Ursache:** #204/#226/#195 registrierten 5 weitere `@mcp.tool` (28 → 33); `test_issue_207` hatte 28 hartkodiert und 4 Tools waren nicht in der README dokumentiert.

**Fix:**
- README: Sektion auf 33 aktualisiert; `supersede_decision`, `list_excluded_sources` + neue Snapshot-Sektion (`export_snapshot`/`restore_snapshot`) dokumentiert.
- `test_registered_tool_count_is_stable`: erwartet 33.

`pytest tests/test_issue_207_readme_mcp_tools.py` → 4 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)